### PR TITLE
Initial fmt

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -20,9 +20,7 @@ fn main() {
 }
 
 fn generate_models_code(models: &[YamlModel]) -> String {
-    let mut code = String::from(
-        "// Auto-generated from resources/models.yaml - do not edit\n\n",
-    );
+    let mut code = String::from("// Auto-generated from resources/models.yaml - do not edit\n\n");
 
     // Generate a struct for each model
     for model in models {
@@ -30,10 +28,15 @@ fn generate_models_code(models: &[YamlModel]) -> String {
     }
 
     // Generate registration function
-    code.push_str("pub fn register_all_models(factory: &mut crate::models::base::ModelFactory) {\n");
+    code.push_str(
+        "pub fn register_all_models(factory: &mut crate::models::base::ModelFactory) {\n",
+    );
     for model in models {
         let struct_name = model_id_to_struct_name(&model.id);
-        code.push_str(&format!("    factory.register::<{}>(\"{}\");\n", struct_name, model.id));
+        code.push_str(&format!(
+            "    factory.register::<{}>(\"{}\");\n",
+            struct_name, model.id
+        ));
     }
     code.push_str("}\n");
 
@@ -48,19 +51,40 @@ fn generate_model_struct(model: &YamlModel) -> String {
     s.push_str(&format!("pub struct {} {{}}\n\n", struct_name));
 
     // ConfigConstructable implementation
-    s.push_str(&format!("impl crate::registry::ConfigConstructable for {} {{\n", struct_name));
+    s.push_str(&format!(
+        "impl crate::registry::ConfigConstructable for {} {{\n",
+        struct_name
+    ));
     s.push_str("    fn new(_cfg: &serde_json::Value) -> Self { Self {} }\n");
     s.push_str("}\n\n");
 
     // Model trait implementation
-    s.push_str(&format!("impl crate::models::base::Model for {} {{\n", struct_name));
-    s.push_str(&format!("    fn family(&self) -> &str {{ {:?} }}\n", model.family));
-    s.push_str(&format!("    fn version(&self) -> &str {{ {:?} }}\n", model.version));
+    s.push_str(&format!(
+        "impl crate::models::base::Model for {} {{\n",
+        struct_name
+    ));
+    s.push_str(&format!(
+        "    fn family(&self) -> &str {{ {:?} }}\n",
+        model.family
+    ));
+    s.push_str(&format!(
+        "    fn version(&self) -> &str {{ {:?} }}\n",
+        model.version
+    ));
     s.push_str(&format!("    fn size(&self) -> u64 {{ {} }}\n", model.size));
-    s.push_str(&format!("    fn context_length(&self) -> u64 {{ {} }}\n", model.context_length));
+    s.push_str(&format!(
+        "    fn context_length(&self) -> u64 {{ {} }}\n",
+        model.context_length
+    ));
     s.push_str(&format!("    fn model_type(&self) -> &crate::models::base::ModelType {{ &crate::models::base::ModelType::{} }}\n", model.model_type));
-    s.push_str(&format!("    fn huggingface_repo(&self) -> &str {{ {:?} }}\n", model.huggingface_repo));
-    s.push_str(&format!("    fn native_dtype(&self) -> &str {{ {:?} }}\n", model.native_dtype));
+    s.push_str(&format!(
+        "    fn huggingface_repo(&self) -> &str {{ {:?} }}\n",
+        model.huggingface_repo
+    ));
+    s.push_str(&format!(
+        "    fn native_dtype(&self) -> &str {{ {:?} }}\n",
+        model.native_dtype
+    ));
 
     // Architecture - use static slice (contains a Vec, so not const-constructible)
     s.push_str("    fn architecture(&self) -> &crate::models::base::ModelArchitecture {\n");
@@ -75,14 +99,26 @@ fn generate_model_struct(model: &YamlModel) -> String {
     s.push_str("        static VARIANTS: std::sync::LazyLock<Vec<crate::models::base::ModelVariant>> = std::sync::LazyLock::new(|| vec![\n");
     for variant in &model.variants {
         s.push_str("            crate::models::base::ModelVariant {\n");
-        s.push_str(&format!("                format: {:?}.to_string(),\n", variant.format));
-        s.push_str(&format!("                precision: {:?}.to_string(),\n", variant.precision));
-        s.push_str(&format!("                size_gb: {},\n", format_float(variant.size_gb)));
-        s.push_str(&format!("                url: {:?}.to_string(),\n", variant.url));
+        s.push_str(&format!(
+            "                format: {:?}.to_string(),\n",
+            variant.format
+        ));
+        s.push_str(&format!(
+            "                precision: {:?}.to_string(),\n",
+            variant.precision
+        ));
+        s.push_str(&format!(
+            "                size_gb: {},\n",
+            format_float(variant.size_gb)
+        ));
+        s.push_str(&format!(
+            "                url: {:?}.to_string(),\n",
+            variant.url
+        ));
         s.push_str("            },\n");
     }
     s.push_str("        ]);\n");
-        s.push_str("        &VARIANTS\n");
+    s.push_str("        &VARIANTS\n");
     s.push_str("    }\n");
 
     // Description
@@ -108,7 +144,10 @@ fn generate_model_struct(model: &YamlModel) -> String {
     s.push_str("    fn supported_functions(&self) -> &[crate::models::base::ModelFunction] {\n");
     s.push_str("        static FUNCS: std::sync::LazyLock<Vec<crate::models::base::ModelFunction>> = std::sync::LazyLock::new(|| vec![\n");
     for func in &model.supported_functions {
-        s.push_str(&format!("            crate::models::base::ModelFunction::{},\n", func));
+        s.push_str(&format!(
+            "            crate::models::base::ModelFunction::{},\n",
+            func
+        ));
     }
     s.push_str("        ]);\n");
     s.push_str("        &FUNCS\n");
@@ -116,7 +155,10 @@ fn generate_model_struct(model: &YamlModel) -> String {
     s.push_str("}\n\n");
 
     // HasModelMetadata implementation
-    s.push_str(&format!("impl crate::models::base::HasModelMetadata for {} {{\n", struct_name));
+    s.push_str(&format!(
+        "impl crate::models::base::HasModelMetadata for {} {{\n",
+        struct_name
+    ));
     s.push_str("    fn metadata() -> crate::models::base::ModelMetadata {\n");
     s.push_str(&generate_metadata_literal(model));
     s.push_str("    }\n");
@@ -128,13 +170,31 @@ fn generate_model_struct(model: &YamlModel) -> String {
 fn generate_metadata_literal(model: &YamlModel) -> String {
     let mut s = String::new();
     s.push_str("        crate::models::base::ModelMetadata {\n");
-    s.push_str(&format!("            family: {:?}.to_string(),\n", model.family));
-    s.push_str(&format!("            version: {:?}.to_string(),\n", model.version));
+    s.push_str(&format!(
+        "            family: {:?}.to_string(),\n",
+        model.family
+    ));
+    s.push_str(&format!(
+        "            version: {:?}.to_string(),\n",
+        model.version
+    ));
     s.push_str(&format!("            size: {},\n", model.size));
-    s.push_str(&format!("            context_length: {},\n", model.context_length));
-    s.push_str(&format!("            model_type: crate::models::base::ModelType::{},\n", model.model_type));
-    s.push_str(&format!("            huggingface_repo: {:?}.to_string(),\n", model.huggingface_repo));
-    s.push_str(&format!("            native_dtype: {:?}.to_string(),\n", model.native_dtype));
+    s.push_str(&format!(
+        "            context_length: {},\n",
+        model.context_length
+    ));
+    s.push_str(&format!(
+        "            model_type: crate::models::base::ModelType::{},\n",
+        model.model_type
+    ));
+    s.push_str(&format!(
+        "            huggingface_repo: {:?}.to_string(),\n",
+        model.huggingface_repo
+    ));
+    s.push_str(&format!(
+        "            native_dtype: {:?}.to_string(),\n",
+        model.native_dtype
+    ));
     s.push_str("            architecture: ");
     s.push_str(&generate_architecture_literal(&model.architecture));
     s.push_str(",\n");
@@ -143,17 +203,32 @@ fn generate_metadata_literal(model: &YamlModel) -> String {
     s.push_str("            variants: vec![\n");
     for variant in &model.variants {
         s.push_str("                crate::models::base::ModelVariant {\n");
-        s.push_str(&format!("                    format: {:?}.to_string(),\n", variant.format));
-        s.push_str(&format!("                    precision: {:?}.to_string(),\n", variant.precision));
-        s.push_str(&format!("                    size_gb: {},\n", format_float(variant.size_gb)));
-        s.push_str(&format!("                    url: {:?}.to_string(),\n", variant.url));
+        s.push_str(&format!(
+            "                    format: {:?}.to_string(),\n",
+            variant.format
+        ));
+        s.push_str(&format!(
+            "                    precision: {:?}.to_string(),\n",
+            variant.precision
+        ));
+        s.push_str(&format!(
+            "                    size_gb: {},\n",
+            format_float(variant.size_gb)
+        ));
+        s.push_str(&format!(
+            "                    url: {:?}.to_string(),\n",
+            variant.url
+        ));
         s.push_str("                },\n");
     }
     s.push_str("            ],\n");
 
     // Description
     if let Some(ref desc) = model.description {
-        s.push_str(&format!("            description: Some({:?}.to_string()),\n", desc));
+        s.push_str(&format!(
+            "            description: Some({:?}.to_string()),\n",
+            desc
+        ));
     } else {
         s.push_str("            description: None,\n");
     }
@@ -168,7 +243,10 @@ fn generate_metadata_literal(model: &YamlModel) -> String {
     // Supported functions
     s.push_str("            supported_functions: vec![\n");
     for func in &model.supported_functions {
-        s.push_str(&format!("                crate::models::base::ModelFunction::{},\n", func));
+        s.push_str(&format!(
+            "                crate::models::base::ModelFunction::{},\n",
+            func
+        ));
     }
     s.push_str("            ],\n");
 
@@ -179,15 +257,27 @@ fn generate_metadata_literal(model: &YamlModel) -> String {
 fn generate_architecture_literal(arch: &YamlArchitecture) -> String {
     let mut s = String::new();
     s.push_str("crate::models::base::ModelArchitecture {\n");
-    s.push_str(&format!("            num_hidden_layers: {},\n", arch.num_hidden_layers));
+    s.push_str(&format!(
+        "            num_hidden_layers: {},\n",
+        arch.num_hidden_layers
+    ));
     s.push_str(&format!("            hidden_size: {},\n", arch.hidden_size));
-    s.push_str(&format!("            num_attention_heads: {},\n", arch.num_attention_heads));
-    s.push_str(&format!("            num_key_value_heads: {},\n", arch.num_key_value_heads));
+    s.push_str(&format!(
+        "            num_attention_heads: {},\n",
+        arch.num_attention_heads
+    ));
+    s.push_str(&format!(
+        "            num_key_value_heads: {},\n",
+        arch.num_key_value_heads
+    ));
     s.push_str(&format!("            head_dim: {},\n", arch.head_dim));
     s.push_str("            layer_types: vec![\n");
     for ltc in &arch.layer_types {
         s.push_str("                crate::models::base::LayerTypeCount {\n");
-        s.push_str(&format!("                    kind: {},\n", generate_layer_kind_literal(ltc)));
+        s.push_str(&format!(
+            "                    kind: {},\n",
+            generate_layer_kind_literal(ltc)
+        ));
         s.push_str(&format!("                    count: {},\n", ltc.count));
         s.push_str("                },\n");
     }
@@ -203,7 +293,10 @@ fn generate_layer_kind_literal(ltc: &YamlLayerTypeCount) -> String {
             let window = ltc
                 .window
                 .unwrap_or_else(|| panic!("sliding_attention layer_type missing `window` field"));
-            format!("crate::models::base::LayerKind::SlidingAttention {{ window: {} }}", window)
+            format!(
+                "crate::models::base::LayerKind::SlidingAttention {{ window: {} }}",
+                window
+            )
         }
         "recurrent" => {
             let mamba = ltc
@@ -239,16 +332,14 @@ fn model_id_to_struct_name(id: &str) -> String {
                 let mut chars = part.chars();
                 match chars.next() {
                     None => String::new(),
-                    Some(first) => {
-                        first.to_uppercase().collect::<String>() + chars.as_str()
-                    }
+                    Some(first) => first.to_uppercase().collect::<String>() + chars.as_str(),
                 }
             }
         })
         .collect::<String>() // Join without separator for proper CamelCase
 }
 
- #[derive(serde::Deserialize)]
+#[derive(serde::Deserialize)]
 struct YamlModel {
     id: String,
     family: String,

--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+# Run from the root
+cd $(dirname ${BASH_SOURCE[0]})/..
+
+cargo fmt --all --check --
+cargo clippy --all-targets --all-features -- -D warnings

--- a/src/capabilities/base.rs
+++ b/src/capabilities/base.rs
@@ -145,4 +145,4 @@ pub struct ToolConfig {
 
 use crate::define_factory;
 
-define_factory!( Capability, CapabilityMetadata, CapabilityFactory);
+define_factory!(Capability, CapabilityMetadata, CapabilityFactory);

--- a/src/commands/capability.rs
+++ b/src/commands/capability.rs
@@ -13,11 +13,18 @@ impl CapabilityCommands {
     pub fn catalog(ctx: &crate::AppContext) -> Result<()> {
         let capabilities = CAPABILITY_REGISTRY.entries();
 
-        let mut rows: Vec<Vec<String>> = capabilities.iter().map(|(cap_id, cap)| {
-            let deps: Vec<_> = cap.dependencies.iter().map(|d| d.to_string()).collect();
-            let deps_str = if deps.is_empty() { "None".to_string() } else { deps.join(", ") };
-            vec![cap_id.to_string(), cap.name.clone(), deps_str]
-        }).collect();
+        let mut rows: Vec<Vec<String>> = capabilities
+            .iter()
+            .map(|(cap_id, cap)| {
+                let deps: Vec<_> = cap.dependencies.iter().map(|d| d.to_string()).collect();
+                let deps_str = if deps.is_empty() {
+                    "None".to_string()
+                } else {
+                    deps.join(", ")
+                };
+                vec![cap_id.to_string(), cap.name.clone(), deps_str]
+            })
+            .collect();
         rows.sort_by(|a, b| a[0].cmp(&b[0]));
 
         ctx.ui.table(
@@ -29,12 +36,18 @@ impl CapabilityCommands {
     }
 
     pub fn list(ctx: &crate::AppContext) -> Result<()> {
-        let mut rows: Vec<Vec<String>> = ctx.config.capabilities.iter().map(|(id, cfg)| {
-            let name = CAPABILITY_REGISTRY.get(id)
-                .map(|c| c.name.clone())
-                .unwrap_or_else(|| id.clone());
-            vec![id.clone(), name, cfg.enabled.to_string()]
-        }).collect();
+        let mut rows: Vec<Vec<String>> = ctx
+            .config
+            .capabilities
+            .iter()
+            .map(|(id, cfg)| {
+                let name = CAPABILITY_REGISTRY
+                    .get(id)
+                    .map(|c| c.name.clone())
+                    .unwrap_or_else(|| id.clone());
+                vec![id.clone(), name, cfg.enabled.to_string()]
+            })
+            .collect();
         rows.sort_by(|a, b| a[0].cmp(&b[0]));
 
         ctx.ui.table(
@@ -49,7 +62,7 @@ impl CapabilityCommands {
         match CAPABILITY_REGISTRY.get(capability_id) {
             Some(cap) => {
                 let mut fields: Vec<(&str, String)> = vec![
-                    ("Name",        cap.name.clone()),
+                    ("Name", cap.name.clone()),
                     ("Description", cap.description.clone()),
                 ];
 
@@ -73,12 +86,18 @@ impl CapabilityCommands {
                 if let Some(configured) = ctx.config.get_capability(capability_id) {
                     let fields: Vec<(&str, String)> = vec![
                         ("Enabled", configured.enabled.to_string()),
-                        ("Note", "Configured but not found in bundled registry.".to_string()),
+                        (
+                            "Note",
+                            "Configured but not found in bundled registry.".to_string(),
+                        ),
                     ];
                     ctx.ui.detail(capability_id, &fields);
                     Ok(())
                 } else {
-                    ctx.ui.error(&format!("Capability '{}' not found in registry.", capability_id));
+                    ctx.ui.error(&format!(
+                        "Capability '{}' not found in registry.",
+                        capability_id
+                    ));
                     anyhow::bail!("Capability not found");
                 }
             }
@@ -88,7 +107,8 @@ impl CapabilityCommands {
     pub async fn setup(ctx: &mut crate::AppContext, capability_id: &str) -> Result<()> {
         match CAPABILITY_REGISTRY.get(capability_id) {
             Some(cap) => {
-                ctx.ui.info(&format!("\nSetting up capability: {}", capability_id));
+                ctx.ui
+                    .info(&format!("\nSetting up capability: {}", capability_id));
                 ctx.ui.info(&format!("Name: {}", cap.name));
                 ctx.ui.info(&format!("Description: {}", cap.description));
                 ctx.ui.info("");
@@ -136,10 +156,15 @@ impl CapabilityCommands {
                 // Prompt for capability-specific configuration
                 let mut config_map = HashMap::new();
 
-                let enabled = ctx.ui.confirm(&format!("Enable '{}' capability?", cap.name), true)?;
+                let enabled = ctx
+                    .ui
+                    .confirm(&format!("Enable '{}' capability?", cap.name), true)?;
 
                 if enabled {
-                    ctx.ui.info(&format!("\nCapability {} will be available at tool launch time.", cap.name));
+                    ctx.ui.info(&format!(
+                        "\nCapability {} will be available at tool launch time.",
+                        cap.name
+                    ));
                     config_map.insert("enabled".to_string(), "true".to_string());
 
                     // Get runtime bindings to show what will be injected
@@ -154,21 +179,32 @@ impl CapabilityCommands {
                     //     }
                     // }
                 } else {
-                    ctx.ui.info(&format!("\nCapability {} is disabled.", cap.name));
+                    ctx.ui
+                        .info(&format!("\nCapability {} is disabled.", cap.name));
                     config_map.insert("enabled".to_string(), "false".to_string());
                 }
 
                 let capability_config = crate::config::CapabilityConfig {
                     capability_id: capability_id.to_string(),
-                    enabled: config_map.get("enabled").map(|v| v == "true").unwrap_or(true),
+                    enabled: config_map
+                        .get("enabled")
+                        .map(|v| v == "true")
+                        .unwrap_or(true),
                     config: config_map,
                 };
 
-                if let Err(e) = ctx.config.insert_capability(capability_id, capability_config) {
-                    ctx.ui.warn(&format!("failed to save capability config: {}", e));
+                if let Err(e) = ctx
+                    .config
+                    .insert_capability(capability_id, capability_config)
+                {
+                    ctx.ui
+                        .warn(&format!("failed to save capability config: {}", e));
                 }
 
-                ctx.ui.info(&format!("\nCapability '{}' configured successfully!", capability_id));
+                ctx.ui.info(&format!(
+                    "\nCapability '{}' configured successfully!",
+                    capability_id
+                ));
 
                 Ok(())
             }
@@ -189,15 +225,26 @@ impl CapabilityCommands {
 
                     if overwrite {
                         ctx.ui.info("\nPlease remove the existing config first:");
-                        ctx.ui.info(&format!("  granite-cli capability remove {}", capability_id));
+                        ctx.ui.info(&format!(
+                            "  granite-cli capability remove {}",
+                            capability_id
+                        ));
                         ctx.ui.info("Then run setup again.");
                     }
 
                     Ok(())
                 } else {
-                    ctx.ui.error(&format!("Capability '{}' not found in registry.", capability_id));
-                    let available: Vec<_> = CAPABILITY_REGISTRY.entries().keys().map(|k| k.to_string()).collect();
-                    ctx.ui.info(&format!("Available capabilities: {}", available.join(", ")));
+                    ctx.ui.error(&format!(
+                        "Capability '{}' not found in registry.",
+                        capability_id
+                    ));
+                    let available: Vec<_> = CAPABILITY_REGISTRY
+                        .entries()
+                        .keys()
+                        .map(|k| k.to_string())
+                        .collect();
+                    ctx.ui
+                        .info(&format!("Available capabilities: {}", available.join(", ")));
                     anyhow::bail!("Capability not found");
                 }
             }
@@ -274,23 +321,34 @@ mod tests {
 
     fn ctx_with_capability(id: &str, enabled: bool) -> crate::AppContext {
         let mut ctx = test_ctx();
-        ctx.config.capabilities.insert(id.to_string(), CapabilityConfig {
-            capability_id: id.to_string(),
-            enabled,
-            config: std::collections::HashMap::new(),
-        });
+        ctx.config.capabilities.insert(
+            id.to_string(),
+            CapabilityConfig {
+                capability_id: id.to_string(),
+                enabled,
+                config: std::collections::HashMap::new(),
+            },
+        );
         ctx
     }
 
     macro_rules! tables {
         ($ctx:expr) => {
-            (&*($ctx.ui) as &dyn std::any::Any).downcast_ref::<CaptureUi>().unwrap().tables.borrow()
+            (&*($ctx.ui) as &dyn std::any::Any)
+                .downcast_ref::<CaptureUi>()
+                .unwrap()
+                .tables
+                .borrow()
         };
     }
 
     macro_rules! details {
         ($ctx:expr) => {
-            (&*($ctx.ui) as &dyn std::any::Any).downcast_ref::<CaptureUi>().unwrap().details.borrow()
+            (&*($ctx.ui) as &dyn std::any::Any)
+                .downcast_ref::<CaptureUi>()
+                .unwrap()
+                .details
+                .borrow()
         };
     }
 

--- a/src/commands/hardware.rs
+++ b/src/commands/hardware.rs
@@ -1,6 +1,6 @@
 // Local
-use anyhow::Result;
 use crate::utils::hardware::detect_hardware;
+use anyhow::Result;
 
 pub struct HardwareCommands;
 
@@ -12,11 +12,23 @@ impl HardwareCommands {
     pub(crate) fn hardware_fields() -> Vec<(&'static str, String)> {
         let profile = detect_hardware();
         vec![
-            ("CPU Cores",             profile.cpu_cores.to_string()),
-            ("CPU Architecture",      profile.cpu_arch.clone()),
-            ("RAM",                   format!("{:.2} GB", profile.ram_gb)),
-            ("GPU Vendor",            profile.gpu_vendor.clone().unwrap_or_else(|| "None".to_string())),
-            ("VRAM",                  profile.vram_gb.map(|v| format!("{:.2} GB", v)).unwrap_or_else(|| "None".to_string())),
+            ("CPU Cores", profile.cpu_cores.to_string()),
+            ("CPU Architecture", profile.cpu_arch.clone()),
+            ("RAM", format!("{:.2} GB", profile.ram_gb)),
+            (
+                "GPU Vendor",
+                profile
+                    .gpu_vendor
+                    .clone()
+                    .unwrap_or_else(|| "None".to_string()),
+            ),
+            (
+                "VRAM",
+                profile
+                    .vram_gb
+                    .map(|v| format!("{:.2} GB", v))
+                    .unwrap_or_else(|| "None".to_string()),
+            ),
         ]
     }
 
@@ -45,7 +57,10 @@ mod tests {
         let ctx = ctx();
         HardwareCommands::show(&ctx).unwrap();
         let details = (&*ctx.ui as &dyn std::any::Any)
-            .downcast_ref::<CaptureUi>().unwrap().details.borrow();
+            .downcast_ref::<CaptureUi>()
+            .unwrap()
+            .details
+            .borrow();
         assert_eq!(details.len(), 1);
     }
 

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -1,9 +1,9 @@
+pub mod capability;
 pub mod hardware;
 pub mod model;
-pub mod capability;
 pub mod provider;
 
+pub use capability::CapabilityCommands;
 pub use hardware::HardwareCommands;
 pub use model::ModelCommands;
-pub use capability::CapabilityCommands;
 pub use provider::ProviderCommands;

--- a/src/commands/model.rs
+++ b/src/commands/model.rs
@@ -145,7 +145,7 @@ impl ModelCommands {
 
         let mut rows: Vec<(f64, Vec<String>)> = models
             .iter()
-            .filter(|(_, m)| filter_type.map_or(true, |t| m.model_type == *t))
+            .filter(|(_, m)| filter_type.is_none_or(|t| m.model_type == *t))
             .filter_map(|(id, m)| {
                 let fit_rank = |fit: &ContextFit| match fit {
                     ContextFit::Full => 1,
@@ -167,7 +167,7 @@ impl ModelCommands {
                     })
                     .filter(|(fit, _)| *fit != ContextFit::None)
                     .filter(|(_, v)| {
-                        filter_providers.map_or(true, |ps| {
+                        filter_providers.is_none_or(|ps| {
                             ps.iter().any(|p| p.can_run_model(&v.format, &v.precision))
                         })
                     })
@@ -334,7 +334,7 @@ impl ModelCommands {
         let models = MODEL_REGISTRY.entries();
         let mut rows: Vec<(Vec<String>, ModelMetadata)> = models
             .iter()
-            .filter(|(_, m)| filter_type.map_or(true, |t| m.model_type == *t))
+            .filter(|(_, m)| filter_type.is_none_or(|t| m.model_type == *t))
             .map(|(id, m)| {
                 let row = vec![
                     id.to_string(),
@@ -375,11 +375,10 @@ impl ModelCommands {
 
         for (model_id, model_config) in &ctx.config.models {
             if let Some(model_md) = MODEL_REGISTRY.get(model_id) {
-                if let Some(ref t) = filter_type {
-                    if model_md.model_type != *t {
+                if let Some(ref t) = filter_type
+                    && model_md.model_type != *t {
                         continue;
                     }
-                }
                 let row = vec![
                     model_id.clone(),
                     model_md.family.clone(),
@@ -503,8 +502,8 @@ impl ModelCommands {
                     selected_variant.format, selected_variant.precision
                 ));
 
-                if let Some(existing) = ctx.config.get_model(model_id) {
-                    if existing.enabled {
+                if let Some(existing) = ctx.config.get_model(model_id)
+                    && existing.enabled {
                         let overwrite = ctx.ui.confirm(
                             &format!("Model '{}' is already configured. Overwrite?", model_id),
                             false,
@@ -514,7 +513,6 @@ impl ModelCommands {
                             return Ok(());
                         }
                     }
-                }
 
                 let requirement = VariantRequirement {
                     format: selected_variant.format.clone(),

--- a/src/commands/model.rs
+++ b/src/commands/model.rs
@@ -32,7 +32,7 @@ fn compare_versions_desc(a: &str, b: &str) -> std::cmp::Ordering {
 }
 
 /// Sort enriched rows by family (asc), version (desc), size (desc), id (asc).
-fn sort_enriched_rows(rows: &mut Vec<(Vec<String>, ModelMetadata)>) {
+fn sort_enriched_rows(rows: &mut [(Vec<String>, ModelMetadata)]) {
     rows.sort_by(|(row_a, meta_a), (row_b, meta_b)| {
         meta_a
             .family
@@ -376,9 +376,10 @@ impl ModelCommands {
         for (model_id, model_config) in &ctx.config.models {
             if let Some(model_md) = MODEL_REGISTRY.get(model_id) {
                 if let Some(ref t) = filter_type
-                    && model_md.model_type != *t {
-                        continue;
-                    }
+                    && model_md.model_type != *t
+                {
+                    continue;
+                }
                 let row = vec![
                     model_id.clone(),
                     model_md.family.clone(),
@@ -503,16 +504,17 @@ impl ModelCommands {
                 ));
 
                 if let Some(existing) = ctx.config.get_model(model_id)
-                    && existing.enabled {
-                        let overwrite = ctx.ui.confirm(
-                            &format!("Model '{}' is already configured. Overwrite?", model_id),
-                            false,
-                        )?;
-                        if !overwrite {
-                            ctx.ui.info("Model setup skipped.");
-                            return Ok(());
-                        }
+                    && existing.enabled
+                {
+                    let overwrite = ctx.ui.confirm(
+                        &format!("Model '{}' is already configured. Overwrite?", model_id),
+                        false,
+                    )?;
+                    if !overwrite {
+                        ctx.ui.info("Model setup skipped.");
+                        return Ok(());
                     }
+                }
 
                 let requirement = VariantRequirement {
                     format: selected_variant.format.clone(),

--- a/src/commands/model.rs
+++ b/src/commands/model.rs
@@ -5,19 +5,18 @@ use anyhow::Result;
 use crate::commands::ProviderCommands;
 use crate::dependency::{self, Configured, DependsOn, Requirement};
 use crate::models::{ContextFit, MODEL_REGISTRY, ModelMetadata, ModelType, ModelVariant};
-use crate::utils::hardware::detect_hardware;
-use crate::providers::{Provider, ProviderMetadata, ProviderSource, ProviderType, PullResult, PROVIDER_REGISTRY};
-use crate::utils::ui::Ui;
+use crate::providers::{
+    PROVIDER_REGISTRY, Provider, ProviderMetadata, ProviderSource, ProviderType, PullResult,
+};
 use crate::utils::Searchable;
+use crate::utils::hardware::detect_hardware;
+use crate::utils::ui::Ui;
 
 /// Compare semantic versions in descending order (higher versions first).
 /// Handles versions like "3.1", "4.0", "3.0.1".
 fn compare_versions_desc(a: &str, b: &str) -> std::cmp::Ordering {
-    let parse_version = |v: &str| -> Vec<u32> {
-        v.split('.')
-            .filter_map(|s| s.parse::<u32>().ok())
-            .collect()
-    };
+    let parse_version =
+        |v: &str| -> Vec<u32> { v.split('.').filter_map(|s| s.parse::<u32>().ok()).collect() };
 
     let va = parse_version(a);
     let vb = parse_version(b);
@@ -35,7 +34,9 @@ fn compare_versions_desc(a: &str, b: &str) -> std::cmp::Ordering {
 /// Sort enriched rows by family (asc), version (desc), size (desc), id (asc).
 fn sort_enriched_rows(rows: &mut Vec<(Vec<String>, ModelMetadata)>) {
     rows.sort_by(|(row_a, meta_a), (row_b, meta_b)| {
-        meta_a.family.cmp(&meta_b.family)
+        meta_a
+            .family
+            .cmp(&meta_b.family)
             .then_with(|| compare_versions_desc(&meta_a.version, &meta_b.version))
             .then_with(|| meta_b.size.cmp(&meta_a.size))
             .then_with(|| row_a[0].cmp(&row_b[0]))
@@ -88,7 +89,9 @@ impl ModelCommands {
             .iter()
             .filter(|(id, m)| {
                 id.to_lowercase().contains(&q)
-                    || m.search_fields().iter().any(|f| f.to_lowercase().contains(&q))
+                    || m.search_fields()
+                        .iter()
+                        .any(|f| f.to_lowercase().contains(&q))
             })
             .map(|(id, m)| {
                 let row = vec![
@@ -108,7 +111,8 @@ impl ModelCommands {
     pub fn search(ctx: &crate::AppContext, query: &str) -> Result<()> {
         let rows = Self::search_rows(query);
         if rows.is_empty() {
-            ctx.ui.info(&format!("No models found matching '{}'.", query));
+            ctx.ui
+                .info(&format!("No models found matching '{}'.", query));
             return Ok(());
         }
         ctx.ui.table(
@@ -148,28 +152,46 @@ impl ModelCommands {
                     ContextFit::Partial(_) => 0,
                     ContextFit::None => -1,
                 };
-                let best = m.variants.iter()
+                let best = m
+                    .variants
+                    .iter()
                     .map(|v| {
                         let fit = crate::models::context_fit::estimate(
-                            m.context_length, &m.architecture, &m.native_dtype, v, &profile,
+                            m.context_length,
+                            &m.architecture,
+                            &m.native_dtype,
+                            v,
+                            &profile,
                         );
                         (fit, v)
                     })
                     .filter(|(fit, _)| *fit != ContextFit::None)
-                    .filter(|(_, v)| filter_providers.map_or(true, |ps| {
-                        ps.iter().any(|p| p.can_run_model(&v.format, &v.precision))
-                    }))
+                    .filter(|(_, v)| {
+                        filter_providers.map_or(true, |ps| {
+                            ps.iter().any(|p| p.can_run_model(&v.format, &v.precision))
+                        })
+                    })
                     .max_by(|(fit_a, a), (fit_b, b)| {
-                        fit_rank(fit_a).cmp(&fit_rank(fit_b)).then_with(|| a.size_gb.partial_cmp(&b.size_gb).unwrap())
+                        fit_rank(fit_a)
+                            .cmp(&fit_rank(fit_b))
+                            .then_with(|| a.size_gb.partial_cmp(&b.size_gb).unwrap())
                     })?;
                 let (fit, variant) = best;
-                let variant_label = format!("{} / {} ({:.1} GB)", variant.format, variant.precision, variant.size_gb);
+                let variant_label = format!(
+                    "{} / {} ({:.1} GB)",
+                    variant.format, variant.precision, variant.size_gb
+                );
                 let providers_str = {
-                    let matching: Vec<&str> = display_providers.iter()
+                    let matching: Vec<&str> = display_providers
+                        .iter()
                         .filter(|(_, p)| p.can_run_model(&variant.format, &variant.precision))
                         .map(|(pid, _)| pid.as_str())
                         .collect();
-                    if matching.is_empty() { "None".to_string() } else { matching.join(", ") }
+                    if matching.is_empty() {
+                        "None".to_string()
+                    } else {
+                        matching.join(", ")
+                    }
                 };
 
                 let fit_str = if matches!(fit, ContextFit::Partial(_)) {
@@ -233,23 +255,43 @@ impl ModelCommands {
         } else if providers_arg.is_empty() {
             Some(instances.iter().map(|(_, p)| *p).collect())
         } else {
-            let unknown: Vec<&str> = providers_arg.iter()
+            let unknown: Vec<&str> = providers_arg
+                .iter()
                 .filter(|id| !instances.iter().any(|(iid, _)| iid == *id))
                 .map(String::as_str)
                 .collect();
             if !unknown.is_empty() {
-                let configured = instances.iter().map(|(id, _)| id.clone())
-                    .collect::<Vec<_>>().join(", ");
+                let configured = instances
+                    .iter()
+                    .map(|(id, _)| id.clone())
+                    .collect::<Vec<_>>()
+                    .join(", ");
                 anyhow::bail!(
                     "Unknown or disabled provider(s): {}. Configured providers: {}",
                     unknown.join(", "),
-                    if configured.is_empty() { "none".to_string() } else { configured },
+                    if configured.is_empty() {
+                        "none".to_string()
+                    } else {
+                        configured
+                    },
                 );
             }
-            Some(instances.iter().filter(|(iid, _)| providers_arg.contains(iid)).map(|(_, p)| *p).collect())
+            Some(
+                instances
+                    .iter()
+                    .filter(|(iid, _)| providers_arg.contains(iid))
+                    .map(|(_, p)| *p)
+                    .collect(),
+            )
         };
 
-        let table_rows = Self::recommend_rows(filter_type.as_ref(), providers.as_deref(), &instances, wide, ctx.ui.as_ref());
+        let table_rows = Self::recommend_rows(
+            filter_type.as_ref(),
+            providers.as_deref(),
+            &instances,
+            wide,
+            ctx.ui.as_ref(),
+        );
         if table_rows.is_empty() {
             let msg = if matches!(&providers, Some(list) if list.is_empty()) {
                 "No models fit: no providers are configured. Use --providers all to ignore \
@@ -261,12 +303,24 @@ impl ModelCommands {
             return Ok(());
         }
         let headers: &[&str] = if wide {
-            &["ID", "FAMILY", "SIZE", "CONTEXT", "VARIANT", "TYPE", "FIT", "PROVIDERS"]
+            &[
+                "ID",
+                "FAMILY",
+                "SIZE",
+                "CONTEXT",
+                "VARIANT",
+                "TYPE",
+                "FIT",
+                "PROVIDERS",
+            ]
         } else {
             &["ID", "SIZE", "VARIANT", "TYPE", "FIT", "PROVIDERS"]
         };
         ctx.ui.table(
-            &format!("Recommended Models for this hardware ({} models)", table_rows.len()),
+            &format!(
+                "Recommended Models for this hardware ({} models)",
+                table_rows.len()
+            ),
             headers,
             &table_rows,
         );
@@ -301,7 +355,10 @@ impl ModelCommands {
         if rows.is_empty() {
             ctx.ui.info(&format!(
                 "No models found{}.",
-                filter_type.as_ref().map(|t| format!(" matching type: {}", t)).unwrap_or_default()
+                filter_type
+                    .as_ref()
+                    .map(|t| format!(" matching type: {}", t))
+                    .unwrap_or_default()
             ));
             return Ok(());
         }
@@ -329,7 +386,10 @@ impl ModelCommands {
                     model_md.format_size(),
                     model_md.context_length.to_string(),
                     model_md.model_type.to_string(),
-                    model_config.provider_id.clone().unwrap_or_else(|| "None".to_string()),
+                    model_config
+                        .provider_id
+                        .clone()
+                        .unwrap_or_else(|| "None".to_string()),
                 ];
                 enriched.push((row, model_md.clone()));
             }
@@ -351,12 +411,12 @@ impl ModelCommands {
     pub(crate) fn info_fields(model_id: &str) -> Option<Vec<(&'static str, String)>> {
         let model = MODEL_REGISTRY.get(model_id)?;
         let mut fields: Vec<(&'static str, String)> = vec![
-            ("Family",         model.family.clone()),
-            ("Version",        model.version.clone()),
-            ("Size",           format!("{} parameters", model.format_size())),
+            ("Family", model.family.clone()),
+            ("Version", model.version.clone()),
+            ("Size", format!("{} parameters", model.format_size())),
             ("Context Length", format!("{} tokens", model.context_length)),
-            ("Type",           model.model_type.to_string()),
-            ("Hugging Face",   model.huggingface_repo.clone()),
+            ("Type", model.model_type.to_string()),
+            ("Hugging Face", model.huggingface_repo.clone()),
         ];
         if let Some(desc) = &model.description {
             fields.push(("Description", desc.clone()));
@@ -364,12 +424,16 @@ impl ModelCommands {
         if !model.tags.is_empty() {
             fields.push(("Tags", model.tags.join(", ")));
         }
-        let variants_str = model.variants.iter()
+        let variants_str = model
+            .variants
+            .iter()
             .map(|v| format!("{} / {} ({:.1} GB)", v.format, v.precision, v.size_gb))
             .collect::<Vec<_>>()
             .join(", ");
         fields.push(("Variants", variants_str));
-        let funcs_str = model.supported_functions.iter()
+        let funcs_str = model
+            .supported_functions
+            .iter()
             .map(|f| f.to_string())
             .collect::<Vec<_>>()
             .join(", ");
@@ -382,17 +446,23 @@ impl ModelCommands {
             Some(mut fields) => {
                 if let Some(configured) = ctx.config.get_model(model_id) {
                     fields.push(("Config: Provider", format!("{:?}", configured.provider_id)));
-                    fields.push(("Config: Variant",  format!("{:?}", configured.variant)));
-                    fields.push(("Config: Enabled",  configured.enabled.to_string()));
+                    fields.push(("Config: Variant", format!("{:?}", configured.variant)));
+                    fields.push(("Config: Enabled", configured.enabled.to_string()));
                 }
 
                 ctx.ui.detail(model_id, &fields);
                 Ok(())
             }
             None => {
-                ctx.ui.error(&format!("Model '{}' not found in registry.", model_id));
-                let available: Vec<_> = MODEL_REGISTRY.entries().keys().map(|k| k.to_string()).collect();
-                ctx.ui.info(&format!("Available models: {}", available.join(", ")));
+                ctx.ui
+                    .error(&format!("Model '{}' not found in registry.", model_id));
+                let available: Vec<_> = MODEL_REGISTRY
+                    .entries()
+                    .keys()
+                    .map(|k| k.to_string())
+                    .collect();
+                ctx.ui
+                    .info(&format!("Available models: {}", available.join(", ")));
                 anyhow::bail!("Model not found");
             }
         }
@@ -402,20 +472,36 @@ impl ModelCommands {
         match MODEL_REGISTRY.get(model_id) {
             Some(model) => {
                 ctx.ui.info(&format!("\nSetting up model: {}", model_id));
-                ctx.ui.info(model.description.as_deref().unwrap_or("No description available."));
+                ctx.ui.info(
+                    model
+                        .description
+                        .as_deref()
+                        .unwrap_or("No description available."),
+                );
                 ctx.ui.info("");
-                ctx.ui.info(&format!("Size: {} params, {} context", model.format_size(), model.context_length));
+                ctx.ui.info(&format!(
+                    "Size: {} params, {} context",
+                    model.format_size(),
+                    model.context_length
+                ));
                 ctx.ui.info(&format!("Type: {}", model.model_type));
                 ctx.ui.info("");
 
-                let variant_options: Vec<_> = model.variants.iter()
+                let variant_options: Vec<_> = model
+                    .variants
+                    .iter()
                     .map(|v| format!("{} / {} ({:.1} GB)", v.format, v.precision, v.size_gb))
                     .collect();
 
-                let variant_index = ctx.ui.select("Select model variant:", &variant_options, 0)?;
+                let variant_index = ctx
+                    .ui
+                    .select("Select model variant:", &variant_options, 0)?;
 
                 let selected_variant = &model.variants[variant_index];
-                ctx.ui.info(&format!("\nSelected: {} / {}", selected_variant.format, selected_variant.precision));
+                ctx.ui.info(&format!(
+                    "\nSelected: {} / {}",
+                    selected_variant.format, selected_variant.precision
+                ));
 
                 if let Some(existing) = ctx.config.get_model(model_id) {
                     if existing.enabled {
@@ -442,7 +528,10 @@ impl ModelCommands {
                 let model_config = crate::config::ModelConfig {
                     model_id: model_id.to_string(),
                     provider_id: provider_id.clone(),
-                    variant: Some(format!("{}/{}", selected_variant.format, selected_variant.precision)),
+                    variant: Some(format!(
+                        "{}/{}",
+                        selected_variant.format, selected_variant.precision
+                    )),
                     enabled: true,
                 };
 
@@ -450,10 +539,13 @@ impl ModelCommands {
                     ctx.ui.warn(&format!("failed to save model config: {}", e));
                 }
 
-                ctx.ui.info(&format!("\nModel '{}' configured successfully!", model_id));
+                ctx.ui
+                    .info(&format!("\nModel '{}' configured successfully!", model_id));
 
                 if let Some(pid) = &provider_id {
-                    let is_local = ctx.config.get_provider(pid)
+                    let is_local = ctx
+                        .config
+                        .get_provider(pid)
                         .and_then(|pc| PROVIDER_REGISTRY.get(&pc.provider_type))
                         .map(|meta| meta.provider_type == ProviderType::Local)
                         .unwrap_or(false);
@@ -470,9 +562,18 @@ impl ModelCommands {
                             let source = ProviderSource::from_config(&ctx.config);
                             match source.instances().into_iter().find(|(id, _)| id == pid) {
                                 Some((_, provider)) => {
-                                    ensure_model_pulled(provider, &model, selected_variant, ctx.ui.as_ref()).await?;
+                                    ensure_model_pulled(
+                                        provider,
+                                        &model,
+                                        selected_variant,
+                                        ctx.ui.as_ref(),
+                                    )
+                                    .await?;
                                 }
-                                None => ctx.ui.warn(&format!("Provider '{}' is not available; skipping pull.", pid)),
+                                None => ctx.ui.warn(&format!(
+                                    "Provider '{}' is not available; skipping pull.",
+                                    pid
+                                )),
                             }
                         }
                     }
@@ -481,9 +582,15 @@ impl ModelCommands {
                 Ok(())
             }
             None => {
-                ctx.ui.error(&format!("Model '{}' not found in registry.", model_id));
-                let available: Vec<_> = MODEL_REGISTRY.entries().keys().map(|k| k.to_string()).collect();
-                ctx.ui.info(&format!("Available models: {}", available.join(", ")));
+                ctx.ui
+                    .error(&format!("Model '{}' not found in registry.", model_id));
+                let available: Vec<_> = MODEL_REGISTRY
+                    .entries()
+                    .keys()
+                    .map(|k| k.to_string())
+                    .collect();
+                ctx.ui
+                    .info(&format!("Available models: {}", available.join(", ")));
                 anyhow::bail!("Model not found");
             }
         }
@@ -493,9 +600,15 @@ impl ModelCommands {
         let model = match MODEL_REGISTRY.get(model_id) {
             Some(model) => model,
             None => {
-                ctx.ui.error(&format!("Model '{}' not found in registry.", model_id));
-                let available: Vec<_> = MODEL_REGISTRY.entries().keys().map(|k| k.to_string()).collect();
-                ctx.ui.info(&format!("Available models: {}", available.join(", ")));
+                ctx.ui
+                    .error(&format!("Model '{}' not found in registry.", model_id));
+                let available: Vec<_> = MODEL_REGISTRY
+                    .entries()
+                    .keys()
+                    .map(|k| k.to_string())
+                    .collect();
+                ctx.ui
+                    .info(&format!("Available models: {}", available.join(", ")));
                 anyhow::bail!("Model not found");
             }
         };
@@ -506,36 +619,60 @@ impl ModelCommands {
                 (c.variant.clone().unwrap(), c.provider_id.clone().unwrap())
             }
             _ => {
-                anyhow::bail!("Model '{}' is not configured yet. Run `model setup {}` first.", model_id, model_id);
+                anyhow::bail!(
+                    "Model '{}' is not configured yet. Run `model setup {}` first.",
+                    model_id,
+                    model_id
+                );
             }
         };
 
         let (format, precision) = variant_str.split_once('/').ok_or_else(|| {
-            anyhow::anyhow!("Invalid stored variant '{}' for model '{}'.", variant_str, model_id)
+            anyhow::anyhow!(
+                "Invalid stored variant '{}' for model '{}'.",
+                variant_str,
+                model_id
+            )
         })?;
 
-        let variant: &ModelVariant = model.variants.iter()
+        let variant: &ModelVariant = model
+            .variants
+            .iter()
             .find(|v| v.format == format && v.precision == precision)
-            .ok_or_else(|| anyhow::anyhow!(
-                "Variant '{}/{}' is no longer available for model '{}'.", format, precision, model_id
-            ))?;
+            .ok_or_else(|| {
+                anyhow::anyhow!(
+                    "Variant '{}/{}' is no longer available for model '{}'.",
+                    format,
+                    precision,
+                    model_id
+                )
+            })?;
 
         let source = ProviderSource::from_config(&ctx.config);
         let instances = source.instances();
-        let provider = instances.iter()
+        let provider = instances
+            .iter()
             .find(|(id, _)| id == &provider_id)
             .map(|(_, p)| *p)
-            .ok_or_else(|| anyhow::anyhow!(
-                "Provider '{}' is not configured or enabled. Run `provider setup` first.", provider_id
-            ))?;
+            .ok_or_else(|| {
+                anyhow::anyhow!(
+                    "Provider '{}' is not configured or enabled. Run `provider setup` first.",
+                    provider_id
+                )
+            })?;
 
         let result = ensure_model_pulled(provider, &model, variant, ctx.ui.as_ref()).await;
         match result {
             Ok(PullResult::Success) => {
-                ctx.ui.info(&format!("Model '{}' pulled successfully.", model.family));
+                ctx.ui
+                    .info(&format!("Model '{}' pulled successfully.", model.family));
             }
             Ok(PullResult::Unnecessary) => {
-                ctx.ui.info(&format!("No pull needed for '{}' ({}).", model.family, provider.name()));
+                ctx.ui.info(&format!(
+                    "No pull needed for '{}' ({}).",
+                    model.family,
+                    provider.name()
+                ));
             }
             Ok(PullResult::Unsupported { message }) => {
                 ctx.ui.warn(&message);
@@ -557,8 +694,10 @@ impl ModelCommands {
         resolution: &dependency::Resolution,
     ) -> Result<Option<String>> {
         if resolution.is_unsatisfiable() {
-            ctx.ui.info("\nNo provider supports this variant's format/precision yet.");
-            ctx.ui.info("Configure a provider later, then set its id on this model.");
+            ctx.ui
+                .info("\nNo provider supports this variant's format/precision yet.");
+            ctx.ui
+                .info("Configure a provider later, then set its id on this model.");
             return Ok(None);
         }
 
@@ -571,7 +710,8 @@ impl ModelCommands {
         let choice = if options.len() == 1 {
             0
         } else {
-            ctx.ui.select("Select a provider for this model", &options, 0)?
+            ctx.ui
+                .select("Select a provider for this model", &options, 0)?
         };
 
         if options[choice] != CONFIGURE_NEW {
@@ -581,8 +721,14 @@ impl ModelCommands {
         let provider_type = if resolution.configurable_types.len() == 1 {
             resolution.configurable_types[0]
         } else {
-            let type_options: Vec<String> = resolution.configurable_types.iter().map(|s| s.to_string()).collect();
-            let type_index = ctx.ui.select("Select a provider type to configure", &type_options, 0)?;
+            let type_options: Vec<String> = resolution
+                .configurable_types
+                .iter()
+                .map(|s| s.to_string())
+                .collect();
+            let type_index =
+                ctx.ui
+                    .select("Select a provider type to configure", &type_options, 0)?;
             resolution.configurable_types[type_index]
         };
 
@@ -626,49 +772,75 @@ mod tests {
 
     macro_rules! tables {
         ($ctx:expr) => {
-            (&*($ctx.ui) as &dyn std::any::Any).downcast_ref::<CaptureUi>().unwrap().tables.borrow()
+            (&*($ctx.ui) as &dyn std::any::Any)
+                .downcast_ref::<CaptureUi>()
+                .unwrap()
+                .tables
+                .borrow()
         };
     }
 
     macro_rules! details {
         ($ctx:expr) => {
-            (&*($ctx.ui) as &dyn std::any::Any).downcast_ref::<CaptureUi>().unwrap().details.borrow()
+            (&*($ctx.ui) as &dyn std::any::Any)
+                .downcast_ref::<CaptureUi>()
+                .unwrap()
+                .details
+                .borrow()
         };
     }
 
     macro_rules! errors {
         ($ctx:expr) => {
-            (&*($ctx.ui) as &dyn std::any::Any).downcast_ref::<CaptureUi>().unwrap().errors.borrow()
+            (&*($ctx.ui) as &dyn std::any::Any)
+                .downcast_ref::<CaptureUi>()
+                .unwrap()
+                .errors
+                .borrow()
         };
     }
 
     macro_rules! infos {
         ($ctx:expr) => {
-            (&*($ctx.ui) as &dyn std::any::Any).downcast_ref::<CaptureUi>().unwrap().infos.borrow()
+            (&*($ctx.ui) as &dyn std::any::Any)
+                .downcast_ref::<CaptureUi>()
+                .unwrap()
+                .infos
+                .borrow()
         };
     }
 
     fn ctx_with_model(id: &str, provider_id: Option<&str>) -> crate::AppContext {
         let mut ctx = empty_ctx();
-        ctx.config.models.insert(id.to_string(), ModelConfig {
-            model_id: id.to_string(),
-            provider_id: provider_id.map(String::from),
-            variant: None,
-            enabled: true,
-        });
+        ctx.config.models.insert(
+            id.to_string(),
+            ModelConfig {
+                model_id: id.to_string(),
+                provider_id: provider_id.map(String::from),
+                variant: None,
+                enabled: true,
+            },
+        );
         ctx
     }
 
     fn ctx_with_model_variant_and_provider(
-        model_id: &str, variant: &str, provider_id: &str, provider_type: &str, provider_config: serde_json::Value,
+        model_id: &str,
+        variant: &str,
+        provider_id: &str,
+        provider_type: &str,
+        provider_config: serde_json::Value,
     ) -> crate::AppContext {
         let mut config = config_with_provider(provider_id, provider_type, provider_config);
-        config.models.insert(model_id.to_string(), ModelConfig {
-            model_id: model_id.to_string(),
-            provider_id: Some(provider_id.to_string()),
-            variant: Some(variant.to_string()),
-            enabled: true,
-        });
+        config.models.insert(
+            model_id.to_string(),
+            ModelConfig {
+                model_id: model_id.to_string(),
+                provider_id: Some(provider_id.to_string()),
+                variant: Some(variant.to_string()),
+                enabled: true,
+            },
+        );
         ctx_with_config(config)
     }
 
@@ -676,44 +848,82 @@ mod tests {
 
     #[test]
     fn compare_versions_desc_simple() {
-        assert_eq!(compare_versions_desc("3.1", "3.0"), std::cmp::Ordering::Less);
-        assert_eq!(compare_versions_desc("3.0", "3.1"), std::cmp::Ordering::Greater);
-        assert_eq!(compare_versions_desc("3.1", "3.1"), std::cmp::Ordering::Equal);
+        assert_eq!(
+            compare_versions_desc("3.1", "3.0"),
+            std::cmp::Ordering::Less
+        );
+        assert_eq!(
+            compare_versions_desc("3.0", "3.1"),
+            std::cmp::Ordering::Greater
+        );
+        assert_eq!(
+            compare_versions_desc("3.1", "3.1"),
+            std::cmp::Ordering::Equal
+        );
     }
 
     #[test]
     fn compare_versions_desc_multi_part() {
-        assert_eq!(compare_versions_desc("3.1.1", "3.1.0"), std::cmp::Ordering::Less);
-        assert_eq!(compare_versions_desc("3.1", "3.1.0"), std::cmp::Ordering::Greater);
+        assert_eq!(
+            compare_versions_desc("3.1.1", "3.1.0"),
+            std::cmp::Ordering::Less
+        );
+        assert_eq!(
+            compare_versions_desc("3.1", "3.1.0"),
+            std::cmp::Ordering::Greater
+        );
     }
 
     #[test]
     fn compare_versions_desc_major_difference() {
-        assert_eq!(compare_versions_desc("4.0", "3.1"), std::cmp::Ordering::Less);
+        assert_eq!(
+            compare_versions_desc("4.0", "3.1"),
+            std::cmp::Ordering::Less
+        );
     }
 
     #[test]
     fn sort_model_rows_by_family_version_size() {
         let rows = vec![
-            vec!["granite-3.0-8b-instruct".to_string(), "Granite 3.0".to_string(), "8B".to_string()],
-            vec!["granite-3.1-2b-instruct".to_string(), "Granite 3.1".to_string(), "2B".to_string()],
-            vec!["granite-3.1-8b-instruct".to_string(), "Granite 3.1".to_string(), "8B".to_string()],
-            vec!["granite-3.0-2b-instruct".to_string(), "Granite 3.0".to_string(), "2B".to_string()],
+            vec![
+                "granite-3.0-8b-instruct".to_string(),
+                "Granite 3.0".to_string(),
+                "8B".to_string(),
+            ],
+            vec![
+                "granite-3.1-2b-instruct".to_string(),
+                "Granite 3.1".to_string(),
+                "2B".to_string(),
+            ],
+            vec![
+                "granite-3.1-8b-instruct".to_string(),
+                "Granite 3.1".to_string(),
+                "8B".to_string(),
+            ],
+            vec![
+                "granite-3.0-2b-instruct".to_string(),
+                "Granite 3.0".to_string(),
+                "2B".to_string(),
+            ],
         ];
         let mut enriched: Vec<(Vec<String>, ModelMetadata)> = rows
             .into_iter()
-            .filter_map(|row| {
-                MODEL_REGISTRY.get(&row[0]).map(|m| (row, m.clone()))
-            })
+            .filter_map(|row| MODEL_REGISTRY.get(&row[0]).map(|m| (row, m.clone())))
             .collect();
         sort_enriched_rows(&mut enriched);
-        let sorted: Vec<String> = enriched.into_iter().map(|(row, _)| row[0].clone()).collect();
-        assert_eq!(sorted, vec![
-            "granite-3.0-8b-instruct",
-            "granite-3.0-2b-instruct",
-            "granite-3.1-8b-instruct",
-            "granite-3.1-2b-instruct",
-        ]);
+        let sorted: Vec<String> = enriched
+            .into_iter()
+            .map(|(row, _)| row[0].clone())
+            .collect();
+        assert_eq!(
+            sorted,
+            vec![
+                "granite-3.0-8b-instruct",
+                "granite-3.0-2b-instruct",
+                "granite-3.1-8b-instruct",
+                "granite-3.1-2b-instruct",
+            ]
+        );
     }
 
     // -- catalog --------------------------------------------------------------
@@ -837,7 +1047,6 @@ mod tests {
         assert!(!errors!(ctx).is_empty());
     }
 
-
     fn metadata_supporting(formats: Vec<ModelFormat>) -> ProviderMetadata {
         ProviderMetadata {
             name: "Test Provider".to_string(),
@@ -854,29 +1063,43 @@ mod tests {
 
     #[test]
     fn admits_type_only_checks_format_not_precision() {
-        let requirement = VariantRequirement { format: "gguf".to_string(), precision: "some-exotic-precision".to_string() };
+        let requirement = VariantRequirement {
+            format: "gguf".to_string(),
+            precision: "some-exotic-precision".to_string(),
+        };
         let metadata = metadata_supporting(vec![ModelFormat::GGUF]);
         assert!(requirement.admits_type(&metadata));
     }
 
     #[test]
     fn admits_type_rejects_unsupported_format() {
-        let requirement = VariantRequirement { format: "gguf".to_string(), precision: "fp16".to_string() };
+        let requirement = VariantRequirement {
+            format: "gguf".to_string(),
+            precision: "fp16".to_string(),
+        };
         let metadata = metadata_supporting(vec![ModelFormat::Safetensors]);
         assert!(!requirement.admits_type(&metadata));
     }
 
     #[test]
     fn admits_type_matches_format_case_insensitively() {
-        let requirement = VariantRequirement { format: "GGUF".to_string(), precision: "FP16".to_string() };
+        let requirement = VariantRequirement {
+            format: "GGUF".to_string(),
+            precision: "FP16".to_string(),
+        };
         let metadata = metadata_supporting(vec![ModelFormat::GGUF]);
         assert!(requirement.admits_type(&metadata));
     }
 
     #[test]
     fn admits_instance_defers_to_the_provider_instance() {
-        let requirement = VariantRequirement { format: "safetensors".to_string(), precision: "bfloat16".to_string() };
-        let provider = crate::providers::OpenAIProvider::new(&serde_json::json!({ "base_url": "http://localhost:8080" }));
+        let requirement = VariantRequirement {
+            format: "safetensors".to_string(),
+            precision: "bfloat16".to_string(),
+        };
+        let provider = crate::providers::OpenAIProvider::new(
+            &serde_json::json!({ "base_url": "http://localhost:8080" }),
+        );
         assert!(requirement.admits_instance(&provider));
     }
 
@@ -934,17 +1157,23 @@ mod tests {
 
     fn config_with_provider(id: &str, provider_type: &str, config: serde_json::Value) -> Config {
         let mut config_obj = Config::default();
-        config_obj.providers.insert(id.to_string(), crate::config::ProviderConfig {
-            provider_id: id.to_string(),
-            provider_type: provider_type.to_string(),
-            config,
-            enabled: true,
-        });
+        config_obj.providers.insert(
+            id.to_string(),
+            crate::config::ProviderConfig {
+                provider_id: id.to_string(),
+                provider_type: provider_type.to_string(),
+                config,
+                enabled: true,
+            },
+        );
         config_obj
     }
 
     fn ctx_with_config(config: Config) -> crate::AppContext {
-        crate::AppContext { config, ui: Box::new(CaptureUi::default()) }
+        crate::AppContext {
+            config,
+            ui: Box::new(CaptureUi::default()),
+        }
     }
 
     #[test]
@@ -952,7 +1181,7 @@ mod tests {
         let ctx = empty_ctx();
         ModelCommands::recommend(&ctx, None, &all_providers(), false).unwrap();
         let has_table = !tables!(ctx).is_empty();
-        let has_info  = !infos!(ctx).is_empty();
+        let has_info = !infos!(ctx).is_empty();
         assert!(has_table || has_info, "expected a table or an info message");
     }
 
@@ -1010,14 +1239,20 @@ mod tests {
         ModelCommands::recommend(&ctx, None, &all_providers(), false).unwrap();
         for (_, _, rows) in tables!(ctx).iter() {
             // Extract the GB value from the VARIANT column "format / precision (N.N GB)"
-            let sizes: Vec<f64> = rows.iter().map(|r| {
-                let v = &r[2];
-                let start = v.rfind('(').unwrap() + 1;
-                let end   = v.rfind(" GB)").unwrap();
-                v[start..end].parse::<f64>().expect("parseable GB value")
-            }).collect();
+            let sizes: Vec<f64> = rows
+                .iter()
+                .map(|r| {
+                    let v = &r[2];
+                    let start = v.rfind('(').unwrap() + 1;
+                    let end = v.rfind(" GB)").unwrap();
+                    v[start..end].parse::<f64>().expect("parseable GB value")
+                })
+                .collect();
             for window in sizes.windows(2) {
-                assert!(window[0] >= window[1], "rows must be sorted descending by variant size");
+                assert!(
+                    window[0] >= window[1],
+                    "rows must be sorted descending by variant size"
+                );
             }
         }
     }
@@ -1028,55 +1263,85 @@ mod tests {
         ModelCommands::recommend(&ctx, None, &[], false).unwrap();
         assert!(tables!(ctx).is_empty());
         let infos = infos!(ctx);
-        assert!(infos.iter().any(|m| m.contains("no providers are configured")));
+        assert!(
+            infos
+                .iter()
+                .any(|m| m.contains("no providers are configured"))
+        );
     }
 
     #[test]
     fn recommend_default_with_permissive_provider_shows_results() {
         let ctx = ctx_with_config(config_with_provider(
-            "openai", "openai-compatible", serde_json::json!({ "base_url": "http://localhost:8080" }),
+            "openai",
+            "openai-compatible",
+            serde_json::json!({ "base_url": "http://localhost:8080" }),
         ));
         ModelCommands::recommend(&ctx, None, &[], false).unwrap();
-        assert!(!tables!(ctx).is_empty(), "a permissive configured provider should surface recommendations");
+        assert!(
+            !tables!(ctx).is_empty(),
+            "a permissive configured provider should surface recommendations"
+        );
     }
 
     #[test]
     fn recommend_default_with_gguf_only_provider_excludes_non_gguf_models() {
         let with_all = ctx_with_config(Config::default());
         ModelCommands::recommend(&with_all, None, &all_providers(), false).unwrap();
-        let all_count: usize = tables!(with_all).iter().map(|(_, _, rows)| rows.len()).sum();
+        let all_count: usize = tables!(with_all)
+            .iter()
+            .map(|(_, _, rows)| rows.len())
+            .sum();
 
         let gguf_only = ctx_with_config(config_with_provider(
-            "llama-cpp", "llama-cpp", serde_json::json!({}),
+            "llama-cpp",
+            "llama-cpp",
+            serde_json::json!({}),
         ));
         ModelCommands::recommend(&gguf_only, None, &[], false).unwrap();
-        let gguf_rows: Vec<Vec<String>> = tables!(gguf_only).iter()
-            .flat_map(|(_, _, rows)| rows.clone()).collect();
+        let gguf_rows: Vec<Vec<String>> = tables!(gguf_only)
+            .iter()
+            .flat_map(|(_, _, rows)| rows.clone())
+            .collect();
 
         assert!(
             gguf_rows.len() <= all_count,
             "gguf-only provider should not recommend more models than the unfiltered set",
         );
         for row in &gguf_rows {
-            assert!(row[2].to_lowercase().starts_with("gguf"), "variant column must be gguf, got {}", row[2]);
+            assert!(
+                row[2].to_lowercase().starts_with("gguf"),
+                "variant column must be gguf, got {}",
+                row[2]
+            );
         }
     }
 
     #[test]
     fn recommend_providers_flag_narrows_to_named_provider() {
         let mut config = config_with_provider("llama-cpp", "llama-cpp", serde_json::json!({}));
-        config.providers.insert("openai".to_string(), crate::config::ProviderConfig {
-            provider_id: "openai".to_string(),
-            provider_type: "openai-compatible".to_string(),
-            config: serde_json::json!({ "base_url": "http://localhost:8080" }),
-            enabled: true,
-        });
+        config.providers.insert(
+            "openai".to_string(),
+            crate::config::ProviderConfig {
+                provider_id: "openai".to_string(),
+                provider_type: "openai-compatible".to_string(),
+                config: serde_json::json!({ "base_url": "http://localhost:8080" }),
+                enabled: true,
+            },
+        );
         let ctx = ctx_with_config(config);
 
         ModelCommands::recommend(&ctx, None, &["llama-cpp".to_string()], false).unwrap();
-        let narrowed_rows: Vec<Vec<String>> = tables!(ctx).iter().flat_map(|(_, _, rows)| rows.clone()).collect();
+        let narrowed_rows: Vec<Vec<String>> = tables!(ctx)
+            .iter()
+            .flat_map(|(_, _, rows)| rows.clone())
+            .collect();
         for row in &narrowed_rows {
-            assert!(row[2].to_lowercase().starts_with("gguf"), "narrowed to llama-cpp should only show gguf, got {}", row[2]);
+            assert!(
+                row[2].to_lowercase().starts_with("gguf"),
+                "narrowed to llama-cpp should only show gguf, got {}",
+                row[2]
+            );
         }
     }
 
@@ -1090,19 +1355,30 @@ mod tests {
     #[test]
     fn recommend_all_combined_with_named_provider_errors() {
         let ctx = empty_ctx();
-        let result = ModelCommands::recommend(&ctx, None, &["all".to_string(), "llama-cpp".to_string()], false);
+        let result = ModelCommands::recommend(
+            &ctx,
+            None,
+            &["all".to_string(), "llama-cpp".to_string()],
+            false,
+        );
         assert!(result.is_err());
     }
 
     #[test]
     fn recommend_providers_column_lists_matching_configured_providers() {
         let ctx = ctx_with_config(config_with_provider(
-            "llama-cpp", "llama-cpp", serde_json::json!({}),
+            "llama-cpp",
+            "llama-cpp",
+            serde_json::json!({}),
         ));
         ModelCommands::recommend(&ctx, None, &[], false).unwrap();
         for (_, _, rows) in tables!(ctx).iter() {
             for row in rows {
-                assert_eq!(row[5], "llama-cpp", "providers column should name the matching configured provider, got {}", row[5]);
+                assert_eq!(
+                    row[5], "llama-cpp",
+                    "providers column should name the matching configured provider, got {}",
+                    row[5]
+                );
             }
         }
     }
@@ -1112,7 +1388,11 @@ mod tests {
         let ui = Box::new(CaptureUi::default());
         let rows = ModelCommands::recommend_rows(None, None, &[], false, &*ui);
         for row in &rows {
-            assert_eq!(row[5], "None", "with no display providers, PROVIDERS column must be None, got {}", row[5]);
+            assert_eq!(
+                row[5], "None",
+                "with no display providers, PROVIDERS column must be None, got {}",
+                row[5]
+            );
         }
     }
 
@@ -1144,8 +1424,11 @@ mod tests {
     #[tokio::test]
     async fn pull_with_unconfigured_provider_errors() {
         let mut ctx = ctx_with_model("granite-3.1-8b-instruct", Some("missing-provider"));
-        ctx.config.models.get_mut("granite-3.1-8b-instruct").unwrap().variant =
-            Some("safetensors/bfloat16".to_string());
+        ctx.config
+            .models
+            .get_mut("granite-3.1-8b-instruct")
+            .unwrap()
+            .variant = Some("safetensors/bfloat16".to_string());
         let result = ModelCommands::pull(&mut ctx, "granite-3.1-8b-instruct").await;
         assert!(result.is_err());
         assert!(result.unwrap_err().to_string().contains("missing-provider"));
@@ -1154,8 +1437,11 @@ mod tests {
     #[tokio::test]
     async fn pull_with_unknown_variant_errors() {
         let mut ctx = ctx_with_model_variant_and_provider(
-            "granite-3.1-8b-instruct", "safetensors/does-not-exist", "openai",
-            "openai-compatible", serde_json::json!({ "base_url": "http://localhost:8080" }),
+            "granite-3.1-8b-instruct",
+            "safetensors/does-not-exist",
+            "openai",
+            "openai-compatible",
+            serde_json::json!({ "base_url": "http://localhost:8080" }),
         );
         let result = ModelCommands::pull(&mut ctx, "granite-3.1-8b-instruct").await;
         assert!(result.is_err());
@@ -1164,15 +1450,22 @@ mod tests {
     #[tokio::test]
     async fn pull_delegates_to_provider_pull_model() {
         let mut ctx = ctx_with_model_variant_and_provider(
-            "granite-3.1-8b-instruct", "safetensors/bfloat16", "openai",
-            "openai-compatible", serde_json::json!({ "base_url": "http://localhost:8080" }),
+            "granite-3.1-8b-instruct",
+            "safetensors/bfloat16",
+            "openai",
+            "openai-compatible",
+            serde_json::json!({ "base_url": "http://localhost:8080" }),
         );
         // OpenAIProvider::pull_model is a pure warning (no network call), so
         // this exercises the full lookup path end-to-end without needing a
         // live server.
         let result = ModelCommands::pull(&mut ctx, "granite-3.1-8b-instruct").await;
         assert!(result.is_ok());
-        let warns = (&*(ctx.ui) as &dyn std::any::Any).downcast_ref::<CaptureUi>().unwrap().warns.borrow();
+        let warns = (&*(ctx.ui) as &dyn std::any::Any)
+            .downcast_ref::<CaptureUi>()
+            .unwrap()
+            .warns
+            .borrow();
         assert!(!warns.is_empty());
     }
 }

--- a/src/commands/provider.rs
+++ b/src/commands/provider.rs
@@ -2,7 +2,7 @@
 use anyhow::Result;
 
 // Local
-use crate::providers::{PROVIDER_REGISTRY, HealthStatus};
+use crate::providers::{HealthStatus, PROVIDER_REGISTRY};
 use crate::utils::prompt_from_schema;
 
 pub struct ProviderCommands;
@@ -11,9 +11,10 @@ impl ProviderCommands {
     pub fn catalog(ctx: &crate::AppContext) -> Result<()> {
         let providers = PROVIDER_REGISTRY.entries();
 
-        let mut rows: Vec<Vec<String>> = providers.iter().map(|(id, p)| {
-            vec![id.to_string(), p.default_endpoint.clone()]
-        }).collect();
+        let mut rows: Vec<Vec<String>> = providers
+            .iter()
+            .map(|(id, p)| vec![id.to_string(), p.default_endpoint.clone()])
+            .collect();
         rows.sort_by(|a, b| a[0].cmp(&b[0]));
 
         ctx.ui.table(
@@ -25,13 +26,25 @@ impl ProviderCommands {
     }
 
     pub fn list(ctx: &crate::AppContext) -> Result<()> {
-        let mut rows: Vec<Vec<String>> = ctx.config.providers.iter().map(|(id, cfg)| {
-            let base_url = cfg.config.get("base_url")
-                .and_then(|v| v.as_str())
-                .unwrap_or("-")
-                .to_string();
-            vec![id.clone(), cfg.provider_type.clone(), cfg.enabled.to_string(), base_url]
-        }).collect();
+        let mut rows: Vec<Vec<String>> = ctx
+            .config
+            .providers
+            .iter()
+            .map(|(id, cfg)| {
+                let base_url = cfg
+                    .config
+                    .get("base_url")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("-")
+                    .to_string();
+                vec![
+                    id.clone(),
+                    cfg.provider_type.clone(),
+                    cfg.enabled.to_string(),
+                    base_url,
+                ]
+            })
+            .collect();
         rows.sort_by(|a, b| {
             let type_cmp = a[1].cmp(&b[1]);
             if type_cmp != std::cmp::Ordering::Equal {
@@ -48,7 +61,7 @@ impl ProviderCommands {
         Ok(())
     }
 
-     /// Interactive provider setup wizard.
+    /// Interactive provider setup wizard.
     ///
     /// `provider_type` is the catalog/registry key (e.g. `openai-compatible`).
     /// `instance_id` is this instance's nickname, distinct from its type --
@@ -63,17 +76,31 @@ impl ProviderCommands {
         let provider_def = match PROVIDER_REGISTRY.get(provider_type) {
             Some(def) => def,
             None => {
-                ctx.ui.error(&format!("Provider type '{}' not found in registry.", provider_type));
-                let available: Vec<_> = PROVIDER_REGISTRY.entries().iter().map(|(p_id, p)| format!("{} ({})", p_id, p.name)).collect();
-                ctx.ui.info(&format!("Available provider types: {}", available.join(", ")));
+                ctx.ui.error(&format!(
+                    "Provider type '{}' not found in registry.",
+                    provider_type
+                ));
+                let available: Vec<_> = PROVIDER_REGISTRY
+                    .entries()
+                    .iter()
+                    .map(|(p_id, p)| format!("{} ({})", p_id, p.name))
+                    .collect();
+                ctx.ui.info(&format!(
+                    "Available provider types: {}",
+                    available.join(", ")
+                ));
                 anyhow::bail!("Provider type not found");
             }
         };
 
-        ctx.ui.info(&format!("\nSetting up provider instance: {}", provider_type));
+        ctx.ui.info(&format!(
+            "\nSetting up provider instance: {}",
+            provider_type
+        ));
         ctx.ui.info(&provider_def.description);
         ctx.ui.info("");
-        ctx.ui.info(&format!("Type: {}", provider_def.provider_type));
+        ctx.ui
+            .info(&format!("Type: {}", provider_def.provider_type));
 
         // Get a name for this instance
         let instance_id = match instance_id {
@@ -82,7 +109,12 @@ impl ProviderCommands {
         };
 
         if !provider_def.authentication.is_empty() {
-            let auths = provider_def.authentication.iter().map(|a| a.to_string()).collect::<Vec<_>>().join(", ");
+            let auths = provider_def
+                .authentication
+                .iter()
+                .map(|a| a.to_string())
+                .collect::<Vec<_>>()
+                .join(", ");
             ctx.ui.info(&format!("Authentication: {}", auths));
         }
 
@@ -90,7 +122,10 @@ impl ProviderCommands {
         let existing_config = ctx.config.get_provider(&instance_id);
         if existing_config.is_some() {
             let overwrite = ctx.ui.confirm(
-                &format!("Provider instance '{}' is already configured. Overwrite?", instance_id),
+                &format!(
+                    "Provider instance '{}' is already configured. Overwrite?",
+                    instance_id
+                ),
                 false,
             )?;
             if !overwrite {
@@ -99,8 +134,14 @@ impl ProviderCommands {
             }
         }
 
-        let schema = PROVIDER_REGISTRY.config_schema(provider_type)
-            .ok_or_else(|| anyhow::anyhow!("No config schema registered for provider type '{}'", provider_type))?;
+        let schema = PROVIDER_REGISTRY
+            .config_schema(provider_type)
+            .ok_or_else(|| {
+                anyhow::anyhow!(
+                    "No config schema registered for provider type '{}'",
+                    provider_type
+                )
+            })?;
         let defaults = existing_config
             .map(|c| c.config.clone())
             .or_else(|| PROVIDER_REGISTRY.default_config(provider_type))
@@ -116,7 +157,8 @@ impl ProviderCommands {
         };
 
         if let Err(e) = ctx.config.insert_provider(&instance_id, provider_config) {
-            ctx.ui.warn(&format!("failed to save provider config: {}", e));
+            ctx.ui
+                .warn(&format!("failed to save provider config: {}", e));
         }
 
         // Health check
@@ -124,7 +166,8 @@ impl ProviderCommands {
         match Self::check_provider_health(ctx, &instance_id).await {
             Ok(status) => {
                 if status.healthy {
-                    ctx.ui.info(&format!("Provider '{}' is healthy!", instance_id));
+                    ctx.ui
+                        .info(&format!("Provider '{}' is healthy!", instance_id));
                 } else {
                     ctx.ui.warn(&format!("Provider '{}' health check failed. It may need to be started or configured differently.", instance_id));
                 }
@@ -134,13 +177,18 @@ impl ProviderCommands {
             }
         }
 
-        ctx.ui.info(&format!("\nProvider instance '{}' configured successfully!", instance_id));
+        ctx.ui.info(&format!(
+            "\nProvider instance '{}' configured successfully!",
+            instance_id
+        ));
         ctx.ui.info("Supported APIs:");
         for (func, endpoints) in &provider_def.default_function_endpoints {
-            let endpoint_strs: Vec<String> = endpoints.iter()
+            let endpoint_strs: Vec<String> = endpoints
+                .iter()
                 .map(|ep| format!("{} ({})", ep.api_type(), ep.path()))
                 .collect();
-            ctx.ui.info(&format!("  - {} -> {}", func, endpoint_strs.join(", ")));
+            ctx.ui
+                .info(&format!("  - {} -> {}", func, endpoint_strs.join(", ")));
         }
 
         Ok(())
@@ -177,9 +225,13 @@ impl ProviderCommands {
         Ok(())
     }
 
-    async fn check_provider_health(ctx: &crate::AppContext, provider_id: &str) -> Result<HealthStatus> {
-        let provider_config = ctx.config.get_provider(provider_id)
-            .ok_or_else(|| anyhow::anyhow!("Provider '{}' not found in configuration", provider_id))?;
+    async fn check_provider_health(
+        ctx: &crate::AppContext,
+        provider_id: &str,
+    ) -> Result<HealthStatus> {
+        let provider_config = ctx.config.get_provider(provider_id).ok_or_else(|| {
+            anyhow::anyhow!("Provider '{}' not found in configuration", provider_id)
+        })?;
 
         let provider = PROVIDER_REGISTRY
             .construct(&provider_config.provider_type, &provider_config.config)
@@ -208,30 +260,45 @@ mod tests {
 
     fn ctx_with_provider(id: &str, url: &str) -> crate::AppContext {
         let mut ctx = test_ctx();
-        ctx.config.providers.insert(id.to_string(), ProviderConfig {
-            provider_id: id.to_string(),
-            provider_type: "openai-compatible".to_string(),
-            config: serde_json::json!({ "base_url": url }),
-            enabled: true,
-        });
+        ctx.config.providers.insert(
+            id.to_string(),
+            ProviderConfig {
+                provider_id: id.to_string(),
+                provider_type: "openai-compatible".to_string(),
+                config: serde_json::json!({ "base_url": url }),
+                enabled: true,
+            },
+        );
         ctx
     }
 
     macro_rules! tables {
         ($ctx:expr) => {
-            (&*($ctx.ui) as &dyn std::any::Any).downcast_ref::<CaptureUi>().unwrap().tables.borrow()
+            (&*($ctx.ui) as &dyn std::any::Any)
+                .downcast_ref::<CaptureUi>()
+                .unwrap()
+                .tables
+                .borrow()
         };
     }
 
     macro_rules! infos {
         ($ctx:expr) => {
-            (&*($ctx.ui) as &dyn std::any::Any).downcast_ref::<CaptureUi>().unwrap().infos.borrow()
+            (&*($ctx.ui) as &dyn std::any::Any)
+                .downcast_ref::<CaptureUi>()
+                .unwrap()
+                .infos
+                .borrow()
         };
     }
 
     macro_rules! statuses {
         ($ctx:expr) => {
-            (&*($ctx.ui) as &dyn std::any::Any).downcast_ref::<CaptureUi>().unwrap().statuses.borrow()
+            (&*($ctx.ui) as &dyn std::any::Any)
+                .downcast_ref::<CaptureUi>()
+                .unwrap()
+                .statuses
+                .borrow()
         };
     }
 
@@ -293,24 +360,33 @@ mod tests {
     #[test]
     fn list_sorted_by_type_then_id() {
         let mut ctx = test_ctx();
-        ctx.config.providers.insert("prod-openai".to_string(), ProviderConfig {
-            provider_id: "prod-openai".to_string(),
-            provider_type: "openai-compatible".to_string(),
-            config: serde_json::json!({ "base_url": "http://prod" }),
-            enabled: true,
-        });
-        ctx.config.providers.insert("local-ollama".to_string(), ProviderConfig {
-            provider_id: "local-ollama".to_string(),
-            provider_type: "ollama".to_string(),
-            config: serde_json::json!({ "base_url": "http://localhost:11434" }),
-            enabled: true,
-        });
-        ctx.config.providers.insert("dev-openai".to_string(), ProviderConfig {
-            provider_id: "dev-openai".to_string(),
-            provider_type: "openai-compatible".to_string(),
-            config: serde_json::json!({ "base_url": "http://dev" }),
-            enabled: true,
-        });
+        ctx.config.providers.insert(
+            "prod-openai".to_string(),
+            ProviderConfig {
+                provider_id: "prod-openai".to_string(),
+                provider_type: "openai-compatible".to_string(),
+                config: serde_json::json!({ "base_url": "http://prod" }),
+                enabled: true,
+            },
+        );
+        ctx.config.providers.insert(
+            "local-ollama".to_string(),
+            ProviderConfig {
+                provider_id: "local-ollama".to_string(),
+                provider_type: "ollama".to_string(),
+                config: serde_json::json!({ "base_url": "http://localhost:11434" }),
+                enabled: true,
+            },
+        );
+        ctx.config.providers.insert(
+            "dev-openai".to_string(),
+            ProviderConfig {
+                provider_id: "dev-openai".to_string(),
+                provider_type: "openai-compatible".to_string(),
+                config: serde_json::json!({ "base_url": "http://dev" }),
+                enabled: true,
+            },
+        );
         ProviderCommands::list(&ctx).unwrap();
         let tables = tables!(ctx);
         let (_, _, rows) = &tables[0];

--- a/src/config/exports.rs
+++ b/src/config/exports.rs
@@ -239,7 +239,7 @@ mod tests {
         );
 
         exporter
-            .add_exports(&CaptureUi::default(), &vec![("API_KEY", "secret123")])
+            .add_exports(&CaptureUi::default(), &[("API_KEY", "secret123")])
             .unwrap();
 
         let content = fs::read_to_string(&export_file).unwrap();
@@ -261,7 +261,7 @@ mod tests {
         );
 
         exporter
-            .add_exports(&CaptureUi::default(), &vec![("API_KEY", "secret123")])
+            .add_exports(&CaptureUi::default(), &[("API_KEY", "secret123")])
             .unwrap();
 
         let content_after_add = fs::read_to_string(&export_file).unwrap();
@@ -290,7 +290,7 @@ mod tests {
         assert!(!exporter.check_shell_profile_updated());
 
         exporter
-            .add_exports(&CaptureUi::default(), &vec![("API_KEY", "secret123")])
+            .add_exports(&CaptureUi::default(), &[("API_KEY", "secret123")])
             .unwrap();
 
         assert!(exporter.check_shell_profile_updated());
@@ -309,10 +309,10 @@ mod tests {
         );
 
         exporter
-            .add_exports(&CaptureUi::default(), &vec![("API_KEY", "old_secret")])
+            .add_exports(&CaptureUi::default(), &[("API_KEY", "old_secret")])
             .unwrap();
         exporter
-            .add_exports(&CaptureUi::default(), &vec![("API_KEY", "new_secret")])
+            .add_exports(&CaptureUi::default(), &[("API_KEY", "new_secret")])
             .unwrap();
 
         let content = fs::read_to_string(&export_file).unwrap();

--- a/src/config/exports.rs
+++ b/src/config/exports.rs
@@ -120,8 +120,7 @@ impl Exporter {
             return false;
         }
 
-        let content = fs::read_to_string(path)
-            .unwrap_or_default();
+        let content = fs::read_to_string(path).unwrap_or_default();
 
         content.contains(EXPORT_MARKER_START) && content.contains(EXPORT_MARKER_END)
     }
@@ -133,7 +132,12 @@ pub fn detect_shell_profile() -> (String, String) {
     (name, path.to_string_lossy().to_string())
 }
 
-pub fn print_export_instructions(ui: &dyn Ui, vars: &[(&str, &str)], _shell_name: &str, export_file: &str) {
+pub fn print_export_instructions(
+    ui: &dyn Ui,
+    vars: &[(&str, &str)],
+    _shell_name: &str,
+    export_file: &str,
+) {
     ui.info(&format!(
         "\nTo persist these settings, you can export them to your shell profile:\n  Granite CLI will add the following to {}:\n",
         export_file
@@ -222,7 +226,11 @@ mod tests {
         let export_path = export_file.to_string_lossy().to_string();
 
         // Create file with existing content
-        fs::write(&export_file, "# Existing content\nexport OTHER_VAR=\"value\"\n").unwrap();
+        fs::write(
+            &export_file,
+            "# Existing content\nexport OTHER_VAR=\"value\"\n",
+        )
+        .unwrap();
 
         let exporter = Exporter::new(
             "bash".to_string(),
@@ -230,7 +238,9 @@ mod tests {
             "export {VAR}=\"{VALUE}\"".to_string(),
         );
 
-        exporter.add_exports(&CaptureUi::default(), &vec![("API_KEY", "secret123")]).unwrap();
+        exporter
+            .add_exports(&CaptureUi::default(), &vec![("API_KEY", "secret123")])
+            .unwrap();
 
         let content = fs::read_to_string(&export_file).unwrap();
         assert!(content.contains("# Existing content"));
@@ -250,7 +260,9 @@ mod tests {
             "export {VAR}=\"{VALUE}\"".to_string(),
         );
 
-        exporter.add_exports(&CaptureUi::default(), &vec![("API_KEY", "secret123")]).unwrap();
+        exporter
+            .add_exports(&CaptureUi::default(), &vec![("API_KEY", "secret123")])
+            .unwrap();
 
         let content_after_add = fs::read_to_string(&export_file).unwrap();
         assert!(content_after_add.contains("API_KEY"));
@@ -277,7 +289,9 @@ mod tests {
 
         assert!(!exporter.check_shell_profile_updated());
 
-        exporter.add_exports(&CaptureUi::default(), &vec![("API_KEY", "secret123")]).unwrap();
+        exporter
+            .add_exports(&CaptureUi::default(), &vec![("API_KEY", "secret123")])
+            .unwrap();
 
         assert!(exporter.check_shell_profile_updated());
     }
@@ -294,8 +308,12 @@ mod tests {
             "export {VAR}=\"{VALUE}\"".to_string(),
         );
 
-        exporter.add_exports(&CaptureUi::default(), &vec![("API_KEY", "old_secret")]).unwrap();
-        exporter.add_exports(&CaptureUi::default(), &vec![("API_KEY", "new_secret")]).unwrap();
+        exporter
+            .add_exports(&CaptureUi::default(), &vec![("API_KEY", "old_secret")])
+            .unwrap();
+        exporter
+            .add_exports(&CaptureUi::default(), &vec![("API_KEY", "new_secret")])
+            .unwrap();
 
         let content = fs::read_to_string(&export_file).unwrap();
         assert!(content.contains("new_secret"));

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -158,7 +158,6 @@ pub struct ConfiguredCapability {
 }
 
 impl Config {
-
     fn config_dir() -> Result<PathBuf> {
         let val_res = std::env::var("GRANITE_CLI_HOME");
 
@@ -169,18 +168,22 @@ impl Config {
                 let has_valid_parent = path.parent().map_or(true, |p| p.exists());
 
                 let valid_dir =
-                    (!path.exists() && has_valid_parent) ||
-                    (path.exists() && path.is_dir());
+                    (!path.exists() && has_valid_parent) || (path.exists() && path.is_dir());
 
                 if !valid_dir {
-                    anyhow::bail!("Invalid GRANITE_CLI_HOME: '{}' parent does not exist or is not a directory.", val);
+                    anyhow::bail!(
+                        "Invalid GRANITE_CLI_HOME: '{}' parent does not exist or is not a directory.",
+                        val
+                    );
                 }
 
                 return Ok(path);
             }
         }
 
-        let default_dir = dirs::config_dir().ok_or_else(|| anyhow::Error::msg("Could not determine system configuration directory"))?;
+        let default_dir = dirs::config_dir().ok_or_else(|| {
+            anyhow::Error::msg("Could not determine system configuration directory")
+        })?;
 
         Ok(default_dir.join("granite-cli"))
     }
@@ -226,8 +229,7 @@ impl Config {
     }
 
     fn save_yaml_to_file<T: serde::Serialize>(path: &Path, data: &T) -> Result<()> {
-        let content = serde_yaml::to_string(data)
-            .with_context(|| "Failed to serialize config")?;
+        let content = serde_yaml::to_string(data).with_context(|| "Failed to serialize config")?;
         fs::write(path, content)
             .with_context(|| format!("Failed to write config file: {}", path.display()))?;
         Ok(())
@@ -245,7 +247,8 @@ impl Config {
             let entry = entry?;
             let path = entry.path();
             if path.extension().map_or(false, |ext| ext == "yaml") {
-                let file_name = path.file_stem()
+                let file_name = path
+                    .file_stem()
                     .map(|s| s.to_string_lossy().to_string())
                     .unwrap_or_default();
                 if let Ok(config) = Self::load_yaml_from_file::<V>(&path) {
@@ -273,22 +276,10 @@ impl Config {
         }
 
         // Load component files
-        config.models = Self::load_dir(
-            &Self::models_dir()?,
-            |s| s.to_string(),
-        )?;
-        config.providers = Self::load_dir(
-            &Self::providers_dir()?,
-            |s| s.to_string(),
-        )?;
-        config.capabilities = Self::load_dir(
-            &Self::capabilities_dir()?,
-            |s| s.to_string(),
-        )?;
-        config.tools = Self::load_dir(
-            &Self::tools_dir()?,
-            |s| s.to_string(),
-        )?;
+        config.models = Self::load_dir(&Self::models_dir()?, |s| s.to_string())?;
+        config.providers = Self::load_dir(&Self::providers_dir()?, |s| s.to_string())?;
+        config.capabilities = Self::load_dir(&Self::capabilities_dir()?, |s| s.to_string())?;
+        config.tools = Self::load_dir(&Self::tools_dir()?, |s| s.to_string())?;
 
         Ok(config)
     }
@@ -416,7 +407,11 @@ impl Config {
         self.save()
     }
 
-    pub fn update_capability(&mut self, id: &str, f: impl FnOnce(&mut CapabilityConfig)) -> Result<()> {
+    pub fn update_capability(
+        &mut self,
+        id: &str,
+        f: impl FnOnce(&mut CapabilityConfig),
+    ) -> Result<()> {
         if let Some(capability) = self.capabilities.get_mut(id) {
             f(capability);
             self.save()

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -8,21 +8,15 @@ use std::fs;
 use std::path::{Path, PathBuf};
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Default)]
 pub struct TopLevelConfig {
     pub routing: RoutingConfig,
     pub shell: ShellConfig,
 }
 
-impl Default for TopLevelConfig {
-    fn default() -> Self {
-        Self {
-            routing: RoutingConfig::default(),
-            shell: ShellConfig::default(),
-        }
-    }
-}
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Default)]
 pub struct Config {
     pub models: HashMap<String, ModelConfig>,
     pub providers: HashMap<String, ProviderConfig>,
@@ -32,18 +26,6 @@ pub struct Config {
     pub tools: HashMap<String, ToolConfig>,
 }
 
-impl Default for Config {
-    fn default() -> Self {
-        Self {
-            models: HashMap::new(),
-            providers: HashMap::new(),
-            capabilities: HashMap::new(),
-            routing: RoutingConfig::default(),
-            shell: ShellConfig::default(),
-            tools: HashMap::new(),
-        }
-    }
-}
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ModelConfig {
@@ -85,34 +67,20 @@ impl Default for ProviderConfig {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Default)]
 pub struct CapabilityConfig {
     pub capability_id: String,
     pub enabled: bool,
     pub config: HashMap<String, String>,
 }
 
-impl Default for CapabilityConfig {
-    fn default() -> Self {
-        Self {
-            capability_id: String::new(),
-            enabled: false,
-            config: HashMap::new(),
-        }
-    }
-}
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Default)]
 pub struct RoutingConfig {
     pub model_routes: HashMap<String, Vec<ProviderRoute>>,
 }
 
-impl Default for RoutingConfig {
-    fn default() -> Self {
-        Self {
-            model_routes: HashMap::new(),
-        }
-    }
-}
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ProviderRoute {
@@ -161,11 +129,11 @@ impl Config {
     fn config_dir() -> Result<PathBuf> {
         let val_res = std::env::var("GRANITE_CLI_HOME");
 
-        if let Ok(val) = val_res {
-            if !val.is_empty() {
+        if let Ok(val) = val_res
+            && !val.is_empty() {
                 let path = PathBuf::from(&val);
 
-                let has_valid_parent = path.parent().map_or(true, |p| p.exists());
+                let has_valid_parent = path.parent().is_none_or(|p| p.exists());
 
                 let valid_dir =
                     (!path.exists() && has_valid_parent) || (path.exists() && path.is_dir());
@@ -179,7 +147,6 @@ impl Config {
 
                 return Ok(path);
             }
-        }
 
         let default_dir = dirs::config_dir().ok_or_else(|| {
             anyhow::Error::msg("Could not determine system configuration directory")
@@ -246,7 +213,7 @@ impl Config {
         for entry in fs::read_dir(dir)? {
             let entry = entry?;
             let path = entry.path();
-            if path.extension().map_or(false, |ext| ext == "yaml") {
+            if path.extension().is_some_and(|ext| ext == "yaml") {
                 let file_name = path
                     .file_stem()
                     .map(|s| s.to_string_lossy().to_string())

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -7,16 +7,13 @@ use std::collections::HashMap;
 use std::fs;
 use std::path::{Path, PathBuf};
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[derive(Default)]
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
 pub struct TopLevelConfig {
     pub routing: RoutingConfig,
     pub shell: ShellConfig,
 }
 
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[derive(Default)]
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
 pub struct Config {
     pub models: HashMap<String, ModelConfig>,
     pub providers: HashMap<String, ProviderConfig>,
@@ -25,7 +22,6 @@ pub struct Config {
     pub shell: ShellConfig,
     pub tools: HashMap<String, ToolConfig>,
 }
-
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ModelConfig {
@@ -66,21 +62,17 @@ impl Default for ProviderConfig {
     }
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[derive(Default)]
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
 pub struct CapabilityConfig {
     pub capability_id: String,
     pub enabled: bool,
     pub config: HashMap<String, String>,
 }
 
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[derive(Default)]
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
 pub struct RoutingConfig {
     pub model_routes: HashMap<String, Vec<ProviderRoute>>,
 }
-
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ProviderRoute {
@@ -130,23 +122,24 @@ impl Config {
         let val_res = std::env::var("GRANITE_CLI_HOME");
 
         if let Ok(val) = val_res
-            && !val.is_empty() {
-                let path = PathBuf::from(&val);
+            && !val.is_empty()
+        {
+            let path = PathBuf::from(&val);
 
-                let has_valid_parent = path.parent().is_none_or(|p| p.exists());
+            let has_valid_parent = path.parent().is_none_or(|p| p.exists());
 
-                let valid_dir =
-                    (!path.exists() && has_valid_parent) || (path.exists() && path.is_dir());
+            let valid_dir =
+                (!path.exists() && has_valid_parent) || (path.exists() && path.is_dir());
 
-                if !valid_dir {
-                    anyhow::bail!(
-                        "Invalid GRANITE_CLI_HOME: '{}' parent does not exist or is not a directory.",
-                        val
-                    );
-                }
-
-                return Ok(path);
+            if !valid_dir {
+                anyhow::bail!(
+                    "Invalid GRANITE_CLI_HOME: '{}' parent does not exist or is not a directory.",
+                    val
+                );
             }
+
+            return Ok(path);
+        }
 
         let default_dir = dirs::config_dir().ok_or_else(|| {
             anyhow::Error::msg("Could not determine system configuration directory")

--- a/src/config/shell.rs
+++ b/src/config/shell.rs
@@ -123,7 +123,10 @@ mod tests {
     fn test_detect_shell_returns_name() {
         let result = detect_shell();
         assert!(!result.0.is_empty());
-        assert!(matches!(result.0.as_str(), "bash" | "zsh" | "fish" | "unknown"));
+        assert!(matches!(
+            result.0.as_str(),
+            "bash" | "zsh" | "fish" | "unknown"
+        ));
     }
 
     #[test]

--- a/src/config/shell.rs
+++ b/src/config/shell.rs
@@ -34,7 +34,7 @@ pub fn detect_shell() -> (String, PathBuf, String) {
         ),
         _ => (
             shell_name.clone(),
-            PathBuf::from(format!("/etc/shell_exports")),
+            PathBuf::from("/etc/shell_exports".to_string()),
             "export {VAR}=\"{VALUE}\"".to_string(),
         ),
     }
@@ -111,7 +111,7 @@ fn home_dir() -> Option<PathBuf> {
 fn config_home_dir() -> Option<PathBuf> {
     std::env::var("XDG_CONFIG_HOME")
         .ok()
-        .map(|p| PathBuf::from(p))
+        .map(PathBuf::from)
         .or_else(|| home_dir().map(|h| h.join(".config")))
 }
 

--- a/src/dependency/mod.rs
+++ b/src/dependency/mod.rs
@@ -205,7 +205,10 @@ mod tests {
 
     impl Configured<dyn Paint> for PaintShop {
         fn instances(&self) -> Vec<(String, &(dyn Paint + 'static))> {
-            self.cans.iter().map(|(id, p)| (id.clone(), p.as_ref())).collect()
+            self.cans
+                .iter()
+                .map(|(id, p)| (id.clone(), p.as_ref()))
+                .collect()
         }
         fn catalog(&self) -> HashMap<&'static str, PaintMetadata> {
             self.recipes
@@ -253,7 +256,8 @@ mod tests {
     #[test]
     fn resolution_includes_configurable_types_alongside_instances() {
         let mut shop = empty_shop();
-        shop.cans.push(("can-1".to_string(), Box::new(MixedPaint("blue"))));
+        shop.cans
+            .push(("can-1".to_string(), Box::new(MixedPaint("blue"))));
         shop.recipes.insert(
             "cyan-mix",
             PaintMetadata {
@@ -278,7 +282,8 @@ mod tests {
     #[test]
     fn resolution_is_configurable_only_when_no_instance_matches() {
         let mut shop = empty_shop();
-        shop.cans.push(("can-1".to_string(), Box::new(MixedPaint("red"))));
+        shop.cans
+            .push(("can-1".to_string(), Box::new(MixedPaint("red"))));
         shop.recipes.insert(
             "cyan-mix",
             PaintMetadata {
@@ -301,7 +306,8 @@ mod tests {
                 claimed_colors: vec!["blue", "green"],
             },
         );
-        shop.recipe_schemas.insert("cyan-mix", schemars::schema_for!(MixRatio));
+        shop.recipe_schemas
+            .insert("cyan-mix", schemars::schema_for!(MixRatio));
 
         let resolution = resolve(&WantsColor("blue"), &shop);
         assert_eq!(resolution.configurable_types, vec!["cyan-mix"]);

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,9 +1,9 @@
-pub mod config;
-pub mod registry;
-pub mod dependency;
-pub mod models;
 pub mod capabilities;
 pub mod commands;
+pub mod config;
+pub mod dependency;
+pub mod models;
+pub mod registry;
 pub mod utils;
 // TODO: Re-enable once rewritten -- pub mod di;
 pub mod providers;
@@ -13,7 +13,7 @@ use clap::{Parser, Subcommand};
 
 // Local
 use commands::{CapabilityCommands, HardwareCommands, ModelCommands, ProviderCommands};
-use utils::ui::{run_interactive_tui, Ui, UI_REGISTRY};
+use utils::ui::{UI_REGISTRY, Ui, run_interactive_tui};
 
 // Hoist paste macro for use in our own macros
 extern crate paste;
@@ -237,7 +237,10 @@ fn construct_ui(output: &str) -> Box<dyn Ui> {
     UI_REGISTRY
         .construct(output, &serde_json::json!({}))
         .unwrap_or_else(|_| {
-            eprintln!("Unknown output format '{}'. Valid: terminal, plain, json, markdown", output);
+            eprintln!(
+                "Unknown output format '{}'. Valid: terminal, plain, json, markdown",
+                output
+            );
             std::process::exit(1);
         })
 }
@@ -258,17 +261,20 @@ async fn main() {
     let result: Result<(), ()> = match cli.command {
         Some(Commands::Model(wrapper)) => {
             let mut ctx = construct_context(&wrapper.output);
-            run_model_command(&mut ctx, wrapper.subcommand).await
+            run_model_command(&mut ctx, wrapper.subcommand)
+                .await
                 .map_err(|e| ctx.ui.error(&e.to_string()))
         }
         Some(Commands::Capability(wrapper)) => {
             let mut ctx = construct_context(&wrapper.output);
-            run_capability_command(&mut ctx, wrapper.subcommand).await
+            run_capability_command(&mut ctx, wrapper.subcommand)
+                .await
                 .map_err(|e| ctx.ui.error(&e.to_string()))
         }
         Some(Commands::Provider(wrapper)) => {
             let mut ctx = construct_context(&wrapper.output);
-            run_provider_command(&mut ctx, wrapper.subcommand).await
+            run_provider_command(&mut ctx, wrapper.subcommand)
+                .await
                 .map_err(|e| ctx.ui.error(&e.to_string()))
         }
         Some(Commands::Hardware) => {
@@ -277,7 +283,8 @@ async fn main() {
         }
         Some(Commands::Configure(wrapper)) => {
             let ui = construct_ui(&wrapper.output);
-            run_configure(&*ui, wrapper.args).await
+            run_configure(&*ui, wrapper.args)
+                .await
                 .map_err(|e| ui.error(&e.to_string()))
         }
         Some(Commands::Launch(wrapper)) => {
@@ -289,7 +296,8 @@ async fn main() {
             // `ctx` (and its `ui`) is consumed by value into the TUI `App`
             // before any error can occur, so it can't be used to report one.
             let ctx = construct_context("terminal");
-            run_interactive_tui(ctx).await
+            run_interactive_tui(ctx)
+                .await
                 .map_err(|e| eprintln!("Error: {}", e))
         }
     };
@@ -308,7 +316,10 @@ async fn run_model_command(ctx: &mut AppContext, subcmd: ModelSubcommands) -> an
                 Some("speech") => Some(models::ModelType::Speech),
                 Some("embedding") => Some(models::ModelType::Embedding),
                 Some(t) => {
-                    anyhow::bail!("Unknown model type: {}. Valid types: text, vision, speech, embedding", t);
+                    anyhow::bail!(
+                        "Unknown model type: {}. Valid types: text, vision, speech, embedding",
+                        t
+                    );
                 }
                 None => None,
             };
@@ -321,21 +332,31 @@ async fn run_model_command(ctx: &mut AppContext, subcmd: ModelSubcommands) -> an
                 Some("speech") => Some(models::ModelType::Speech),
                 Some("embedding") => Some(models::ModelType::Embedding),
                 Some(t) => {
-                    anyhow::bail!("Unknown model type: {}. Valid types: text, vision, speech, embedding", t);
+                    anyhow::bail!(
+                        "Unknown model type: {}. Valid types: text, vision, speech, embedding",
+                        t
+                    );
                 }
                 None => None,
             };
             ModelCommands::list(ctx, filter)
         }
         ModelSubcommands::Search { query } => ModelCommands::search(ctx, &query),
-        ModelSubcommands::Recommend { r#type, providers, wide } => {
+        ModelSubcommands::Recommend {
+            r#type,
+            providers,
+            wide,
+        } => {
             let filter = match r#type.as_deref() {
                 Some("text") => Some(models::ModelType::Text),
                 Some("vision") => Some(models::ModelType::Vision),
                 Some("speech") => Some(models::ModelType::Speech),
                 Some("embedding") => Some(models::ModelType::Embedding),
                 Some(t) => {
-                    anyhow::bail!("Unknown model type: {}. Valid types: text, vision, speech, embedding", t);
+                    anyhow::bail!(
+                        "Unknown model type: {}. Valid types: text, vision, speech, embedding",
+                        t
+                    );
                 }
                 None => None,
             };
@@ -347,23 +368,36 @@ async fn run_model_command(ctx: &mut AppContext, subcmd: ModelSubcommands) -> an
     }
 }
 
-async fn run_capability_command(ctx: &mut AppContext, subcmd: CapabilitySubcommands) -> anyhow::Result<()> {
+async fn run_capability_command(
+    ctx: &mut AppContext,
+    subcmd: CapabilitySubcommands,
+) -> anyhow::Result<()> {
     match subcmd {
         CapabilitySubcommands::Catalog => CapabilityCommands::catalog(ctx),
         CapabilitySubcommands::List => CapabilityCommands::list(ctx),
-        CapabilitySubcommands::Info { capability_id } => CapabilityCommands::info(ctx, &capability_id),
-        CapabilitySubcommands::Setup { capability_id } => CapabilityCommands::setup(ctx, &capability_id).await,
+        CapabilitySubcommands::Info { capability_id } => {
+            CapabilityCommands::info(ctx, &capability_id)
+        }
+        CapabilitySubcommands::Setup { capability_id } => {
+            CapabilityCommands::setup(ctx, &capability_id).await
+        }
     }
 }
 
-async fn run_provider_command(ctx: &mut AppContext, subcmd: ProviderSubcommands) -> anyhow::Result<()> {
+async fn run_provider_command(
+    ctx: &mut AppContext,
+    subcmd: ProviderSubcommands,
+) -> anyhow::Result<()> {
     match subcmd {
         ProviderSubcommands::Catalog => ProviderCommands::catalog(ctx),
         ProviderSubcommands::List => ProviderCommands::list(ctx),
-        ProviderSubcommands::Setup { provider_type, instance_id } => {
-            ProviderCommands::setup(ctx, &provider_type, instance_id.as_deref()).await
+        ProviderSubcommands::Setup {
+            provider_type,
+            instance_id,
+        } => ProviderCommands::setup(ctx, &provider_type, instance_id.as_deref()).await,
+        ProviderSubcommands::Health { provider_id } => {
+            ProviderCommands::health(ctx, provider_id.as_deref()).await
         }
-        ProviderSubcommands::Health { provider_id } => ProviderCommands::health(ctx, provider_id.as_deref()).await,
     }
 }
 

--- a/src/models/base.rs
+++ b/src/models/base.rs
@@ -12,9 +12,7 @@ use crate::utils::hardware::HardwareProfile;
 /// Functional capabilities that models can provide
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, schemars::JsonSchema)]
 pub enum ModelFunction {
-
     /*-- Chat Functions --*/
-
     /// Text-based conversational interaction
     Chat,
     /// Tool inputs and invocations
@@ -27,12 +25,10 @@ pub enum ModelFunction {
     Guardian,
 
     /*-- Embedding Functions --*/
-
     /// Vector representation generation for text
     Embeddings,
 
     /*-- Audio Functions --*/
-
     /// Audio-to-text transcription
     Transcription,
     /// Audio translation
@@ -108,7 +104,6 @@ pub struct ModelArchitecture {
 /// Core trait for model implementations.
 /// All models must implement this trait along with ConfigConstructable.
 pub trait Model: ConfigConstructable {
-
     /// Get the model family name
     fn family(&self) -> &str;
 
@@ -268,7 +263,10 @@ mod format_size_tests {
             num_attention_heads: 32,
             num_key_value_heads: 8,
             head_dim: 128,
-            layer_types: vec![LayerTypeCount { kind: LayerKind::FullAttention, count: 32 }],
+            layer_types: vec![LayerTypeCount {
+                kind: LayerKind::FullAttention,
+                count: 32,
+            }],
         }
     }
 
@@ -330,7 +328,10 @@ mod searchable_tests {
                 num_attention_heads: 32,
                 num_key_value_heads: 8,
                 head_dim: 128,
-                layer_types: vec![LayerTypeCount { kind: LayerKind::FullAttention, count: 32 }],
+                layer_types: vec![LayerTypeCount {
+                    kind: LayerKind::FullAttention,
+                    count: 32,
+                }],
             },
             variants: vec![],
             description: description.map(String::from),
@@ -365,4 +366,3 @@ mod searchable_tests {
         assert!(fields.contains(&"chat"));
     }
 }
-

--- a/src/models/context_fit.rs
+++ b/src/models/context_fit.rs
@@ -20,7 +20,9 @@ impl std::fmt::Display for ContextFit {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             ContextFit::Full => write!(f, "Full"),
-            ContextFit::Partial(max_context) => write!(f, "Partial ({})", format_token_count(*max_context)),
+            ContextFit::Partial(max_context) => {
+                write!(f, "Partial ({})", format_token_count(*max_context))
+            }
             ContextFit::None => write!(f, "None"),
         }
     }
@@ -79,8 +81,13 @@ pub(crate) fn estimate(
         return ContextFit::Full;
     }
 
-    let max_context_tokens =
-        max_context_fitting(architecture, variant, native_dtype, usable_gb, context_length);
+    let max_context_tokens = max_context_fitting(
+        architecture,
+        variant,
+        native_dtype,
+        usable_gb,
+        context_length,
+    );
     let min_useful_context = ((context_length as f64 * MIN_USABLE_CONTEXT_FRACTION) as u64)
         .max(MIN_USABLE_CONTEXT_TOKENS_FLOOR)
         .min(context_length);
@@ -103,15 +110,22 @@ fn required_gb(
 ) -> f64 {
     let attn_bytes_per_elem = cache_bytes_per_elem_attention(&variant.format, native_dtype);
     let recurrent_bytes_per_elem = cache_bytes_per_elem_recurrent(&variant.format, native_dtype);
-    let kv_bytes_per_token =
-        2.0 * architecture.num_key_value_heads as f64 * architecture.head_dim as f64 * attn_bytes_per_elem;
+    let kv_bytes_per_token = 2.0
+        * architecture.num_key_value_heads as f64
+        * architecture.head_dim as f64
+        * attn_bytes_per_elem;
 
     let layers_bytes: f64 = architecture
         .layer_types
         .iter()
         .map(|ltc| {
             ltc.count as f64
-                * layer_kind_bytes(&ltc.kind, context_tokens, kv_bytes_per_token, recurrent_bytes_per_elem)
+                * layer_kind_bytes(
+                    &ltc.kind,
+                    context_tokens,
+                    kv_bytes_per_token,
+                    recurrent_bytes_per_elem,
+                )
         })
         .sum();
 
@@ -137,8 +151,8 @@ fn layer_kind_bytes(
             // Fixed-size state, independent of context length: conv-state +
             // SSM-state element counts, per the Mamba2/SSM cache-sizing
             // formula (see llama.cpp's recurrent-state handling).
-            let conv_state_elems =
-                shape.d_conv.saturating_sub(1) * (shape.d_inner + 2 * shape.n_groups * shape.d_state);
+            let conv_state_elems = shape.d_conv.saturating_sub(1)
+                * (shape.d_inner + 2 * shape.n_groups * shape.d_state);
             let ssm_state_elems = shape.d_state * shape.d_inner;
             (conv_state_elems + ssm_state_elems) as f64 * recurrent_bytes_per_elem
         }
@@ -244,7 +258,10 @@ mod tests {
             num_attention_heads: 32,
             num_key_value_heads: 8,
             head_dim: 128,
-            layer_types: vec![LayerTypeCount { kind: LayerKind::FullAttention, count: 40 }],
+            layer_types: vec![LayerTypeCount {
+                kind: LayerKind::FullAttention,
+                count: 40,
+            }],
         }
     }
 
@@ -257,7 +274,10 @@ mod tests {
             num_key_value_heads: 4,
             head_dim: 128,
             layer_types: vec![
-                LayerTypeCount { kind: LayerKind::FullAttention, count: 4 },
+                LayerTypeCount {
+                    kind: LayerKind::FullAttention,
+                    count: 4,
+                },
                 LayerTypeCount {
                     kind: LayerKind::Recurrent(MambaShape {
                         d_conv: 4,
@@ -280,7 +300,10 @@ mod tests {
             num_key_value_heads: 4,
             head_dim: 128,
             layer_types: vec![
-                LayerTypeCount { kind: LayerKind::FullAttention, count: 7 },
+                LayerTypeCount {
+                    kind: LayerKind::FullAttention,
+                    count: 7,
+                },
                 LayerTypeCount {
                     kind: LayerKind::SlidingAttention { window: 128 },
                     count: 17,
@@ -294,14 +317,24 @@ mod tests {
         // conv_state = (4-1) * (3072 + 2*1*128) = 3 * 3328 = 9984
         // ssm_state  = 128 * 3072 = 393216
         // total elems = 403200, * 4 bytes (F32) = 1612800 bytes
-        let shape = MambaShape { d_conv: 4, d_state: 128, d_inner: 3072, n_groups: 1 };
+        let shape = MambaShape {
+            d_conv: 4,
+            d_state: 128,
+            d_inner: 3072,
+            n_groups: 1,
+        };
         let bytes = layer_kind_bytes(&LayerKind::Recurrent(shape), 100_000, 999.0, 4.0);
         assert_eq!(bytes, 1_612_800.0);
     }
 
     #[test]
     fn recurrent_layer_bytes_ignore_context_length() {
-        let shape = MambaShape { d_conv: 4, d_state: 128, d_inner: 3072, n_groups: 1 };
+        let shape = MambaShape {
+            d_conv: 4,
+            d_state: 128,
+            d_inner: 3072,
+            n_groups: 1,
+        };
         let short = layer_kind_bytes(&LayerKind::Recurrent(shape.clone()), 100, 999.0, 4.0);
         let long = layer_kind_bytes(&LayerKind::Recurrent(shape), 1_000_000, 999.0, 4.0);
         assert_eq!(short, long);
@@ -309,10 +342,16 @@ mod tests {
 
     #[test]
     fn sliding_attention_caps_at_window() {
-        let below_window = layer_kind_bytes(&LayerKind::SlidingAttention { window: 128 }, 64, 10.0, 4.0);
-        let at_window = layer_kind_bytes(&LayerKind::SlidingAttention { window: 128 }, 128, 10.0, 4.0);
-        let above_window =
-            layer_kind_bytes(&LayerKind::SlidingAttention { window: 128 }, 1_000_000, 10.0, 4.0);
+        let below_window =
+            layer_kind_bytes(&LayerKind::SlidingAttention { window: 128 }, 64, 10.0, 4.0);
+        let at_window =
+            layer_kind_bytes(&LayerKind::SlidingAttention { window: 128 }, 128, 10.0, 4.0);
+        let above_window = layer_kind_bytes(
+            &LayerKind::SlidingAttention { window: 128 },
+            1_000_000,
+            10.0,
+            4.0,
+        );
         assert_eq!(below_window, 640.0);
         assert_eq!(at_window, 1280.0);
         assert_eq!(above_window, 1280.0);
@@ -341,14 +380,26 @@ mod tests {
     #[test]
     fn ample_vram_yields_full_fit() {
         let hardware = hardware_with_vram(256.0);
-        let fit = estimate(131_072, &dense_architecture(), "bfloat16", &variant("GGUF", 5.0), &hardware);
+        let fit = estimate(
+            131_072,
+            &dense_architecture(),
+            "bfloat16",
+            &variant("GGUF", 5.0),
+            &hardware,
+        );
         assert_eq!(fit, ContextFit::Full);
     }
 
     #[test]
     fn insufficient_vram_for_weights_alone_yields_none() {
         let hardware = hardware_with_vram(4.0);
-        let fit = estimate(131_072, &dense_architecture(), "bfloat16", &variant("GGUF", 5.0), &hardware);
+        let fit = estimate(
+            131_072,
+            &dense_architecture(),
+            "bfloat16",
+            &variant("GGUF", 5.0),
+            &hardware,
+        );
         assert_eq!(fit, ContextFit::None);
     }
 
@@ -357,14 +408,26 @@ mod tests {
         // Enough for weights + a meaningfully reduced dense KV cache, but
         // not the full 131072-token context.
         let hardware = hardware_with_vram(22.5);
-        let fit = estimate(131_072, &dense_architecture(), "bfloat16", &variant("GGUF", 5.0), &hardware);
+        let fit = estimate(
+            131_072,
+            &dense_architecture(),
+            "bfloat16",
+            &variant("GGUF", 5.0),
+            &hardware,
+        );
         assert!(matches!(fit, ContextFit::Partial(_)));
     }
 
     #[test]
     fn partial_fit_carries_max_context_as_power_of_two() {
         let hardware = hardware_with_vram(22.5);
-        let fit = estimate(131_072, &dense_architecture(), "bfloat16", &variant("GGUF", 5.0), &hardware);
+        let fit = estimate(
+            131_072,
+            &dense_architecture(),
+            "bfloat16",
+            &variant("GGUF", 5.0),
+            &hardware,
+        );
         match fit {
             ContextFit::Partial(max_context) => {
                 assert!(max_context.is_power_of_two());
@@ -387,8 +450,20 @@ mod tests {
     fn hybrid_model_fits_full_context_where_dense_equivalent_would_not() {
         let hardware = hardware_with_vram(6.0);
         let variant = variant("GGUF", 2.0);
-        let dense_fit = estimate(131_072, &dense_architecture(), "bfloat16", &variant, &hardware);
-        let hybrid_fit = estimate(131_072, &hybrid_architecture(), "bfloat16", &variant, &hardware);
+        let dense_fit = estimate(
+            131_072,
+            &dense_architecture(),
+            "bfloat16",
+            &variant,
+            &hardware,
+        );
+        let hybrid_fit = estimate(
+            131_072,
+            &hybrid_architecture(),
+            "bfloat16",
+            &variant,
+            &hardware,
+        );
         assert_ne!(dense_fit, ContextFit::Full);
         assert_eq!(hybrid_fit, ContextFit::Full);
     }
@@ -397,8 +472,20 @@ mod tests {
     fn swa_model_fits_full_context_where_dense_equivalent_would_not() {
         let hardware = hardware_with_vram(7.5);
         let variant = variant("GGUF", 2.0);
-        let dense_fit = estimate(131_072, &dense_architecture(), "bfloat16", &variant, &hardware);
-        let swa_fit = estimate(131_072, &swa_architecture(), "bfloat16", &variant, &hardware);
+        let dense_fit = estimate(
+            131_072,
+            &dense_architecture(),
+            "bfloat16",
+            &variant,
+            &hardware,
+        );
+        let swa_fit = estimate(
+            131_072,
+            &swa_architecture(),
+            "bfloat16",
+            &variant,
+            &hardware,
+        );
         assert_ne!(dense_fit, ContextFit::Full);
         assert_eq!(swa_fit, ContextFit::Full);
     }
@@ -406,7 +493,13 @@ mod tests {
     #[test]
     fn zero_context_length_yields_none() {
         let hardware = hardware_with_vram(256.0);
-        let fit = estimate(0, &dense_architecture(), "bfloat16", &variant("GGUF", 5.0), &hardware);
+        let fit = estimate(
+            0,
+            &dense_architecture(),
+            "bfloat16",
+            &variant("GGUF", 5.0),
+            &hardware,
+        );
         assert_eq!(fit, ContextFit::None);
     }
 
@@ -421,7 +514,13 @@ mod tests {
             head_dim: 0,
             layer_types: vec![],
         };
-        let fit = estimate(4096, &empty_architecture, "bfloat16", &variant("GGUF", 5.0), &hardware);
+        let fit = estimate(
+            4096,
+            &empty_architecture,
+            "bfloat16",
+            &variant("GGUF", 5.0),
+            &hardware,
+        );
         assert_eq!(fit, ContextFit::None);
     }
 
@@ -431,7 +530,10 @@ mod tests {
         let variant = variant("safetensors", 16.0);
         let bf16_gb = required_gb(&architecture, &variant, "bfloat16", 100_000);
         let fp32_gb = required_gb(&architecture, &variant, "float32", 100_000);
-        assert!(fp32_gb > bf16_gb, "float32 KV cache should require more memory than bfloat16");
+        assert!(
+            fp32_gb > bf16_gb,
+            "float32 KV cache should require more memory than bfloat16"
+        );
     }
 
     #[test]
@@ -439,7 +541,8 @@ mod tests {
         let architecture = dense_architecture();
         let variant = variant("GGUF", 5.0);
         let usable_gb = 8.0;
-        let max_tokens = max_context_fitting(&architecture, &variant, "bfloat16", usable_gb, 131_072);
+        let max_tokens =
+            max_context_fitting(&architecture, &variant, "bfloat16", usable_gb, 131_072);
         assert!(max_tokens <= 131_072);
         assert!(required_gb(&architecture, &variant, "bfloat16", max_tokens) <= usable_gb);
         if max_tokens < 131_072 {

--- a/src/models/huggingface.rs
+++ b/src/models/huggingface.rs
@@ -39,13 +39,18 @@ mod tests {
 
     #[test]
     fn hf_repo_id_from_bare_repo() {
-        assert_eq!(hf_repo_id("ibm-granite/granite-speech-4.1-2b"), Some("ibm-granite/granite-speech-4.1-2b"));
+        assert_eq!(
+            hf_repo_id("ibm-granite/granite-speech-4.1-2b"),
+            Some("ibm-granite/granite-speech-4.1-2b")
+        );
     }
 
     #[test]
     fn hf_repo_id_from_blob_url() {
         assert_eq!(
-            hf_repo_id("https://huggingface.co/ibm-granite/granite-speech-4.1-2b-GGUF/blob/main/granite-speech-4.1-2b-Q4_K_M.gguf"),
+            hf_repo_id(
+                "https://huggingface.co/ibm-granite/granite-speech-4.1-2b-GGUF/blob/main/granite-speech-4.1-2b-Q4_K_M.gguf"
+            ),
             Some("ibm-granite/granite-speech-4.1-2b-GGUF")
         );
     }
@@ -58,7 +63,9 @@ mod tests {
     #[test]
     fn hf_blob_filename_from_blob_url() {
         assert_eq!(
-            hf_blob_filename("https://huggingface.co/ibm-granite/granite-speech-4.1-2b-GGUF/blob/main/granite-speech-4.1-2b-Q4_K_M.gguf"),
+            hf_blob_filename(
+                "https://huggingface.co/ibm-granite/granite-speech-4.1-2b-GGUF/blob/main/granite-speech-4.1-2b-Q4_K_M.gguf"
+            ),
             Some("granite-speech-4.1-2b-Q4_K_M.gguf")
         );
     }

--- a/src/models/mod.rs
+++ b/src/models/mod.rs
@@ -33,7 +33,7 @@ mod tests {
     #[test]
     fn test_all_models_registered() {
         let models = MODEL_REGISTRY.entries();
-        assert!(models.len() > 0, "Expected models to be registered");
+        assert!(!models.is_empty(), "Expected models to be registered");
     }
 
     #[test]
@@ -55,7 +55,7 @@ mod tests {
     fn test_model_variants() {
         let model = MODEL_REGISTRY.get("granite-3.1-8b-instruct").unwrap();
         assert!(
-            model.variants.len() > 0,
+            !model.variants.is_empty(),
             "granite-3.1-8b-instruct should have variants"
         );
 

--- a/src/models/mod.rs
+++ b/src/models/mod.rs
@@ -39,7 +39,10 @@ mod tests {
     #[test]
     fn test_get_specific_model() {
         let model = MODEL_REGISTRY.get("granite-3.1-8b-instruct");
-        assert!(model.is_some(), "granite-3.1-8b-instruct should be registered");
+        assert!(
+            model.is_some(),
+            "granite-3.1-8b-instruct should be registered"
+        );
 
         let metadata = model.unwrap();
         assert_eq!(metadata.family, "Granite 3.1");
@@ -51,7 +54,10 @@ mod tests {
     #[test]
     fn test_model_variants() {
         let model = MODEL_REGISTRY.get("granite-3.1-8b-instruct").unwrap();
-        assert!(model.variants.len() > 0, "granite-3.1-8b-instruct should have variants");
+        assert!(
+            model.variants.len() > 0,
+            "granite-3.1-8b-instruct should have variants"
+        );
 
         // Check first variant
         let variant = &model.variants[0];
@@ -84,14 +90,34 @@ mod tests {
     #[test]
     fn test_model_supported_functions() {
         let text_model = MODEL_REGISTRY.get("granite-3.1-8b-instruct").unwrap();
-        assert!(text_model.supported_functions.contains(&ModelFunction::Chat));
+        assert!(
+            text_model
+                .supported_functions
+                .contains(&ModelFunction::Chat)
+        );
 
         let vision_model = MODEL_REGISTRY.get("granite-vision-3.3-2b").unwrap();
-        assert!(vision_model.supported_functions.contains(&ModelFunction::Chat));
-        assert!(vision_model.supported_functions.contains(&ModelFunction::ImageUnderstanding));
+        assert!(
+            vision_model
+                .supported_functions
+                .contains(&ModelFunction::Chat)
+        );
+        assert!(
+            vision_model
+                .supported_functions
+                .contains(&ModelFunction::ImageUnderstanding)
+        );
 
         let speech_model = MODEL_REGISTRY.get("granite-speech-4.1-2b").unwrap();
-        assert!(speech_model.supported_functions.contains(&ModelFunction::Chat));
-        assert!(speech_model.supported_functions.contains(&ModelFunction::Transcription));
+        assert!(
+            speech_model
+                .supported_functions
+                .contains(&ModelFunction::Chat)
+        );
+        assert!(
+            speech_model
+                .supported_functions
+                .contains(&ModelFunction::Transcription)
+        );
     }
 }

--- a/src/providers/base.rs
+++ b/src/providers/base.rs
@@ -55,8 +55,7 @@ impl ApiEndpoint {
             | ApiEndpoint::OpenAIEmbeddings
             | ApiEndpoint::OpenAIAudioTranscription => ApiType::OpenAI,
 
-            ApiEndpoint::OllamaChat
-            | ApiEndpoint::OllamaEmbeddings => ApiType::Ollama,
+            ApiEndpoint::OllamaChat | ApiEndpoint::OllamaEmbeddings => ApiType::Ollama,
 
             ApiEndpoint::AnthropicMessages => ApiType::Anthropic,
         }
@@ -77,20 +76,19 @@ impl ApiEndpoint {
     /// Returns the model functions this endpoint provides
     pub fn provides_functions(&self) -> Vec<ModelFunction> {
         match self {
-            ApiEndpoint::OpenAIChat
-            | ApiEndpoint::OllamaChat
-            | ApiEndpoint::AnthropicMessages => vec![
-                ModelFunction::Chat,
-                ModelFunction::ToolCalling,
-                ModelFunction::Thinking,
-                ModelFunction::ImageUnderstanding,
-                ModelFunction::Guardian,
-            ],
+            ApiEndpoint::OpenAIChat | ApiEndpoint::OllamaChat | ApiEndpoint::AnthropicMessages => {
+                vec![
+                    ModelFunction::Chat,
+                    ModelFunction::ToolCalling,
+                    ModelFunction::Thinking,
+                    ModelFunction::ImageUnderstanding,
+                    ModelFunction::Guardian,
+                ]
+            }
 
-            ApiEndpoint::OpenAIEmbeddings
-            | ApiEndpoint::OllamaEmbeddings => vec![
-                ModelFunction::Embeddings,
-            ],
+            ApiEndpoint::OpenAIEmbeddings | ApiEndpoint::OllamaEmbeddings => {
+                vec![ModelFunction::Embeddings]
+            }
 
             ApiEndpoint::OpenAIAudioTranscription => vec![
                 ModelFunction::Transcription,
@@ -104,7 +102,9 @@ impl ApiEndpoint {
 
 impl std::fmt::Display for ApiEndpoint {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{} {} ({})",
+        write!(
+            f,
+            "{} {} ({})",
             self.api_type(),
             self.path(),
             self.provides_functions()
@@ -248,7 +248,8 @@ pub async fn http_health_check(
                 Ok(HealthStatus {
                     healthy: false,
                     latency,
-                    error: Some(format!("HTTP {}: {}",
+                    error: Some(format!(
+                        "HTTP {}: {}",
                         response.status(),
                         response.text().await.unwrap_or_default()
                     )),
@@ -366,7 +367,10 @@ mod tests {
     fn test_api_endpoint_paths() {
         assert_eq!(ApiEndpoint::OpenAIChat.path(), "/v1/chat/completions");
         assert_eq!(ApiEndpoint::OpenAIEmbeddings.path(), "/v1/embeddings");
-        assert_eq!(ApiEndpoint::OpenAIAudioTranscription.path(), "/v1/audio/transcriptions");
+        assert_eq!(
+            ApiEndpoint::OpenAIAudioTranscription.path(),
+            "/v1/audio/transcriptions"
+        );
         assert_eq!(ApiEndpoint::OllamaChat.path(), "/api/chat");
         assert_eq!(ApiEndpoint::OllamaEmbeddings.path(), "/api/embeddings");
         assert_eq!(ApiEndpoint::AnthropicMessages.path(), "/v1/messages");
@@ -374,9 +378,18 @@ mod tests {
 
     #[test]
     fn test_api_endpoint_types() {
-        assert!(matches!(ApiEndpoint::OpenAIChat.api_type(), ApiType::OpenAI));
-        assert!(matches!(ApiEndpoint::OllamaChat.api_type(), ApiType::Ollama));
-        assert!(matches!(ApiEndpoint::AnthropicMessages.api_type(), ApiType::Anthropic));
+        assert!(matches!(
+            ApiEndpoint::OpenAIChat.api_type(),
+            ApiType::OpenAI
+        ));
+        assert!(matches!(
+            ApiEndpoint::OllamaChat.api_type(),
+            ApiType::Ollama
+        ));
+        assert!(matches!(
+            ApiEndpoint::AnthropicMessages.api_type(),
+            ApiType::Anthropic
+        ));
     }
 
     #[test]
@@ -395,9 +408,12 @@ mod tests {
 
     #[test]
     fn test_model_function_display() {
-use crate::models::ModelFunction;
+        use crate::models::ModelFunction;
         assert_eq!(ModelFunction::Chat.to_string(), "Chat");
-        assert_eq!(ModelFunction::ImageUnderstanding.to_string(), "Image Understanding");
+        assert_eq!(
+            ModelFunction::ImageUnderstanding.to_string(),
+            "Image Understanding"
+        );
         assert_eq!(ModelFunction::Transcription.to_string(), "Transcription");
     }
 }

--- a/src/providers/llamacpp.rs
+++ b/src/providers/llamacpp.rs
@@ -1,13 +1,12 @@
 use crate::models::huggingface::hf_repo_id;
 use crate::models::{ModelFunction, ModelMetadata, ModelVariant};
 use crate::providers::base::{
-    http_health_check, ApiEndpoint, ApiType, AuthType, HealthStatus,
-    ModelFormat, Provider, ProviderError, ProviderMetadata, ProviderType,
-    HasProviderMetadata,
+    ApiEndpoint, ApiType, AuthType, HasProviderMetadata, HealthStatus, ModelFormat, Provider,
+    ProviderError, ProviderMetadata, ProviderType, http_health_check,
 };
 use crate::registry::{ConfigConstructable, Secret};
-use crate::utils::ui::base::PullHandle;
 use crate::utils::ui::Ui;
+use crate::utils::ui::base::PullHandle;
 use async_trait::async_trait;
 use futures_util::StreamExt;
 use serde::{Deserialize, Serialize};
@@ -116,14 +115,15 @@ impl LlamaCppProvider {
     fn default_function_endpoints() -> HashMap<ModelFunction, Vec<ApiEndpoint>> {
         let mut map = HashMap::new();
 
-        map.insert(ModelFunction::Chat, vec![
-            ApiEndpoint::OpenAIChat,
-            ApiEndpoint::AnthropicMessages,
-        ]);
+        map.insert(
+            ModelFunction::Chat,
+            vec![ApiEndpoint::OpenAIChat, ApiEndpoint::AnthropicMessages],
+        );
 
-        map.insert(ModelFunction::Embeddings, vec![
-            ApiEndpoint::OpenAIEmbeddings,
-        ]);
+        map.insert(
+            ModelFunction::Embeddings,
+            vec![ApiEndpoint::OpenAIEmbeddings],
+        );
 
         map
     }
@@ -164,7 +164,9 @@ impl LlamaCppProvider {
             while let Some(pos) = find_double_newline(&buf) {
                 let frame_bytes: Vec<u8> = buf.drain(..pos + 2).collect();
                 let frame_text = String::from_utf8_lossy(&frame_bytes);
-                let Some(json_str) = frame_text.trim().strip_prefix("data:") else { continue };
+                let Some(json_str) = frame_text.trim().strip_prefix("data:") else {
+                    continue;
+                };
                 let json_str = json_str.trim();
                 if json_str.is_empty() {
                     continue;
@@ -179,14 +181,21 @@ impl LlamaCppProvider {
 
                 match frame.event.as_str() {
                     "download_progress" => {
-                        if let Some(progress) = frame.data.get("progress").and_then(|p| p.as_object()) {
+                        if let Some(progress) =
+                            frame.data.get("progress").and_then(|p| p.as_object())
+                        {
                             let mut done_sum = 0u64;
                             let mut total_sum = 0u64;
                             for entry in progress.values() {
                                 done_sum += entry.get("done").and_then(|v| v.as_u64()).unwrap_or(0);
-                                total_sum += entry.get("total").and_then(|v| v.as_u64()).unwrap_or(0);
+                                total_sum +=
+                                    entry.get("total").and_then(|v| v.as_u64()).unwrap_or(0);
                             }
-                            ui.pull_progress(handle, done_sum, if total_sum > 0 { Some(total_sum) } else { None });
+                            ui.pull_progress(
+                                handle,
+                                done_sum,
+                                if total_sum > 0 { Some(total_sum) } else { None },
+                            );
                         }
                     }
                     "download_finished" => {
@@ -229,7 +238,10 @@ impl LlamaCppProvider {
             if !response.status().is_success() {
                 let status = response.status();
                 let body = response.text().await.unwrap_or_default();
-                let err = format!("llama.cpp models status check failed ({}): {}", status, body);
+                let err = format!(
+                    "llama.cpp models status check failed ({}): {}",
+                    status, body
+                );
                 ui.pull_finish(handle, label, Some(&err));
                 return Err(ProviderError::Other(err));
             }
@@ -253,8 +265,8 @@ impl LlamaCppProvider {
 
 impl ConfigConstructable for LlamaCppProvider {
     fn new(cfg: &serde_json::Value) -> Self {
-        let config: LlamaCppProviderConfig = serde_json::from_value(cfg.clone())
-            .unwrap_or_default();
+        let config: LlamaCppProviderConfig =
+            serde_json::from_value(cfg.clone()).unwrap_or_default();
 
         let client = reqwest::Client::builder()
             .timeout(Duration::from_secs(config.timeout_secs))
@@ -267,7 +279,11 @@ impl ConfigConstructable for LlamaCppProvider {
             .build()
             .expect("Failed to create HTTP client");
 
-        Self { config, client, stream_client }
+        Self {
+            config,
+            client,
+            stream_client,
+        }
     }
 }
 
@@ -299,7 +315,8 @@ impl Provider for LlamaCppProvider {
             &self.config.base_url,
             &self.config.health_check_endpoint,
             self.config.api_key.as_ref(),
-        ).await
+        )
+        .await
     }
 
     async fn pull_model(
@@ -308,15 +325,23 @@ impl Provider for LlamaCppProvider {
         variant: &ModelVariant,
         ui: &dyn Ui,
     ) -> Result<crate::providers::PullResult, ProviderError> {
-        let repo = hf_repo_id(&variant.url).ok_or_else(|| ProviderError::Other(format!(
-            "cannot determine a HuggingFace repo for {} variant {}/{}",
-            model.family, variant.format, variant.precision
-        )))?;
+        let repo = hf_repo_id(&variant.url).ok_or_else(|| {
+            ProviderError::Other(format!(
+                "cannot determine a HuggingFace repo for {} variant {}/{}",
+                model.family, variant.format, variant.precision
+            ))
+        })?;
         let model_ref = format!("{}:{}", repo, variant.precision);
-        let label = format!("{} ({} {})", model.family, variant.format, variant.precision);
+        let label = format!(
+            "{} ({} {})",
+            model.family, variant.format, variant.precision
+        );
 
         let post_url = format!("{}/models", self.config.base_url);
-        let mut request = self.client.post(&post_url).json(&serde_json::json!({ "model": model_ref }));
+        let mut request = self
+            .client
+            .post(&post_url)
+            .json(&serde_json::json!({ "model": model_ref }));
         if let Some(key) = &self.config.api_key {
             request = request.bearer_auth(&key.0);
         }
@@ -329,12 +354,18 @@ impl Provider for LlamaCppProvider {
                 ui.info(&format!("{} is already downloaded.", label));
                 return Ok(crate::providers::PullResult::Success);
             }
-            return Err(ProviderError::Other(format!("llama.cpp model pull request failed ({}): {}", status, body)));
+            return Err(ProviderError::Other(format!(
+                "llama.cpp model pull request failed ({}): {}",
+                status, body
+            )));
         }
 
         let handle = ui.pull_start(&label, None);
 
-        match self.watch_pull_via_sse(&model_ref, handle, &label, ui).await {
+        match self
+            .watch_pull_via_sse(&model_ref, handle, &label, ui)
+            .await
+        {
             Ok(true) => Ok(crate::providers::PullResult::Success),
             Ok(false) => self.watch_pull_via_polling(repo, handle, &label, ui).await,
             Err(e) => Err(e),
@@ -393,7 +424,10 @@ mod tests {
         assert_eq!(meta.name, "llama.cpp");
         assert!(meta.supported_api_types.contains(&ApiType::OpenAI));
         assert!(meta.supported_api_types.contains(&ApiType::Anthropic));
-        assert!(meta.default_function_endpoints.contains_key(&ModelFunction::Chat));
+        assert!(
+            meta.default_function_endpoints
+                .contains_key(&ModelFunction::Chat)
+        );
     }
 
     #[test]

--- a/src/providers/lmstudio.rs
+++ b/src/providers/lmstudio.rs
@@ -149,11 +149,8 @@ impl Provider for LMStudioProvider {
     }
 
     fn can_run_model(&self, variant_format: &str, _variant_precision: &str) -> bool {
-        match variant_format.to_lowercase().as_str() {
-            "gguf" => true,
-            "mlx" => cfg!(target_os = "macos"),
-            _ => false,
-        }
+        let format = variant_format.to_lowercase();
+        matches!(format.as_str(), "gguf" | "mlx" if format != "mlx" || cfg!(target_os = "macos"))
     }
 
     async fn health_check(&self) -> Result<HealthStatus, ProviderError> {

--- a/src/providers/lmstudio.rs
+++ b/src/providers/lmstudio.rs
@@ -1,9 +1,8 @@
 use crate::models::huggingface::hf_repo_id;
 use crate::models::{ModelFunction, ModelMetadata, ModelVariant};
 use crate::providers::base::{
-    http_health_check, ApiEndpoint, ApiType, AuthType, HealthStatus,
-    ModelFormat, Provider, ProviderError, ProviderMetadata, ProviderType,
-    HasProviderMetadata,
+    ApiEndpoint, ApiType, AuthType, HasProviderMetadata, HealthStatus, ModelFormat, Provider,
+    ProviderError, ProviderMetadata, ProviderType, http_health_check,
 };
 use crate::registry::{ConfigConstructable, Secret};
 use crate::utils::ui::Ui;
@@ -92,14 +91,15 @@ impl LMStudioProvider {
     fn default_function_endpoints() -> HashMap<ModelFunction, Vec<ApiEndpoint>> {
         let mut map = HashMap::new();
 
-        map.insert(ModelFunction::Chat, vec![
-            ApiEndpoint::OpenAIChat,
-            ApiEndpoint::AnthropicMessages,
-        ]);
+        map.insert(
+            ModelFunction::Chat,
+            vec![ApiEndpoint::OpenAIChat, ApiEndpoint::AnthropicMessages],
+        );
 
-        map.insert(ModelFunction::Embeddings, vec![
-            ApiEndpoint::OpenAIEmbeddings,
-        ]);
+        map.insert(
+            ModelFunction::Embeddings,
+            vec![ApiEndpoint::OpenAIEmbeddings],
+        );
 
         map
     }
@@ -117,8 +117,8 @@ impl LMStudioProvider {
 
 impl ConfigConstructable for LMStudioProvider {
     fn new(cfg: &serde_json::Value) -> Self {
-        let config: LMStudioProviderConfig = serde_json::from_value(cfg.clone())
-            .unwrap_or_default();
+        let config: LMStudioProviderConfig =
+            serde_json::from_value(cfg.clone()).unwrap_or_default();
 
         let client = reqwest::Client::builder()
             .timeout(Duration::from_secs(config.timeout_secs))
@@ -162,7 +162,8 @@ impl Provider for LMStudioProvider {
             &self.config.base_url,
             &self.config.health_check_endpoint,
             self.config.api_key.as_ref(),
-        ).await
+        )
+        .await
     }
 
     async fn pull_model(
@@ -171,11 +172,16 @@ impl Provider for LMStudioProvider {
         variant: &ModelVariant,
         ui: &dyn Ui,
     ) -> Result<crate::providers::PullResult, ProviderError> {
-        let repo = hf_repo_id(&variant.url).ok_or_else(|| ProviderError::Other(format!(
-            "cannot determine a HuggingFace repo for {} variant {}/{}",
+        let repo = hf_repo_id(&variant.url).ok_or_else(|| {
+            ProviderError::Other(format!(
+                "cannot determine a HuggingFace repo for {} variant {}/{}",
+                model.family, variant.format, variant.precision
+            ))
+        })?;
+        let label = format!(
+            "{} ({} {})",
             model.family, variant.format, variant.precision
-        )))?;
-        let label = format!("{} ({} {})", model.family, variant.format, variant.precision);
+        );
 
         let url = format!("{}/api/v1/models/download", self.config.base_url);
         let mut request = self.client.post(&url).json(&serde_json::json!({
@@ -190,7 +196,10 @@ impl Provider for LMStudioProvider {
         if !response.status().is_success() {
             let status = response.status();
             let body = response.text().await.unwrap_or_default();
-            return Err(ProviderError::Other(format!("LM Studio download request failed ({}): {}", status, body)));
+            return Err(ProviderError::Other(format!(
+                "LM Studio download request failed ({}): {}",
+                status, body
+            )));
         }
         let started: LMStudioDownloadResponse = response.json().await?;
 
@@ -208,7 +217,10 @@ impl Provider for LMStudioProvider {
                 return Ok(crate::providers::PullResult::Success);
             }
         };
-        let status_url = format!("{}/api/v1/models/download/status/{}", self.config.base_url, job_id);
+        let status_url = format!(
+            "{}/api/v1/models/download/status/{}",
+            self.config.base_url, job_id
+        );
 
         loop {
             tokio::time::sleep(Duration::from_secs(1)).await;
@@ -267,7 +279,9 @@ impl HasProviderMetadata for LMStudioProvider {
 
         ProviderMetadata {
             name: "LM Studio".to_string(),
-            description: "User-friendly local inference server with GUI, supporting GGUF and MLX models".to_string(),
+            description:
+                "User-friendly local inference server with GUI, supporting GGUF and MLX models"
+                    .to_string(),
             provider_type: ProviderType::Local,
             default_endpoint: "http://localhost:1234".to_string(),
             supported_api_types: vec![ApiType::OpenAI, ApiType::Anthropic],
@@ -309,7 +323,10 @@ mod tests {
         assert_eq!(meta.name, "LM Studio");
         assert!(meta.supported_api_types.contains(&ApiType::OpenAI));
         assert!(meta.supported_api_types.contains(&ApiType::Anthropic));
-        assert!(meta.default_function_endpoints.contains_key(&ModelFunction::Chat));
+        assert!(
+            meta.default_function_endpoints
+                .contains_key(&ModelFunction::Chat)
+        );
     }
 
     #[test]

--- a/src/providers/mod.rs
+++ b/src/providers/mod.rs
@@ -62,8 +62,8 @@ impl crate::dependency::Configured<dyn Provider> for ProviderSource {
 
 mod base;
 pub use base::{
-    ApiEndpoint, ApiType, AuthType, HealthStatus, ModelFormat,
-    Provider, ProviderError, ProviderMetadata, ProviderType, PullResult,
+    ApiEndpoint, ApiType, AuthType, HealthStatus, ModelFormat, Provider, ProviderError,
+    ProviderMetadata, ProviderType, PullResult,
 };
 
 mod openai;
@@ -84,7 +84,7 @@ pub use lmstudio::{LMStudioProvider, LMStudioProviderConfig};
 mod tests {
     use super::*;
     use crate::config::{Config, ProviderConfig};
-    use crate::dependency::{resolve, Configured, DependsOn, Requirement};
+    use crate::dependency::{Configured, DependsOn, Requirement, resolve};
 
     fn openai_provider_config(id: &str, base_url: &str) -> ProviderConfig {
         ProviderConfig {

--- a/src/providers/ollama.rs
+++ b/src/providers/ollama.rs
@@ -1,9 +1,8 @@
 use crate::models::huggingface::hf_repo_id;
 use crate::models::{ModelFunction, ModelMetadata, ModelVariant};
 use crate::providers::base::{
-    http_health_check, ApiEndpoint, ApiType, AuthType, HealthStatus,
-    ModelFormat, Provider, ProviderError, ProviderMetadata, ProviderType,
-    HasProviderMetadata,
+    ApiEndpoint, ApiType, AuthType, HasProviderMetadata, HealthStatus, ModelFormat, Provider,
+    ProviderError, ProviderMetadata, ProviderType, http_health_check,
 };
 use crate::registry::{ConfigConstructable, Secret};
 use crate::utils::ui::Ui;
@@ -98,16 +97,19 @@ impl OllamaProvider {
     fn default_function_endpoints() -> HashMap<ModelFunction, Vec<ApiEndpoint>> {
         let mut map = HashMap::new();
 
-        map.insert(ModelFunction::Chat, vec![
-            ApiEndpoint::OpenAIChat,
-            ApiEndpoint::OllamaChat,
-            ApiEndpoint::AnthropicMessages,
-        ]);
+        map.insert(
+            ModelFunction::Chat,
+            vec![
+                ApiEndpoint::OpenAIChat,
+                ApiEndpoint::OllamaChat,
+                ApiEndpoint::AnthropicMessages,
+            ],
+        );
 
-        map.insert(ModelFunction::Embeddings, vec![
-            ApiEndpoint::OpenAIEmbeddings,
-            ApiEndpoint::OllamaEmbeddings,
-        ]);
+        map.insert(
+            ModelFunction::Embeddings,
+            vec![ApiEndpoint::OpenAIEmbeddings, ApiEndpoint::OllamaEmbeddings],
+        );
 
         map
     }
@@ -115,8 +117,7 @@ impl OllamaProvider {
 
 impl ConfigConstructable for OllamaProvider {
     fn new(cfg: &serde_json::Value) -> Self {
-        let config: OllamaProviderConfig = serde_json::from_value(cfg.clone())
-            .unwrap_or_default();
+        let config: OllamaProviderConfig = serde_json::from_value(cfg.clone()).unwrap_or_default();
 
         let client = reqwest::Client::builder()
             .timeout(Duration::from_secs(config.timeout_secs))
@@ -129,7 +130,11 @@ impl ConfigConstructable for OllamaProvider {
             .build()
             .expect("Failed to create HTTP client");
 
-        Self { config, client, stream_client }
+        Self {
+            config,
+            client,
+            stream_client,
+        }
     }
 }
 
@@ -161,7 +166,8 @@ impl Provider for OllamaProvider {
             &self.config.base_url,
             &self.config.health_check_endpoint,
             self.config.api_key.as_ref(),
-        ).await
+        )
+        .await
     }
 
     async fn pull_model(
@@ -181,7 +187,10 @@ impl Provider for OllamaProvider {
             )));
         };
 
-        let label = format!("{} ({} {})", model.family, variant.format, variant.precision);
+        let label = format!(
+            "{} ({} {})",
+            model.family, variant.format, variant.precision
+        );
 
         let url = format!("{}/api/pull", self.config.base_url);
         let mut request = self.stream_client.post(&url).json(&serde_json::json!({
@@ -196,7 +205,10 @@ impl Provider for OllamaProvider {
         if !response.status().is_success() {
             let status = response.status();
             let body = response.text().await.unwrap_or_default();
-            return Err(ProviderError::Other(format!("Ollama pull failed ({}): {}", status, body)));
+            return Err(ProviderError::Other(format!(
+                "Ollama pull failed ({}): {}",
+                status, body
+            )));
         }
 
         let handle = ui.pull_start(&label, None);
@@ -254,7 +266,8 @@ impl HasProviderMetadata for OllamaProvider {
     fn metadata() -> ProviderMetadata {
         ProviderMetadata {
             name: "Ollama".to_string(),
-            description: "Local inference server supporting multiple API protocols and GGUF models".to_string(),
+            description: "Local inference server supporting multiple API protocols and GGUF models"
+                .to_string(),
             provider_type: ProviderType::Local,
             default_endpoint: "http://localhost:11434".to_string(),
             supported_api_types: vec![ApiType::OpenAI, ApiType::Ollama, ApiType::Anthropic],
@@ -334,7 +347,10 @@ mod tests {
         assert!(meta.supported_api_types.contains(&ApiType::OpenAI));
         assert!(meta.supported_api_types.contains(&ApiType::Ollama));
         assert!(meta.supported_api_types.contains(&ApiType::Anthropic));
-        assert!(meta.default_function_endpoints.contains_key(&ModelFunction::Chat));
+        assert!(
+            meta.default_function_endpoints
+                .contains_key(&ModelFunction::Chat)
+        );
     }
 
     #[test]
@@ -364,12 +380,20 @@ mod tests {
 
     #[test]
     fn test_ollama_library_ref_parses_library_url() {
-        assert_eq!(ollama_library_ref("https://ollama.com/library/granite4:1b"), Some("granite4:1b"));
+        assert_eq!(
+            ollama_library_ref("https://ollama.com/library/granite4:1b"),
+            Some("granite4:1b")
+        );
     }
 
     #[test]
     fn test_ollama_library_ref_rejects_non_library_url() {
-        assert_eq!(ollama_library_ref("https://huggingface.co/ibm-granite/granite-4.1-30b-GGUF/blob/main/x.gguf"), None);
+        assert_eq!(
+            ollama_library_ref(
+                "https://huggingface.co/ibm-granite/granite-4.1-30b-GGUF/blob/main/x.gguf"
+            ),
+            None
+        );
     }
 
     #[test]
@@ -410,7 +434,10 @@ mod tests {
 
     #[test]
     fn test_pull_outcome_empty_stream() {
-        assert_eq!(process_pull_lines(Vec::<String>::new()), PullOutcome::Incomplete);
+        assert_eq!(
+            process_pull_lines(Vec::<String>::new()),
+            PullOutcome::Incomplete
+        );
     }
 
     #[test]

--- a/src/providers/openai.rs
+++ b/src/providers/openai.rs
@@ -1,7 +1,7 @@
 use crate::models::ModelFunction;
 use crate::providers::base::{
-    ApiEndpoint, ApiType, AuthType, HealthStatus, ModelFormat, Provider, ProviderError,
-    ProviderMetadata, ProviderType, HasProviderMetadata,
+    ApiEndpoint, ApiType, AuthType, HasProviderMetadata, HealthStatus, ModelFormat, Provider,
+    ProviderError, ProviderMetadata, ProviderType,
 };
 use crate::registry::{ConfigConstructable, Secret};
 use async_trait::async_trait;
@@ -73,16 +73,21 @@ impl OpenAIProvider {
     fn default_function_endpoints() -> HashMap<ModelFunction, Vec<ApiEndpoint>> {
         let mut map = HashMap::new();
         map.insert(ModelFunction::Chat, vec![ApiEndpoint::OpenAIChat]);
-        map.insert(ModelFunction::Embeddings, vec![ApiEndpoint::OpenAIEmbeddings]);
-        map.insert(ModelFunction::Transcription, vec![ApiEndpoint::OpenAIAudioTranscription]);
+        map.insert(
+            ModelFunction::Embeddings,
+            vec![ApiEndpoint::OpenAIEmbeddings],
+        );
+        map.insert(
+            ModelFunction::Transcription,
+            vec![ApiEndpoint::OpenAIAudioTranscription],
+        );
         map
     }
 }
 
 impl ConfigConstructable for OpenAIProvider {
     fn new(cfg: &serde_json::Value) -> Self {
-        let config: OpenAIProviderConfig = serde_json::from_value(cfg.clone())
-            .unwrap_or_default();
+        let config: OpenAIProviderConfig = serde_json::from_value(cfg.clone()).unwrap_or_default();
 
         let client = reqwest::Client::builder()
             .timeout(Duration::from_secs(config.timeout_secs))
@@ -90,16 +95,21 @@ impl ConfigConstructable for OpenAIProvider {
             .build()
             .expect("Failed to create HTTP client");
 
-        let function_endpoints = config.function_endpoints.clone()
+        let function_endpoints = config
+            .function_endpoints
+            .clone()
             .unwrap_or_else(Self::default_function_endpoints);
 
-        Self { config, client, function_endpoints }
+        Self {
+            config,
+            client,
+            function_endpoints,
+        }
     }
 }
 
 #[async_trait]
 impl Provider for OpenAIProvider {
-
     fn name(&self) -> &str {
         "OpenAI Compatible Provider"
     }
@@ -113,10 +123,7 @@ impl Provider for OpenAIProvider {
     }
 
     fn supported_formats(&self) -> Vec<ModelFormat> {
-        vec![
-            ModelFormat::Safetensors,
-            ModelFormat::GGUF,
-        ]
+        vec![ModelFormat::Safetensors, ModelFormat::GGUF]
     }
 
     fn can_run_model(&self, _variant_format: &str, _variant_precision: &str) -> bool {
@@ -126,7 +133,10 @@ impl Provider for OpenAIProvider {
     async fn health_check(&self) -> Result<HealthStatus, ProviderError> {
         let start = Instant::now();
 
-        let url = format!("{}{}", self.config.base_url, self.config.health_check_endpoint);
+        let url = format!(
+            "{}{}",
+            self.config.base_url, self.config.health_check_endpoint
+        );
 
         let mut request = self.client.get(&url);
 
@@ -148,7 +158,8 @@ impl Provider for OpenAIProvider {
                     Ok(HealthStatus {
                         healthy: false,
                         latency,
-                        error: Some(format!("HTTP {}: {}",
+                        error: Some(format!(
+                            "HTTP {}: {}",
                             response.status(),
                             response.text().await.unwrap_or_default()
                         )),
@@ -175,7 +186,10 @@ impl Provider for OpenAIProvider {
         let message = format!(
             "Generic OpenAI-compatible provider '{}' does not support pulling models. \
              Pull '{} ({} {})' manually using whatever mechanism your specific server requires, then restart it.",
-            self.name(), model.family, variant.format, variant.precision
+            self.name(),
+            model.family,
+            variant.format,
+            variant.precision
         );
         Ok(crate::providers::PullResult::Unsupported { message })
     }
@@ -185,8 +199,14 @@ impl HasProviderMetadata for OpenAIProvider {
     fn metadata() -> ProviderMetadata {
         let mut default_mappings = HashMap::new();
         default_mappings.insert(ModelFunction::Chat, vec![ApiEndpoint::OpenAIChat]);
-        default_mappings.insert(ModelFunction::Embeddings, vec![ApiEndpoint::OpenAIEmbeddings]);
-        default_mappings.insert(ModelFunction::Transcription, vec![ApiEndpoint::OpenAIAudioTranscription]);
+        default_mappings.insert(
+            ModelFunction::Embeddings,
+            vec![ApiEndpoint::OpenAIEmbeddings],
+        );
+        default_mappings.insert(
+            ModelFunction::Transcription,
+            vec![ApiEndpoint::OpenAIAudioTranscription],
+        );
 
         ProviderMetadata {
             name: "OpenAI Compatible Provider".to_string(),
@@ -253,9 +273,18 @@ mod tests {
         let meta = OpenAIProvider::metadata();
         assert_eq!(meta.name, "OpenAI Compatible Provider");
         assert!(meta.supported_api_types.contains(&ApiType::OpenAI));
-        assert!(meta.default_function_endpoints.contains_key(&ModelFunction::Chat));
-        assert!(meta.default_function_endpoints.contains_key(&ModelFunction::Embeddings));
-        assert!(meta.default_function_endpoints.contains_key(&ModelFunction::Transcription));
+        assert!(
+            meta.default_function_endpoints
+                .contains_key(&ModelFunction::Chat)
+        );
+        assert!(
+            meta.default_function_endpoints
+                .contains_key(&ModelFunction::Embeddings)
+        );
+        assert!(
+            meta.default_function_endpoints
+                .contains_key(&ModelFunction::Transcription)
+        );
     }
 
     #[test]
@@ -267,7 +296,10 @@ mod tests {
         });
         let provider = OpenAIProvider::new(&cfg);
         assert_eq!(provider.config.base_url, "http://example.com:8080");
-        assert_eq!(provider.config.api_key, Some(Secret("test-key".to_string())));
+        assert_eq!(
+            provider.config.api_key,
+            Some(Secret("test-key".to_string()))
+        );
         assert_eq!(provider.config.timeout_secs, 30);
     }
 

--- a/src/registry/mod.rs
+++ b/src/registry/mod.rs
@@ -10,7 +10,6 @@ pub use secret::Secret;
 /// Core trait that all factory-managed types must implement.
 /// Provides construction from a configuration object.
 pub trait ConfigConstructable {
-
     /// Construct with a config instance
     fn new(cfg: &serde_json::Value) -> Self
     where
@@ -57,13 +56,14 @@ pub trait ConfigConstructable {
 #[macro_export]
 macro_rules! define_factory {
     ($trait:ident, $metadata:ty, $factory:ident) => {
-
         /// Wrapper type that connects an implementation to its metadata.
         /// Uses PhantomData to maintain type information without storing instances.
         struct MetaOf<T>(std::marker::PhantomData<T>);
         impl<T> MetaOf<T> {
             #[allow(unused)]
-            const fn new() -> Self { Self(std::marker::PhantomData) }
+            const fn new() -> Self {
+                Self(std::marker::PhantomData)
+            }
         }
 
         $crate::paste::paste! {

--- a/src/registry/mod.rs
+++ b/src/registry/mod.rs
@@ -1,9 +1,9 @@
 mod secret;
 pub use secret::Secret;
 
-/// TODO: There are a number of instances of `#[allow(unused)]` that allow
-/// certain portions of the factories to be unused without warning. These should
-/// be removed once all factories are populated and utilized.
+// TODO: There are a number of instances of `#[allow(unused)]` that allow
+// certain portions of the factories to be unused without warning. These should
+// be removed once all factories are populated and utilized.
 
 /*-- Generic Factory Infrastructure ------------------------------------------*/
 

--- a/src/registry/secret.rs
+++ b/src/registry/secret.rs
@@ -65,7 +65,10 @@ mod tests {
         // whole schema (properties + $defs) rather than assuming a specific nesting
         // shape, since that's what matters for consumers like `utils::schema_prompt`.
         let as_str = serde_json::to_string(&schema).unwrap();
-        assert!(as_str.contains("\"password\""), "schema should mark api_key as password format: {as_str}");
+        assert!(
+            as_str.contains("\"password\""),
+            "schema should mark api_key as password format: {as_str}"
+        );
     }
 
     #[test]

--- a/src/utils/hardware.rs
+++ b/src/utils/hardware.rs
@@ -118,7 +118,9 @@ mod gpu {
         for entry in drm_dir.flatten() {
             let name = entry.file_name();
             let name = name.to_string_lossy();
-            if !name.starts_with("card") || !name["card".len()..].bytes().all(|b| b.is_ascii_digit()) {
+            if !name.starts_with("card")
+                || !name["card".len()..].bytes().all(|b| b.is_ascii_digit())
+            {
                 continue;
             }
 

--- a/src/utils/traits.rs
+++ b/src/utils/traits.rs
@@ -1,4 +1,3 @@
-
 /*-- Searchable Trait ---------------------------------------------------------*/
 
 /// Declares which string fields on a metadata struct participate in search.
@@ -37,7 +36,10 @@ mod searchable_tests {
                 num_attention_heads: 1,
                 num_key_value_heads: 1,
                 head_dim: 1,
-                layer_types: vec![LayerTypeCount { kind: LayerKind::FullAttention, count: 1 }],
+                layer_types: vec![LayerTypeCount {
+                    kind: LayerKind::FullAttention,
+                    count: 1,
+                }],
             },
             variants: vec![],
             description: description.map(String::from),

--- a/src/utils/ui/app.rs
+++ b/src/utils/ui/app.rs
@@ -29,7 +29,7 @@ fn strip_ansi(input: &str) -> String {
             }
             while i < bytes.len() {
                 let b = bytes[i];
-                if (b >= 0x41 && b <= 0x5A) || (b >= 0x61 && b <= 0x7A) {
+                if (0x41..=0x5A).contains(&b) || (0x61..=0x7A).contains(&b) {
                     i += 1;
                     break;
                 }
@@ -634,11 +634,10 @@ pub async fn run_interactive_tui(ctx: crate::AppContext) -> anyhow::Result<()> {
     loop {
         terminal.draw(|frame| app.render(frame))?;
 
-        if let Event::Key(key) = event::read()? {
-            if app.handle_key(key) {
+        if let Event::Key(key) = event::read()?
+            && app.handle_key(key) {
                 break;
             }
-        }
     }
 
     restore_terminal(terminal)?;

--- a/src/utils/ui/app.rs
+++ b/src/utils/ui/app.rs
@@ -149,8 +149,7 @@ impl App {
                     }
                     KeyCode::Enter => {
                         // Confirm: position cursor at first match, return to browse
-                        let matches = self.filtered_ids(&q);
-                        self.row = if matches.is_empty() { 0 } else { 0 };
+                        self.row = 0;
                         self.sync_table_state();
                         self.mode = AppMode::Browse;
                     }
@@ -635,9 +634,10 @@ pub async fn run_interactive_tui(ctx: crate::AppContext) -> anyhow::Result<()> {
         terminal.draw(|frame| app.render(frame))?;
 
         if let Event::Key(key) = event::read()?
-            && app.handle_key(key) {
-                break;
-            }
+            && app.handle_key(key)
+        {
+            break;
+        }
     }
 
     restore_terminal(terminal)?;

--- a/src/utils/ui/app.rs
+++ b/src/utils/ui/app.rs
@@ -1,10 +1,10 @@
 use crossterm::event::{self, Event, KeyCode, KeyEvent, KeyModifiers};
 use ratatui::{
+    Frame,
     layout::{Constraint, Direction, Layout, Rect},
     style::{Color, Modifier, Style},
     text::{Line, Span},
     widgets::{Block, Borders, Cell, List, ListItem, ListState, Paragraph, Row, Table, TableState},
-    Frame,
 };
 
 use crate::commands::{HardwareCommands, ModelCommands};
@@ -57,21 +57,21 @@ pub enum Section {
 impl Section {
     fn next(&self) -> Self {
         match self {
-            Section::Models       => Section::Providers,
-            Section::Providers    => Section::Capabilities,
+            Section::Models => Section::Providers,
+            Section::Providers => Section::Capabilities,
             Section::Capabilities => Section::Recommend,
-            Section::Recommend    => Section::Hardware,
-            Section::Hardware     => Section::Models,
+            Section::Recommend => Section::Hardware,
+            Section::Hardware => Section::Models,
         }
     }
 
     fn label(&self) -> &'static str {
         match self {
-            Section::Models       => "Models",
-            Section::Providers    => "Providers",
+            Section::Models => "Models",
+            Section::Providers => "Providers",
             Section::Capabilities => "Capabilities",
-            Section::Recommend    => "Recommend",
-            Section::Hardware     => "Hardware",
+            Section::Recommend => "Recommend",
+            Section::Hardware => "Hardware",
         }
     }
 }
@@ -232,22 +232,46 @@ impl App {
         let q = query.to_lowercase();
         // Hardware has no selectable rows; Recommend uses its own row source
         let mut ids: Vec<String> = match self.section {
-            Section::Models       => MODEL_REGISTRY.entries().keys().map(|k| k.to_string()).collect(),
-            Section::Providers    => PROVIDER_REGISTRY.entries().keys().map(|k| k.to_string()).collect(),
-            Section::Capabilities => crate::capabilities::CAPABILITY_REGISTRY.entries().keys().map(|k| k.to_string()).collect(),
-            Section::Recommend    => {
+            Section::Models => MODEL_REGISTRY
+                .entries()
+                .keys()
+                .map(|k| k.to_string())
+                .collect(),
+            Section::Providers => PROVIDER_REGISTRY
+                .entries()
+                .keys()
+                .map(|k| k.to_string())
+                .collect(),
+            Section::Capabilities => crate::capabilities::CAPABILITY_REGISTRY
+                .entries()
+                .keys()
+                .map(|k| k.to_string())
+                .collect(),
+            Section::Recommend => {
                 let source = crate::providers::ProviderSource::from_config(&self.ctx.config);
                 let instances = source.instances();
-                let providers: Vec<&dyn crate::providers::Provider> = instances.iter().map(|(_, p)| *p).collect();
-                ModelCommands::recommend_rows(None, Some(&providers), &instances, false, self.ctx.ui.as_ref()).into_iter().map(|r| r[0].clone()).collect()
+                let providers: Vec<&dyn crate::providers::Provider> =
+                    instances.iter().map(|(_, p)| *p).collect();
+                ModelCommands::recommend_rows(
+                    None,
+                    Some(&providers),
+                    &instances,
+                    false,
+                    self.ctx.ui.as_ref(),
+                )
+                .into_iter()
+                .map(|r| r[0].clone())
+                .collect()
             }
-            Section::Hardware     => vec![],
+            Section::Hardware => vec![],
         };
         ids.sort();
         if q.is_empty() {
             ids
         } else {
-            ids.into_iter().filter(|id| id.to_lowercase().contains(&q)).collect()
+            ids.into_iter()
+                .filter(|id| id.to_lowercase().contains(&q))
+                .collect()
         }
     }
 
@@ -256,91 +280,128 @@ impl App {
     }
 
     fn selected_id(&self) -> Option<String> {
-        self.filtered_ids(self.active_query()).into_iter().nth(self.row)
+        self.filtered_ids(self.active_query())
+            .into_iter()
+            .nth(self.row)
     }
 
     fn render_nav(&self, frame: &mut Frame, area: Rect) {
         let sections = [
-            Section::Models, Section::Providers, Section::Capabilities,
-            Section::Recommend, Section::Hardware,
+            Section::Models,
+            Section::Providers,
+            Section::Capabilities,
+            Section::Recommend,
+            Section::Hardware,
         ];
-        let items: Vec<ListItem> = sections.iter().map(|s| {
-            let count = match s {
-                Section::Models       => MODEL_REGISTRY.entries().len(),
-                Section::Providers    => PROVIDER_REGISTRY.entries().len(),
-                Section::Capabilities => crate::capabilities::CAPABILITY_REGISTRY.entries().len(),
-                Section::Recommend    => {
-                    let source = crate::providers::ProviderSource::from_config(&self.ctx.config);
-                    let instances = source.instances();
-                    let providers: Vec<&dyn crate::providers::Provider> = instances.iter().map(|(_, p)| *p).collect();
-                    ModelCommands::recommend_rows(None, Some(&providers), &instances, false, self.ctx.ui.as_ref()).len()
-                }
-                Section::Hardware     => 0,
-            };
-            let style = if *s == self.section {
-                Style::default().fg(Color::Cyan).add_modifier(Modifier::BOLD)
-            } else {
-                Style::default()
-            };
-            ListItem::new(Line::from(Span::styled(
-                format!("  {} ({})", s.label(), count),
-                style,
-            )))
-        }).collect();
+        let items: Vec<ListItem> = sections
+            .iter()
+            .map(|s| {
+                let count = match s {
+                    Section::Models => MODEL_REGISTRY.entries().len(),
+                    Section::Providers => PROVIDER_REGISTRY.entries().len(),
+                    Section::Capabilities => {
+                        crate::capabilities::CAPABILITY_REGISTRY.entries().len()
+                    }
+                    Section::Recommend => {
+                        let source =
+                            crate::providers::ProviderSource::from_config(&self.ctx.config);
+                        let instances = source.instances();
+                        let providers: Vec<&dyn crate::providers::Provider> =
+                            instances.iter().map(|(_, p)| *p).collect();
+                        ModelCommands::recommend_rows(
+                            None,
+                            Some(&providers),
+                            &instances,
+                            false,
+                            self.ctx.ui.as_ref(),
+                        )
+                        .len()
+                    }
+                    Section::Hardware => 0,
+                };
+                let style = if *s == self.section {
+                    Style::default()
+                        .fg(Color::Cyan)
+                        .add_modifier(Modifier::BOLD)
+                } else {
+                    Style::default()
+                };
+                ListItem::new(Line::from(Span::styled(
+                    format!("  {} ({})", s.label(), count),
+                    style,
+                )))
+            })
+            .collect();
 
-        let list = List::new(items)
-            .block(Block::default().borders(Borders::ALL).title(" granite-cli "));
+        let list = List::new(items).block(
+            Block::default()
+                .borders(Borders::ALL)
+                .title(" granite-cli "),
+        );
         let mut state = ListState::default();
         frame.render_stateful_widget(list, area, &mut state);
     }
 
     fn render_browse(&mut self, frame: &mut Frame, area: Rect, query: &str) {
         // When searching, split the pane: table on top, search bar on bottom
-        let (table_area, search_area) = if !query.is_empty() || matches!(self.mode, AppMode::Search(_)) {
-            let chunks = Layout::default()
-                .direction(Direction::Vertical)
-                .constraints([Constraint::Min(1), Constraint::Length(3)])
-                .split(area);
-            (chunks[0], Some(chunks[1]))
-        } else {
-            (area, None)
-        };
+        let (table_area, search_area) =
+            if !query.is_empty() || matches!(self.mode, AppMode::Search(_)) {
+                let chunks = Layout::default()
+                    .direction(Direction::Vertical)
+                    .constraints([Constraint::Min(1), Constraint::Length(3)])
+                    .split(area);
+                (chunks[0], Some(chunks[1]))
+            } else {
+                (area, None)
+            };
 
         match self.section {
             Section::Models => {
                 let filtered_ids = self.filtered_ids(query);
                 // Use the shared data layer — catalog_rows returns [id, family, size, context, type]
                 let all_rows = ModelCommands::catalog_rows(None);
-                let entries: Vec<Vec<String>> = all_rows.into_iter()
+                let entries: Vec<Vec<String>> = all_rows
+                    .into_iter()
                     .filter(|r| filtered_ids.contains(&r[0]))
                     .collect();
 
-                let header = Row::new(vec!["ID", "FAMILY", "SIZE", "TYPE"])
-                    .style(Style::default().fg(Color::Cyan).add_modifier(Modifier::BOLD));
+                let header = Row::new(vec!["ID", "FAMILY", "SIZE", "TYPE"]).style(
+                    Style::default()
+                        .fg(Color::Cyan)
+                        .add_modifier(Modifier::BOLD),
+                );
 
-                let rows: Vec<Row> = entries.iter().enumerate().map(|(i, r)| {
-                    let style = if i == self.row {
-                        Style::default().bg(Color::DarkGray)
-                    } else if i % 2 == 0 {
-                        Style::default()
-                    } else {
-                        Style::default().bg(Color::Rgb(20, 20, 20))
-                    };
-                    // columns: [0]=id [1]=family [2]=size [3]=context [4]=type
-                    Row::new(vec![
-                        Cell::from(r[0].clone()),
-                        Cell::from(r[1].clone()),
-                        Cell::from(r[2].clone()),
-                        Cell::from(r[4].clone()),
-                    ]).style(style)
-                }).collect();
+                let rows: Vec<Row> = entries
+                    .iter()
+                    .enumerate()
+                    .map(|(i, r)| {
+                        let style = if i == self.row {
+                            Style::default().bg(Color::DarkGray)
+                        } else if i % 2 == 0 {
+                            Style::default()
+                        } else {
+                            Style::default().bg(Color::Rgb(20, 20, 20))
+                        };
+                        // columns: [0]=id [1]=family [2]=size [3]=context [4]=type
+                        Row::new(vec![
+                            Cell::from(r[0].clone()),
+                            Cell::from(r[1].clone()),
+                            Cell::from(r[2].clone()),
+                            Cell::from(r[4].clone()),
+                        ])
+                        .style(style)
+                    })
+                    .collect();
 
-                let table = Table::new(rows, [
-                    Constraint::Percentage(45),
-                    Constraint::Percentage(25),
-                    Constraint::Percentage(10),
-                    Constraint::Percentage(20),
-                ])
+                let table = Table::new(
+                    rows,
+                    [
+                        Constraint::Percentage(45),
+                        Constraint::Percentage(25),
+                        Constraint::Percentage(10),
+                        Constraint::Percentage(20),
+                    ],
+                )
                 .header(header)
                 .block(Block::default().borders(Borders::ALL).title(" Models "));
 
@@ -354,81 +415,112 @@ impl App {
                 };
 
                 let filtered_ids = self.filtered_ids(query);
-                let entries: Vec<_> = all_entries.into_iter()
+                let entries: Vec<_> = all_entries
+                    .into_iter()
                     .filter(|(id, _)| filtered_ids.contains(&id.to_string()))
                     .collect();
 
-                let header = Row::new(vec!["ID", "ENDPOINT"])
-                    .style(Style::default().fg(Color::Cyan).add_modifier(Modifier::BOLD));
+                let header = Row::new(vec!["ID", "ENDPOINT"]).style(
+                    Style::default()
+                        .fg(Color::Cyan)
+                        .add_modifier(Modifier::BOLD),
+                );
 
-                let rows: Vec<Row> = entries.iter().enumerate().map(|(i, (id, p))| {
-                    let style = if i == self.row {
-                        Style::default().bg(Color::DarkGray)
-                    } else {
-                        Style::default()
-                    };
-                    Row::new(vec![
-                        Cell::from(id.to_string()),
-                        Cell::from(p.default_endpoint.clone()),
-                    ]).style(style)
-                }).collect();
+                let rows: Vec<Row> = entries
+                    .iter()
+                    .enumerate()
+                    .map(|(i, (id, p))| {
+                        let style = if i == self.row {
+                            Style::default().bg(Color::DarkGray)
+                        } else {
+                            Style::default()
+                        };
+                        Row::new(vec![
+                            Cell::from(id.to_string()),
+                            Cell::from(p.default_endpoint.clone()),
+                        ])
+                        .style(style)
+                    })
+                    .collect();
 
-                let table = Table::new(rows, [
-                    Constraint::Percentage(30),
-                    Constraint::Percentage(70),
-                ])
+                let table = Table::new(
+                    rows,
+                    [Constraint::Percentage(30), Constraint::Percentage(70)],
+                )
                 .header(header)
                 .block(Block::default().borders(Borders::ALL).title(" Providers "));
 
                 frame.render_stateful_widget(table, table_area, &mut self.table_state);
             }
             Section::Capabilities => {
-                let text = Paragraph::new("No capabilities registered yet.")
-                    .block(Block::default().borders(Borders::ALL).title(" Capabilities "));
+                let text = Paragraph::new("No capabilities registered yet.").block(
+                    Block::default()
+                        .borders(Borders::ALL)
+                        .title(" Capabilities "),
+                );
                 frame.render_widget(text, table_area);
             }
             Section::Recommend => {
                 let source = crate::providers::ProviderSource::from_config(&self.ctx.config);
                 let instances = source.instances();
-                let providers: Vec<&dyn crate::providers::Provider> = instances.iter().map(|(_, p)| *p).collect();
-                let all_rows = ModelCommands::recommend_rows(None, Some(&providers), &instances, false, self.ctx.ui.as_ref());
+                let providers: Vec<&dyn crate::providers::Provider> =
+                    instances.iter().map(|(_, p)| *p).collect();
+                let all_rows = ModelCommands::recommend_rows(
+                    None,
+                    Some(&providers),
+                    &instances,
+                    false,
+                    self.ctx.ui.as_ref(),
+                );
 
                 // columns: [0]=id [1]=size [2]=variant [3]=type [4]=fit [5]=providers
                 let header = Row::new(vec!["ID", "SIZE", "VARIANT", "TYPE", "FIT", "PROVIDERS"])
-                    .style(Style::default().fg(Color::Cyan).add_modifier(Modifier::BOLD));
-
-                let rows: Vec<Row> = all_rows.iter().enumerate().map(|(i, r)| {
-                    let style = if i == self.row {
-                        Style::default().bg(Color::DarkGray)
-                    } else if i % 2 == 0 {
+                    .style(
                         Style::default()
-                    } else {
-                        Style::default().bg(Color::Rgb(20, 20, 20))
-                    };
-                    let fit_display = strip_ansi(&r[4]);
-                    let fit_style = if fit_display.starts_with("Partial") {
-                        Style::default().fg(Color::Yellow)
-                    } else {
-                        Style::default()
-                    };
-                    Row::new(vec![
-                        Cell::from(r[0].clone()),
-                        Cell::from(r[1].clone()),
-                        Cell::from(r[2].clone()),
-                        Cell::from(r[3].clone()),
-                        Cell::from(fit_display).style(fit_style),
-                        Cell::from(r[5].clone()),
-                    ]).style(style)
-                }).collect();
+                            .fg(Color::Cyan)
+                            .add_modifier(Modifier::BOLD),
+                    );
 
-                let table = Table::new(rows, [
-                    Constraint::Percentage(22),
-                    Constraint::Percentage(10),
-                    Constraint::Percentage(25),
-                    Constraint::Percentage(10),
-                    Constraint::Percentage(13),
-                    Constraint::Percentage(20),
-                ])
+                let rows: Vec<Row> = all_rows
+                    .iter()
+                    .enumerate()
+                    .map(|(i, r)| {
+                        let style = if i == self.row {
+                            Style::default().bg(Color::DarkGray)
+                        } else if i % 2 == 0 {
+                            Style::default()
+                        } else {
+                            Style::default().bg(Color::Rgb(20, 20, 20))
+                        };
+                        let fit_display = strip_ansi(&r[4]);
+                        let fit_style = if fit_display.starts_with("Partial") {
+                            Style::default().fg(Color::Yellow)
+                        } else {
+                            Style::default()
+                        };
+                        Row::new(vec![
+                            Cell::from(r[0].clone()),
+                            Cell::from(r[1].clone()),
+                            Cell::from(r[2].clone()),
+                            Cell::from(r[3].clone()),
+                            Cell::from(fit_display).style(fit_style),
+                            Cell::from(r[5].clone()),
+                        ])
+                        .style(style)
+                    })
+                    .collect();
+
+                let table = Table::new(
+                    rows,
+                    [
+                        Constraint::Percentage(22),
+                        Constraint::Percentage(10),
+                        Constraint::Percentage(25),
+                        Constraint::Percentage(10),
+                        Constraint::Percentage(13),
+                        Constraint::Percentage(20),
+                    ],
+                )
                 .header(header)
                 .block(Block::default().borders(Borders::ALL).title(" Recommend "));
 
@@ -436,12 +528,17 @@ impl App {
             }
             Section::Hardware => {
                 // Hardware is a single static detail pane — no rows to browse
-                let content = HardwareCommands::hardware_fields().iter()
+                let content = HardwareCommands::hardware_fields()
+                    .iter()
                     .map(|(k, v)| format!("{}: {}", k, v))
                     .collect::<Vec<_>>()
                     .join("\n");
                 let para = Paragraph::new(content)
-                    .block(Block::default().borders(Borders::ALL).title(" Hardware Profile "))
+                    .block(
+                        Block::default()
+                            .borders(Borders::ALL)
+                            .title(" Hardware Profile "),
+                    )
                     .wrap(ratatui::widgets::Wrap { trim: false })
                     .scroll((self.detail_scroll as u16, 0));
                 frame.render_widget(para, table_area);
@@ -451,11 +548,12 @@ impl App {
         // Render the search bar when in search mode
         if let Some(bar_area) = search_area {
             let display = format!(" / {}", query);
-            let bar = Paragraph::new(display)
-                .block(Block::default()
+            let bar = Paragraph::new(display).block(
+                Block::default()
                     .borders(Borders::ALL)
                     .border_style(Style::default().fg(Color::Yellow))
-                    .title(" Search "));
+                    .title(" Search "),
+            );
             frame.render_widget(bar, bar_area);
         }
     }
@@ -465,7 +563,8 @@ impl App {
             Section::Models => {
                 // Use the shared data layer — no registry access here
                 match ModelCommands::info_fields(id) {
-                    Some(fields) => fields.iter()
+                    Some(fields) => fields
+                        .iter()
                         .map(|(k, v)| format!("{}: {}", k, v))
                         .collect::<Vec<_>>()
                         .join("\n"),
@@ -474,8 +573,10 @@ impl App {
             }
             Section::Providers => {
                 if let Some(p) = PROVIDER_REGISTRY.get(id) {
-                    format!("Provider: {}\n\nName: {}\nType: {}\nEndpoint: {}\n\nDescription: {}",
-                        id, p.name, p.provider_type, p.default_endpoint, p.description)
+                    format!(
+                        "Provider: {}\n\nName: {}\nType: {}\nEndpoint: {}\n\nDescription: {}",
+                        id, p.name, p.provider_type, p.default_endpoint, p.description
+                    )
                 } else {
                     format!("Provider '{}' not found.", id)
                 }
@@ -483,21 +584,27 @@ impl App {
             Section::Capabilities => format!("Capability: {}", id),
             // Recommend detail reuses the Model info_fields
             Section::Recommend => match ModelCommands::info_fields(id) {
-                Some(fields) => fields.iter()
+                Some(fields) => fields
+                    .iter()
                     .map(|(k, v)| format!("{}: {}", k, v))
                     .collect::<Vec<_>>()
                     .join("\n"),
                 None => format!("Model '{}' not found.", id),
             },
             // Hardware has no per-row detail — render the full profile
-            Section::Hardware => HardwareCommands::hardware_fields().iter()
+            Section::Hardware => HardwareCommands::hardware_fields()
+                .iter()
                 .map(|(k, v)| format!("{}: {}", k, v))
                 .collect::<Vec<_>>()
                 .join("\n"),
         };
 
         let para = Paragraph::new(content)
-            .block(Block::default().borders(Borders::ALL).title(format!(" {} — Detail ", id)))
+            .block(
+                Block::default()
+                    .borders(Borders::ALL)
+                    .title(format!(" {} — Detail ", id)),
+            )
             .wrap(ratatui::widgets::Wrap { trim: false })
             .scroll((self.detail_scroll as u16, 0));
         frame.render_widget(para, area);
@@ -505,10 +612,12 @@ impl App {
 
     fn render_footer(&self, frame: &mut Frame, area: Rect) {
         let hints = match &self.mode {
-            AppMode::Browse if self.section == Section::Hardware =>
-                "[↑↓/jk] Scroll  [Tab] Section  [q] Quit",
-            AppMode::Browse =>
-                "[↑↓/jk] Navigate  [Tab] Section  [Enter] Detail  [/] Search  [q] Quit",
+            AppMode::Browse if self.section == Section::Hardware => {
+                "[↑↓/jk] Scroll  [Tab] Section  [q] Quit"
+            }
+            AppMode::Browse => {
+                "[↑↓/jk] Navigate  [Tab] Section  [Enter] Detail  [/] Search  [q] Quit"
+            }
             AppMode::Search(_) => "[typing] Filter  [Enter] Confirm  [Esc] Cancel",
             AppMode::Detail(_) => "[↑↓/jk] Scroll  [Backspace/Esc/q] Back",
         };
@@ -822,7 +931,8 @@ mod tests {
 
     #[test]
     fn recommend_rows_all_have_six_columns() {
-        let ui: Box<dyn crate::utils::ui::base::Ui + Send + Sync> = Box::new(crate::utils::ui::base::tests::CaptureUi::default());
+        let ui: Box<dyn crate::utils::ui::base::Ui + Send + Sync> =
+            Box::new(crate::utils::ui::base::tests::CaptureUi::default());
         for row in ModelCommands::recommend_rows(None, None, &[], false, &*ui) {
             assert_eq!(row.len(), 6, "each recommend row must have 6 columns");
         }

--- a/src/utils/ui/backends/json.rs
+++ b/src/utils/ui/backends/json.rs
@@ -23,13 +23,21 @@ impl JsonOutput {
     pub fn with_capture() -> Self {
         let buf: Arc<Mutex<Vec<u8>>> = Arc::new(Mutex::new(Vec::new()));
         let writer: Box<dyn Write + Send> = Box::new(SharedWriter(Arc::clone(&buf)));
-        Self { writer: Mutex::new(writer), buf: Some(buf) }
+        Self {
+            writer: Mutex::new(writer),
+            buf: Some(buf),
+        }
     }
 
     /// Return all emitted JSON objects in emission order.
     /// Panics if called on a non-capturing instance.
     pub fn captured(&self) -> Vec<serde_json::Value> {
-        let buf = self.buf.as_ref().expect("captured() called on stdout JsonOutput").lock().unwrap();
+        let buf = self
+            .buf
+            .as_ref()
+            .expect("captured() called on stdout JsonOutput")
+            .lock()
+            .unwrap();
         String::from_utf8_lossy(&buf)
             .lines()
             .filter(|l| !l.is_empty())
@@ -52,7 +60,9 @@ impl Write for SharedWriter {
         self.0.lock().unwrap().extend_from_slice(buf);
         Ok(buf.len())
     }
-    fn flush(&mut self) -> std::io::Result<()> { Ok(()) }
+    fn flush(&mut self) -> std::io::Result<()> {
+        Ok(())
+    }
 }
 
 impl ConfigConstructable for JsonOutput {
@@ -75,7 +85,8 @@ impl Ui for JsonOutput {
     }
 
     fn detail(&self, title: &str, fields: &[(&str, String)]) {
-        let obj: serde_json::Map<String, serde_json::Value> = fields.iter()
+        let obj: serde_json::Map<String, serde_json::Value> = fields
+            .iter()
             .map(|(k, v)| (k.to_string(), serde_json::Value::String(v.clone())))
             .collect();
         self.emit(serde_json::json!({
@@ -126,7 +137,13 @@ impl Ui for JsonOutput {
         base::PullHandle(0)
     }
 
-    fn pull_progress(&self, _handle: base::PullHandle, _downloaded_bytes: u64, _total_bytes: Option<u64>) {}
+    fn pull_progress(
+        &self,
+        _handle: base::PullHandle,
+        _downloaded_bytes: u64,
+        _total_bytes: Option<u64>,
+    ) {
+    }
 
     fn pull_finish(&self, _handle: base::PullHandle, label: &str, error: Option<&str>) {
         self.emit(serde_json::json!({
@@ -153,14 +170,20 @@ impl HasUiMetadata for JsonOutput {
 mod tests {
     use super::*;
 
-    fn make() -> JsonOutput { JsonOutput::with_capture() }
+    fn make() -> JsonOutput {
+        JsonOutput::with_capture()
+    }
 
     crate::output_contract_tests!(make());
 
     #[test]
     fn json_table_output_is_valid_json_with_correct_type() {
         let out = make();
-        out.table("T", &["A", "B"], &[vec!["r1a".to_string(), "r1b".to_string()]]);
+        out.table(
+            "T",
+            &["A", "B"],
+            &[vec!["r1a".to_string(), "r1b".to_string()]],
+        );
         let vals = out.captured();
         assert_eq!(vals.len(), 1);
         assert_eq!(vals[0]["type"], "table");

--- a/src/utils/ui/backends/markdown.rs
+++ b/src/utils/ui/backends/markdown.rs
@@ -17,7 +17,14 @@ impl Ui for MarkdownOutput {
     fn table(&self, title: &str, headers: &[&str], rows: &[Vec<String>]) {
         println!("\n## {}\n", title);
         let header_line = format!("| {} |", headers.join(" | "));
-        let sep_line = format!("| {} |", headers.iter().map(|h| "-".repeat(h.len() + 2)).collect::<Vec<_>>().join(" | "));
+        let sep_line = format!(
+            "| {} |",
+            headers
+                .iter()
+                .map(|h| "-".repeat(h.len() + 2))
+                .collect::<Vec<_>>()
+                .join(" | ")
+        );
         println!("{}", header_line);
         println!("{}", sep_line);
         for row in rows {
@@ -43,9 +50,15 @@ impl Ui for MarkdownOutput {
         }
     }
 
-    fn info(&self, msg: &str)  { println!("{}", msg); }
-    fn warn(&self, msg: &str)  { println!("Warning: {}", msg); }
-    fn error(&self, msg: &str) { eprintln!("Error: {}", msg); }
+    fn info(&self, msg: &str) {
+        println!("{}", msg);
+    }
+    fn warn(&self, msg: &str) {
+        println!("Warning: {}", msg);
+    }
+    fn error(&self, msg: &str) {
+        eprintln!("Error: {}", msg);
+    }
 
     fn select(&self, _prompt: &str, _items: &[String], _default: usize) -> anyhow::Result<usize> {
         base::non_interactive()
@@ -67,7 +80,13 @@ impl Ui for MarkdownOutput {
         base::PullHandle(0)
     }
 
-    fn pull_progress(&self, _handle: base::PullHandle, _downloaded_bytes: u64, _total_bytes: Option<u64>) {}
+    fn pull_progress(
+        &self,
+        _handle: base::PullHandle,
+        _downloaded_bytes: u64,
+        _total_bytes: Option<u64>,
+    ) {
+    }
 
     fn pull_finish(&self, _handle: base::PullHandle, label: &str, error: Option<&str>) {
         match error {
@@ -98,7 +117,11 @@ mod tests {
     #[test]
     fn markdown_table_contains_pipe_chars() {
         let out = CaptureUi::default();
-        out.table("Test", &["ID", "NAME"], &[vec!["id-1".to_string(), "name-1".to_string()]]);
+        out.table(
+            "Test",
+            &["ID", "NAME"],
+            &[vec!["id-1".to_string(), "name-1".to_string()]],
+        );
         let tables = out.tables.borrow();
         // verify the CaptureOutput recorded correctly; live rendering tested via contract tests
         assert_eq!(tables.len(), 1);
@@ -108,7 +131,11 @@ mod tests {
     fn markdown_table_has_header_separator() {
         // Invoke the real MarkdownOutput (print-only) — just verifies no panic
         let md = MarkdownOutput::new(&serde_json::json!({}));
-        md.table("T", &["ID", "NAME"], &[vec!["a".to_string(), "b".to_string()]]);
+        md.table(
+            "T",
+            &["ID", "NAME"],
+            &[vec!["a".to_string(), "b".to_string()]],
+        );
     }
 
     #[test]

--- a/src/utils/ui/backends/plain.rs
+++ b/src/utils/ui/backends/plain.rs
@@ -25,15 +25,23 @@ impl Ui for PlainOutput {
                 }
             }
         }
-        let header_line: String = headers.iter().zip(widths.iter())
+        let header_line: String = headers
+            .iter()
+            .zip(widths.iter())
             .map(|(h, w)| format!("{:<width$}", h, width = w))
             .collect::<Vec<_>>()
             .join("  ");
         println!("{}", header_line);
-        let sep: String = widths.iter().map(|w| "-".repeat(*w)).collect::<Vec<_>>().join("  ");
+        let sep: String = widths
+            .iter()
+            .map(|w| "-".repeat(*w))
+            .collect::<Vec<_>>()
+            .join("  ");
         println!("{}", sep);
         for row in rows {
-            let line: String = row.iter().zip(widths.iter())
+            let line: String = row
+                .iter()
+                .zip(widths.iter())
                 .map(|(c, w)| format!("{:<width$}", c, width = w))
                 .collect::<Vec<_>>()
                 .join("  ");
@@ -58,11 +66,21 @@ impl Ui for PlainOutput {
         }
     }
 
-    fn info(&self, msg: &str)  { println!("{}", msg); }
-    fn warn(&self, msg: &str)  { println!("Warning: {}", msg); }
-    fn error(&self, msg: &str) { eprintln!("Error: {}", msg); }
+    fn info(&self, msg: &str) {
+        println!("{}", msg);
+    }
+    fn warn(&self, msg: &str) {
+        println!("Warning: {}", msg);
+    }
+    fn error(&self, msg: &str) {
+        eprintln!("Error: {}", msg);
+    }
 
-    fn pull_start(&self, label: &str, total_bytes: Option<u64>) -> crate::utils::ui::base::PullHandle {
+    fn pull_start(
+        &self,
+        label: &str,
+        total_bytes: Option<u64>,
+    ) -> crate::utils::ui::base::PullHandle {
         match total_bytes {
             Some(total) => println!("Pulling {} ({} bytes total)...", label, total),
             None => println!("Pulling {}...", label),
@@ -70,17 +88,28 @@ impl Ui for PlainOutput {
         crate::utils::ui::base::PullHandle(0)
     }
 
-    fn pull_progress(&self, _handle: crate::utils::ui::base::PullHandle, downloaded_bytes: u64, total_bytes: Option<u64>) {
+    fn pull_progress(
+        &self,
+        _handle: crate::utils::ui::base::PullHandle,
+        downloaded_bytes: u64,
+        total_bytes: Option<u64>,
+    ) {
         match total_bytes {
             Some(total) if total > 0 => {
-                let pct = ((downloaded_bytes as f64 / total as f64) * 100.0).clamp(0.0, 100.0) as u32;
+                let pct =
+                    ((downloaded_bytes as f64 / total as f64) * 100.0).clamp(0.0, 100.0) as u32;
                 println!("  {}%", pct);
             }
             _ => println!("  {} bytes", downloaded_bytes),
         }
     }
 
-    fn pull_finish(&self, _handle: crate::utils::ui::base::PullHandle, label: &str, error: Option<&str>) {
+    fn pull_finish(
+        &self,
+        _handle: crate::utils::ui::base::PullHandle,
+        label: &str,
+        error: Option<&str>,
+    ) {
         match error {
             Some(e) => println!("{}: failed: {}", label, e),
             None => println!("{}: done", label),

--- a/src/utils/ui/backends/terminal.rs
+++ b/src/utils/ui/backends/terminal.rs
@@ -341,7 +341,7 @@ fn visible_len(s: &str) -> usize {
             }
             while i < bytes.len() {
                 let b = bytes[i];
-                if (b >= 0x41 && b <= 0x5A) || (b >= 0x61 && b <= 0x7A) {
+                if (0x41..=0x5A).contains(&b) || (0x61..=0x7A).contains(&b) {
                     i += 1;
                     break;
                 }
@@ -372,7 +372,7 @@ fn split_cell_ansi(s: &str) -> (&str, &str, &str) {
             }
             while i < bytes.len() {
                 let b = bytes[i];
-                if (b >= 0x41 && b <= 0x5A) || (b >= 0x61 && b <= 0x7A) {
+                if (0x41..=0x5A).contains(&b) || (0x61..=0x7A).contains(&b) {
                     i += 1;
                     break;
                 }

--- a/src/utils/ui/backends/terminal.rs
+++ b/src/utils/ui/backends/terminal.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
-use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Mutex;
+use std::sync::atomic::{AtomicU64, Ordering};
 
 use crossterm::style::{Attribute, Color, ResetColor, SetAttribute, SetForegroundColor};
 use indicatif::{ProgressBar, ProgressStyle};
@@ -89,8 +89,17 @@ impl Ui for TerminalOutput {
         );
 
         // 5. Render separator (unchanged)
-        let sep: String = widths.iter().map(|w| "─".repeat(*w)).collect::<Vec<_>>().join("  ");
-        println!("{}{}{}", SetForegroundColor(Color::DarkGrey), sep, ResetColor);
+        let sep: String = widths
+            .iter()
+            .map(|w| "─".repeat(*w))
+            .collect::<Vec<_>>()
+            .join("  ");
+        println!(
+            "{}{}{}",
+            SetForegroundColor(Color::DarkGrey),
+            sep,
+            ResetColor
+        );
 
         // 6. Render rows with wrapping
         render_rows_with_wrapping(rows, &widths);
@@ -132,7 +141,13 @@ impl Ui for TerminalOutput {
             ("✗", Color::Red)
         };
         if detail.is_empty() {
-            println!("  {}{}{}  {}", SetForegroundColor(colour), mark, ResetColor, label);
+            println!(
+                "  {}{}{}  {}",
+                SetForegroundColor(colour),
+                mark,
+                ResetColor,
+                label
+            );
         } else {
             println!(
                 "  {}{}{}  {}  {}",
@@ -215,7 +230,12 @@ impl Ui for TerminalOutput {
         if !self.is_tty {
             return PlainOutput.detail_mark(msg);
         }
-        format!("{}{}{}", SetForegroundColor(Color::DarkGrey), msg, ResetColor)
+        format!(
+            "{}{}{}",
+            SetForegroundColor(Color::DarkGrey),
+            msg,
+            ResetColor
+        )
     }
 
     fn pull_start(&self, label: &str, total_bytes: Option<u64>) -> PullHandle {
@@ -370,7 +390,11 @@ fn split_cell_ansi(s: &str) -> (&str, &str, &str) {
         suffix_start = prefix_end + s[prefix_end..].len() - 4;
     }
 
-    (&s[..prefix_end], &s[prefix_end..suffix_start], &s[suffix_start..])
+    (
+        &s[..prefix_end],
+        &s[prefix_end..suffix_start],
+        &s[suffix_start..],
+    )
 }
 
 /// Wrap a cell string with ANSI awareness, optionally applying grey row styling.
@@ -599,10 +623,7 @@ mod tests {
 
     #[test]
     fn wrap_text_at_hyphen() {
-        assert_eq!(
-            wrap_text("granite-3.0-8b", 12),
-            vec!["granite-3.0-", "8b"]
-        );
+        assert_eq!(wrap_text("granite-3.0-8b", 12), vec!["granite-3.0-", "8b"]);
     }
 
     #[test]
@@ -612,10 +633,7 @@ mod tests {
 
     #[test]
     fn wrap_text_character_wrap_long_word() {
-        assert_eq!(
-            wrap_text("verylongword", 6),
-            vec!["verylo", "ngword"]
-        );
+        assert_eq!(wrap_text("verylongword", 6), vec!["verylo", "ngword"]);
     }
 
     #[test]

--- a/src/utils/ui/base.rs
+++ b/src/utils/ui/base.rs
@@ -5,6 +5,15 @@ use crate::registry::ConfigConstructable;
 
 /*-- public --*/
 
+/// A single row of string cells in a table.
+pub type TableRow = Vec<String>;
+/// A captured table: `(title, headers, rows)`.
+pub type TableEntry = (String, Vec<String>, Vec<TableRow>);
+/// A single key-value field in a detail view.
+pub type DetailField = (String, String);
+/// A captured detail view: `(title, fields)`.
+pub type DetailEntry = (String, Vec<DetailField>);
+
 /// Metadata describing a registered UI backend.
 #[derive(Debug, Clone)]
 pub struct UiMetadata {
@@ -228,9 +237,9 @@ pub(crate) mod tests {
     #[derive(Default)]
     pub struct CaptureUi {
         /// (title, headers, rows) for each table() call
-        pub tables: RefCell<Vec<(String, Vec<String>, Vec<Vec<String>>)>>,
+        pub tables: RefCell<Vec<TableEntry>>,
         /// (title, fields) for each detail() call
-        pub details: RefCell<Vec<(String, Vec<(String, String)>)>>,
+        pub details: RefCell<Vec<DetailEntry>>,
         /// (label, ok, detail) for each status() call
         pub statuses: RefCell<Vec<(String, bool, String)>>,
         pub infos: RefCell<Vec<String>>,

--- a/src/utils/ui/base.rs
+++ b/src/utils/ui/base.rs
@@ -35,7 +35,9 @@ pub static UI_REGISTRY: LazyLock<UiFactory> = LazyLock::new(|| {
 /// Shared error for backends (json, markdown) that render for scripting/docs
 /// rather than a live session, and so can't sensibly block on interactive input.
 pub(crate) fn non_interactive<T>() -> anyhow::Result<T> {
-    anyhow::bail!("interactive prompts are not supported with this output format; rerun with --output=terminal or --output=plain")
+    anyhow::bail!(
+        "interactive prompts are not supported with this output format; rerun with --output=terminal or --output=plain"
+    )
 }
 
 /// Generates panic-safety contract tests for any [`Ui`] implementation.
@@ -285,7 +287,10 @@ pub(crate) mod tests {
         fn detail(&self, title: &str, fields: &[(&str, String)]) {
             self.details.borrow_mut().push((
                 title.to_string(),
-                fields.iter().map(|(k, v)| (k.to_string(), v.clone())).collect(),
+                fields
+                    .iter()
+                    .map(|(k, v)| (k.to_string(), v.clone()))
+                    .collect(),
             ));
         }
 
@@ -308,19 +313,32 @@ pub(crate) mod tests {
         }
 
         fn pull_start(&self, label: &str, total_bytes: Option<u64>) -> PullHandle {
-            self.pull_starts.borrow_mut().push((label.to_string(), total_bytes));
+            self.pull_starts
+                .borrow_mut()
+                .push((label.to_string(), total_bytes));
             let mut next = self.next_pull_handle.borrow_mut();
             let handle = PullHandle(*next);
             *next += 1;
             handle
         }
 
-        fn pull_progress(&self, handle: PullHandle, downloaded_bytes: u64, total_bytes: Option<u64>) {
-            self.pull_progresses.borrow_mut().push((handle, downloaded_bytes, total_bytes));
+        fn pull_progress(
+            &self,
+            handle: PullHandle,
+            downloaded_bytes: u64,
+            total_bytes: Option<u64>,
+        ) {
+            self.pull_progresses
+                .borrow_mut()
+                .push((handle, downloaded_bytes, total_bytes));
         }
 
         fn pull_finish(&self, handle: PullHandle, label: &str, error: Option<&str>) {
-            self.pull_finishes.borrow_mut().push((handle, label.to_string(), error.map(|e| e.to_string())));
+            self.pull_finishes.borrow_mut().push((
+                handle,
+                label.to_string(),
+                error.map(|e| e.to_string()),
+            ));
         }
 
         fn ok(&self, msg: &str) -> String {
@@ -344,23 +362,45 @@ pub(crate) mod tests {
         }
 
         fn select(&self, prompt: &str, items: &[String], default: usize) -> anyhow::Result<usize> {
-            self.select_prompts.borrow_mut().push((prompt.to_string(), items.to_vec(), default));
-            Ok(self.select_answers.borrow_mut().pop_front().unwrap_or(default))
+            self.select_prompts
+                .borrow_mut()
+                .push((prompt.to_string(), items.to_vec(), default));
+            Ok(self
+                .select_answers
+                .borrow_mut()
+                .pop_front()
+                .unwrap_or(default))
         }
 
         fn confirm(&self, prompt: &str, default: bool) -> anyhow::Result<bool> {
-            self.confirm_prompts.borrow_mut().push((prompt.to_string(), default));
-            Ok(self.confirm_answers.borrow_mut().pop_front().unwrap_or(default))
+            self.confirm_prompts
+                .borrow_mut()
+                .push((prompt.to_string(), default));
+            Ok(self
+                .confirm_answers
+                .borrow_mut()
+                .pop_front()
+                .unwrap_or(default))
         }
 
         fn text(&self, prompt: &str, default: &str) -> anyhow::Result<String> {
-            self.text_prompts.borrow_mut().push((prompt.to_string(), default.to_string()));
-            Ok(self.text_answers.borrow_mut().pop_front().unwrap_or_else(|| default.to_string()))
+            self.text_prompts
+                .borrow_mut()
+                .push((prompt.to_string(), default.to_string()));
+            Ok(self
+                .text_answers
+                .borrow_mut()
+                .pop_front()
+                .unwrap_or_else(|| default.to_string()))
         }
 
         fn password(&self, prompt: &str) -> anyhow::Result<String> {
             self.password_prompts.borrow_mut().push(prompt.to_string());
-            Ok(self.password_answers.borrow_mut().pop_front().unwrap_or_default())
+            Ok(self
+                .password_answers
+                .borrow_mut()
+                .pop_front()
+                .unwrap_or_default())
         }
     }
 
@@ -370,7 +410,6 @@ pub(crate) mod tests {
     // capture across threads, which is always true in practice.
     unsafe impl Send for CaptureUi {}
     unsafe impl Sync for CaptureUi {}
-
 
     // -- UiFactory registry ------------------------------------------------
 
@@ -453,7 +492,10 @@ pub(crate) mod tests {
     #[test]
     fn capture_records_detail_title_and_field_pairs() {
         let out = make();
-        out.detail("Item", &[("Key", "Value".to_string()), ("Foo", "Bar".to_string())]);
+        out.detail(
+            "Item",
+            &[("Key", "Value".to_string()), ("Foo", "Bar".to_string())],
+        );
         let details = out.details.borrow();
         assert_eq!(details.len(), 1);
         let (title, fields) = &details[0];
@@ -492,8 +534,18 @@ pub(crate) mod tests {
         out.status("provider-a", true, "");
         out.status("provider-b", false, "connection refused");
         let statuses = out.statuses.borrow();
-        assert_eq!(statuses[0], ("provider-a".to_string(), true, "".to_string()));
-        assert_eq!(statuses[1], ("provider-b".to_string(), false, "connection refused".to_string()));
+        assert_eq!(
+            statuses[0],
+            ("provider-a".to_string(), true, "".to_string())
+        );
+        assert_eq!(
+            statuses[1],
+            (
+                "provider-b".to_string(),
+                false,
+                "connection refused".to_string()
+            )
+        );
     }
 
     // -- CaptureUi input methods -------------------------------------------
@@ -501,7 +553,9 @@ pub(crate) mod tests {
     #[test]
     fn select_falls_back_to_default_when_no_canned_answer() {
         let ui = make();
-        let choice = ui.select("Pick one", &["a".to_string(), "b".to_string()], 1).unwrap();
+        let choice = ui
+            .select("Pick one", &["a".to_string(), "b".to_string()], 1)
+            .unwrap();
         assert_eq!(choice, 1);
         assert_eq!(ui.select_prompts.borrow()[0].0, "Pick one");
     }
@@ -549,7 +603,9 @@ pub(crate) mod tests {
     #[test]
     fn password_consumes_canned_answer() {
         let ui = make();
-        ui.password_answers.borrow_mut().push_back("s3cr3t".to_string());
+        ui.password_answers
+            .borrow_mut()
+            .push_back("s3cr3t".to_string());
         assert_eq!(ui.password("Secret?").unwrap(), "s3cr3t");
     }
 
@@ -566,12 +622,21 @@ pub(crate) mod tests {
         ui.pull_finish(h1, "model-a", None);
         ui.pull_finish(h2, "model-b", Some("boom"));
 
-        assert_eq!(*ui.pull_starts.borrow(), vec![
-            ("model-a".to_string(), Some(100)),
-            ("model-b".to_string(), None),
-        ]);
+        assert_eq!(
+            *ui.pull_starts.borrow(),
+            vec![
+                ("model-a".to_string(), Some(100)),
+                ("model-b".to_string(), None),
+            ]
+        );
         assert_eq!(*ui.pull_progresses.borrow(), vec![(h1, 50, Some(100))]);
-        assert_eq!(ui.pull_finishes.borrow()[0], (h1, "model-a".to_string(), None));
-        assert_eq!(ui.pull_finishes.borrow()[1], (h2, "model-b".to_string(), Some("boom".to_string())));
+        assert_eq!(
+            ui.pull_finishes.borrow()[0],
+            (h1, "model-a".to_string(), None)
+        );
+        assert_eq!(
+            ui.pull_finishes.borrow()[1],
+            (h2, "model-b".to_string(), Some("boom".to_string()))
+        );
     }
 }

--- a/src/utils/ui/base.rs
+++ b/src/utils/ui/base.rs
@@ -571,14 +571,14 @@ pub(crate) mod tests {
     #[test]
     fn confirm_falls_back_to_default_when_no_canned_answer() {
         let ui = make();
-        assert_eq!(ui.confirm("Sure?", true).unwrap(), true);
+        assert!(ui.confirm("Sure?", true).unwrap());
     }
 
     #[test]
     fn confirm_consumes_canned_answer() {
         let ui = make();
         ui.confirm_answers.borrow_mut().push_back(false);
-        assert_eq!(ui.confirm("Sure?", true).unwrap(), false);
+        assert!(!ui.confirm("Sure?", true).unwrap());
     }
 
     #[test]

--- a/src/utils/ui/mod.rs
+++ b/src/utils/ui/mod.rs
@@ -5,5 +5,5 @@ pub mod prompt;
 pub mod tui;
 
 pub use app::run_interactive_tui;
-pub use base::{Ui, UI_REGISTRY};
+pub use base::{UI_REGISTRY, Ui};
 pub use prompt::prompt_from_schema;

--- a/src/utils/ui/prompt.rs
+++ b/src/utils/ui/prompt.rs
@@ -9,14 +9,25 @@ use crate::utils::ui::Ui;
 /// arrays (indented), and masks input for fields whose schema is marked
 /// `"format": "password"` (see `registry::Secret`) rather than guessing from
 /// field names.
-pub fn prompt_from_schema(ui: &dyn Ui, schema: &schemars::Schema, defaults: &Value) -> anyhow::Result<Value> {
+pub fn prompt_from_schema(
+    ui: &dyn Ui,
+    schema: &schemars::Schema,
+    defaults: &Value,
+) -> anyhow::Result<Value> {
     let root = serde_json::to_value(schema)?;
     prompt_value(ui, &root, &root, defaults, "", "")
 }
 
 /*-- Recursive dispatch ---------------------------------------------------------*/
 
-fn prompt_value(ui: &dyn Ui, root: &Value, node: &Value, default: &Value, indent: &str, label: &str) -> anyhow::Result<Value> {
+fn prompt_value(
+    ui: &dyn Ui,
+    root: &Value,
+    node: &Value,
+    default: &Value,
+    indent: &str,
+    label: &str,
+) -> anyhow::Result<Value> {
     let node = resolve_ref(root, node);
     match node.get("type").and_then(Value::as_str) {
         Some("object") => prompt_object(ui, root, node, default, indent, label),
@@ -28,7 +39,14 @@ fn prompt_value(ui: &dyn Ui, root: &Value, node: &Value, default: &Value, indent
     }
 }
 
-fn prompt_object(ui: &dyn Ui, root: &Value, node: &Value, default: &Value, indent: &str, label: &str) -> anyhow::Result<Value> {
+fn prompt_object(
+    ui: &dyn Ui,
+    root: &Value,
+    node: &Value,
+    default: &Value,
+    indent: &str,
+    label: &str,
+) -> anyhow::Result<Value> {
     if !indent.is_empty() && !label.is_empty() {
         ui.info(&format!("{indent}{label}:"));
     }
@@ -52,7 +70,14 @@ fn prompt_object(ui: &dyn Ui, root: &Value, node: &Value, default: &Value, inden
     Ok(Value::Object(result))
 }
 
-fn prompt_array(ui: &dyn Ui, root: &Value, node: &Value, default: &Value, indent: &str, label: &str) -> anyhow::Result<Value> {
+fn prompt_array(
+    ui: &dyn Ui,
+    root: &Value,
+    node: &Value,
+    default: &Value,
+    indent: &str,
+    label: &str,
+) -> anyhow::Result<Value> {
     let Some(items_schema) = node.get("items").map(|v| resolve_ref(root, v)) else {
         return Ok(Value::Array(vec![]));
     };
@@ -78,13 +103,23 @@ fn prompt_array(ui: &dyn Ui, root: &Value, node: &Value, default: &Value, indent
 
 /*-- Leaf prompts ---------------------------------------------------------------*/
 
-fn prompt_string(ui: &dyn Ui, node: &Value, default: &Value, indent: &str, label: &str) -> anyhow::Result<Value> {
+fn prompt_string(
+    ui: &dyn Ui,
+    node: &Value,
+    default: &Value,
+    indent: &str,
+    label: &str,
+) -> anyhow::Result<Value> {
     let default_str = default.as_str().unwrap_or("").to_string();
     let prompt = format!("{indent}{label}");
 
     if is_secret_schema(node) {
         let entered = ui.password(&format!("{prompt} (leave blank to keep current)"))?;
-        let value = if entered.is_empty() { default_str } else { entered };
+        let value = if entered.is_empty() {
+            default_str
+        } else {
+            entered
+        };
         Ok(Value::String(value))
     } else {
         let entered = ui.text(&prompt, &default_str)?;
@@ -92,7 +127,13 @@ fn prompt_string(ui: &dyn Ui, node: &Value, default: &Value, indent: &str, label
     }
 }
 
-fn prompt_number(ui: &dyn Ui, node: &Value, default: &Value, indent: &str, label: &str) -> anyhow::Result<Value> {
+fn prompt_number(
+    ui: &dyn Ui,
+    node: &Value,
+    default: &Value,
+    indent: &str,
+    label: &str,
+) -> anyhow::Result<Value> {
     let is_integer = node.get("type").and_then(Value::as_str) == Some("integer");
     let default_str = default
         .as_number()
@@ -139,7 +180,12 @@ fn is_secret_schema(node: &Value) -> bool {
 fn is_promptable(node: &Value) -> bool {
     matches!(
         node.get("type").and_then(Value::as_str),
-        Some("object") | Some("array") | Some("string") | Some("integer") | Some("number") | Some("boolean")
+        Some("object")
+            | Some("array")
+            | Some("string")
+            | Some("integer")
+            | Some("number")
+            | Some("boolean")
     )
 }
 
@@ -205,10 +251,14 @@ mod tests {
 
     #[test]
     fn secret_format_is_detected_from_schema_not_field_name() {
-        assert!(is_secret_schema(&json!({"type": "string", "format": "password"})));
+        assert!(is_secret_schema(
+            &json!({"type": "string", "format": "password"})
+        ));
         assert!(!is_secret_schema(&json!({"type": "string"})));
         // A field literally named "api_key" with no format marker is NOT a secret.
-        assert!(!is_secret_schema(&json!({"type": "string", "title": "api_key"})));
+        assert!(!is_secret_schema(
+            &json!({"type": "string", "title": "api_key"})
+        ));
     }
 
     #[test]


### PR DESCRIPTION
## Description

This PR runs `fmt` and `clippy` and fixes the associated issues.

NOTE: There are still two warnings with `lint.sh` that will need further investigation, so `lint.sh` is not ready for CI _quite_ yet:

```
error: very complex type used. Consider factoring parts into `type` definitions
   --> src/utils/ui/base.rs:231:21
    |
231 |         pub tables: RefCell<Vec<(String, Vec<String>, Vec<Vec<String>>)>>,
    |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/rust-1.97.0/index.html#type_complexity
    = note: `-D clippy::type-complexity` implied by `-D warnings`
    = help: to override `-D warnings` add `#[allow(clippy::type_complexity)]`

error: very complex type used. Consider factoring parts into `type` definitions
   --> src/utils/ui/base.rs:233:22
    |
233 |         pub details: RefCell<Vec<(String, Vec<(String, String)>)>>,
    |                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/rust-1.97.0/index.html#type_complexity

error: could not compile `granite-cli` (bin "granite-cli" test) due to 2 previous errors
```