### PR TITLE
feat: Add "remove" subommand for model, provider, and capability

### DIFF
--- a/src/commands/capability.rs
+++ b/src/commands/capability.rs
@@ -214,6 +214,25 @@ impl CapabilityCommands {
         }
     }
 
+    /// Remove a configured capability instance by ID.
+    ///
+    /// Deletes the capability's config file and removes it from the
+    /// in-memory config. After this call `capability list` will no longer
+    /// show the entry.
+    pub fn remove(ctx: &mut crate::AppContext, capability_id: &str) -> Result<()> {
+        if ctx.config.get_capability(capability_id).is_none() {
+            anyhow::bail!("No capability configured with id '{capability_id}'. Nothing to remove.");
+        }
+
+        if let Err(e) = ctx.config.remove_capability(capability_id) {
+            ctx.ui
+                .warn(&format!("failed to persist capability removal: {e}"));
+        }
+        ctx.ui
+            .info(&format!("Capability '{capability_id}' removed."));
+        Ok(())
+    }
+
     // TODO: Use generic dependency checking
     // fn check_dep_status(ctx: &crate::AppContext, dep: &crate::registry::CapabilityDependency) -> &'static str {
     //     match dep {
@@ -314,6 +333,16 @@ mod tests {
         };
     }
 
+    macro_rules! infos {
+        ($ctx:expr) => {
+            (&*($ctx.ui) as &dyn std::any::Any)
+                .downcast_ref::<CaptureUi>()
+                .unwrap()
+                .infos
+                .borrow()
+        };
+    }
+
     // -- catalog --------------------------------------------------------------
 
     #[test]
@@ -364,5 +393,46 @@ mod tests {
         let result = CapabilityCommands::info(&ctx, "custom-cap");
         assert!(result.is_ok());
         assert!(!details!(ctx).is_empty());
+    }
+
+    // -- remove -----------------------------------------------------------------
+
+    #[test]
+    fn remove_existing_capability_succeeds_and_disappears_from_list() {
+        let mut ctx = ctx_with_capability("my-cap");
+        assert!(ctx.config.get_capability("my-cap").is_some());
+
+        CapabilityCommands::remove(&mut ctx, "my-cap").unwrap();
+
+        assert!(ctx.config.get_capability("my-cap").is_none());
+        let infos = infos!(ctx);
+        assert!(
+            infos
+                .iter()
+                .any(|m| m.contains("my-cap") && m.contains("removed"))
+        );
+    }
+
+    #[test]
+    fn remove_nonexistent_capability_returns_err() {
+        let mut ctx = test_ctx();
+        let result = CapabilityCommands::remove(&mut ctx, "doesnt-exist");
+        assert!(result.is_err());
+        assert!(
+            result
+                .unwrap_err()
+                .to_string()
+                .contains("Nothing to remove")
+        );
+    }
+
+    #[test]
+    fn list_does_not_show_removed_capability() {
+        let mut ctx = ctx_with_capability("my-cap");
+        CapabilityCommands::remove(&mut ctx, "my-cap").unwrap();
+        CapabilityCommands::list(&ctx).unwrap();
+        let tables = tables!(ctx);
+        let (_, _, rows) = &tables[0];
+        assert!(rows.is_empty());
     }
 }

--- a/src/commands/model.rs
+++ b/src/commands/model.rs
@@ -670,6 +670,23 @@ impl ModelCommands {
         Ok(())
     }
 
+    /// Remove a configured model instance by ID.
+    ///
+    /// Deletes the model's config file and removes it from the in-memory
+    /// config. After this call `model list` will no longer show the entry.
+    pub fn remove(ctx: &mut crate::AppContext, model_id: &str) -> Result<()> {
+        if ctx.config.get_model(model_id).is_none() {
+            anyhow::bail!("No model configured with id '{model_id}'. Nothing to remove.");
+        }
+
+        if let Err(e) = ctx.config.remove_model(model_id) {
+            ctx.ui
+                .warn(&format!("failed to persist model removal: {e}"));
+        }
+        ctx.ui.info(&format!("Model '{model_id}' removed."));
+        Ok(())
+    }
+
     /// Resolve which provider instance to use for a model variant, prompting
     /// to configure a new one (with its own instance nickname, distinct from
     /// its catalog type) when no existing instance satisfies it.
@@ -1447,5 +1464,46 @@ mod tests {
             .warns
             .borrow();
         assert!(!warns.is_empty());
+    }
+
+    // -- remove -------------------------------------------------------------
+
+    #[test]
+    fn remove_existing_model_succeeds_and_disappears_from_list() {
+        let mut ctx = ctx_with_model("granite-3.1-8b-instruct", Some("my-ollama"));
+        assert!(ctx.config.get_model("granite-3.1-8b-instruct").is_some());
+
+        ModelCommands::remove(&mut ctx, "granite-3.1-8b-instruct").unwrap();
+
+        assert!(ctx.config.get_model("granite-3.1-8b-instruct").is_none());
+        let infos = infos!(ctx);
+        assert!(
+            infos
+                .iter()
+                .any(|m| m.contains("granite-3.1-8b-instruct") && m.contains("removed"))
+        );
+    }
+
+    #[test]
+    fn remove_nonexistent_model_returns_err() {
+        let mut ctx = empty_ctx();
+        let result = ModelCommands::remove(&mut ctx, "doesnt-exist");
+        assert!(result.is_err());
+        assert!(
+            result
+                .unwrap_err()
+                .to_string()
+                .contains("Nothing to remove")
+        );
+    }
+
+    #[test]
+    fn list_does_not_show_removed_model() {
+        let mut ctx = ctx_with_model("granite-3.1-8b-instruct", Some("my-ollama"));
+        ModelCommands::remove(&mut ctx, "granite-3.1-8b-instruct").unwrap();
+        ModelCommands::list(&ctx, None).unwrap();
+        let tables = tables!(ctx);
+        let (_, _, rows) = &tables[0];
+        assert!(rows.is_empty());
     }
 }

--- a/src/commands/provider.rs
+++ b/src/commands/provider.rs
@@ -208,6 +208,23 @@ impl ProviderCommands {
         Ok(())
     }
 
+    /// Remove a configured provider instance by ID.
+    ///
+    /// Deletes the provider's config file and removes it from the in-memory
+    /// config. After this call `provider list` will no longer show the entry.
+    pub fn remove(ctx: &mut crate::AppContext, provider_id: &str) -> Result<()> {
+        if ctx.config.get_provider(provider_id).is_none() {
+            anyhow::bail!("No provider configured with id '{provider_id}'. Nothing to remove.");
+        }
+
+        if let Err(e) = ctx.config.remove_provider(provider_id) {
+            ctx.ui
+                .warn(&format!("failed to persist provider removal: {e}"));
+        }
+        ctx.ui.info(&format!("Provider '{provider_id}' removed."));
+        Ok(())
+    }
+
     async fn check_provider_health(
         ctx: &crate::AppContext,
         provider_id: &str,
@@ -374,5 +391,46 @@ mod tests {
         ProviderCommands::health(&mut ctx, None).await.unwrap();
         assert!(!infos!(ctx).is_empty());
         assert!(statuses!(ctx).is_empty());
+    }
+
+    // -- remove -----------------------------------------------------------------
+
+    #[test]
+    fn remove_existing_provider_succeeds_and_disappears_from_list() {
+        let mut ctx = ctx_with_provider("my-ollama", "http://localhost:11434");
+        assert!(ctx.config.get_provider("my-ollama").is_some());
+
+        ProviderCommands::remove(&mut ctx, "my-ollama").unwrap();
+
+        assert!(ctx.config.get_provider("my-ollama").is_none());
+        let infos = infos!(ctx);
+        assert!(
+            infos
+                .iter()
+                .any(|m| m.contains("my-ollama") && m.contains("removed"))
+        );
+    }
+
+    #[test]
+    fn remove_nonexistent_provider_returns_err() {
+        let mut ctx = test_ctx();
+        let result = ProviderCommands::remove(&mut ctx, "doesnt-exist");
+        assert!(result.is_err());
+        assert!(
+            result
+                .unwrap_err()
+                .to_string()
+                .contains("Nothing to remove")
+        );
+    }
+
+    #[test]
+    fn list_does_not_show_removed_provider() {
+        let mut ctx = ctx_with_provider("my-ollama", "http://localhost:11434");
+        ProviderCommands::remove(&mut ctx, "my-ollama").unwrap();
+        ProviderCommands::list(&ctx).unwrap();
+        let tables = tables!(ctx);
+        let (_, _, rows) = &tables[0];
+        assert!(rows.is_empty());
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -183,6 +183,12 @@ enum ModelSubcommands {
         /// Model ID to pull
         model_id: String,
     },
+
+    /// Remove a configured model instance
+    Remove {
+        /// Configured model ID to remove
+        model_id: String,
+    },
 }
 
 #[derive(Subcommand, Debug)]
@@ -202,6 +208,12 @@ enum CapabilitySubcommands {
     /// Set up a capability
     Setup {
         /// Capability ID to set up
+        capability_id: String,
+    },
+
+    /// Remove a configured capability instance
+    Remove {
+        /// Configured capability ID to remove
         capability_id: String,
     },
 }
@@ -230,6 +242,12 @@ enum ProviderSubcommands {
     Health {
         /// Provider ID (optional, checks all if not specified)
         provider_id: Option<String>,
+    },
+
+    /// Remove a configured provider instance
+    Remove {
+        /// Configured provider instance ID to remove
+        provider_id: String,
     },
 }
 
@@ -419,6 +437,7 @@ async fn run_model_command(ctx: &mut AppContext, subcmd: ModelSubcommands) -> an
         ModelSubcommands::Info { model_id } => ModelCommands::info(ctx, &model_id),
         ModelSubcommands::Setup { model_id } => ModelCommands::setup(ctx, &model_id).await,
         ModelSubcommands::Pull { model_id } => ModelCommands::pull(ctx, &model_id).await,
+        ModelSubcommands::Remove { model_id } => ModelCommands::remove(ctx, &model_id),
     }
 }
 
@@ -434,6 +453,9 @@ async fn run_capability_command(
         }
         CapabilitySubcommands::Setup { capability_id } => {
             CapabilityCommands::setup(ctx, &capability_id).await
+        }
+        CapabilitySubcommands::Remove { capability_id } => {
+            CapabilityCommands::remove(ctx, &capability_id)
         }
     }
 }
@@ -452,6 +474,7 @@ async fn run_provider_command(
         ProviderSubcommands::Health { provider_id } => {
             ProviderCommands::health(ctx, provider_id.as_deref()).await
         }
+        ProviderSubcommands::Remove { provider_id } => ProviderCommands::remove(ctx, &provider_id),
     }
 }
 


### PR DESCRIPTION
## Description

Closes #38 

This PR adds `granite-cli <type> remove <inst_id>` for `model`, `provider`, and `capability` to remove configured instances.