### PR TITLE
Logging framework

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,6 +12,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "alchemy-logging"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d857cd0568ebd4359b0bd6decf135d23f2d86ef4db3efbdd9b38b9fb6e2d9329"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "allocator-api2"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -817,6 +827,7 @@ dependencies = [
 name = "granite-cli"
 version = "0.0.0"
 dependencies = [
+ "alchemy-logging",
  "anyhow",
  "async-trait",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ readme = "README.md"
 description = "CLI for discovering, configuring, and launching AI workflows powered by IBM Granite models."
 
 [dependencies]
+alchemy-logging = "0.1"
 clap = { version = "4", features = ["derive"] }
 serde = { version = "1", features = ["derive"] }
 serde_yaml = "0.9"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ description = "CLI for discovering, configuring, and launching AI workflows powe
 
 [dependencies]
 alchemy-logging = "0.1"
-clap = { version = "4", features = ["derive"] }
+clap = { version = "4", features = ["derive", "env"] }
 serde = { version = "1", features = ["derive"] }
 serde_yaml = "0.9"
 serde_json = "1"

--- a/src/commands/capability.rs
+++ b/src/commands/capability.rs
@@ -291,16 +291,16 @@ impl CapabilityCommands {
 #[cfg(test)]
 mod tests {
     use super::*;
-use crate::config::{CapabilityConfig, Config};
-use crate::utils::ui::base::tests::CaptureUi;
-use std::sync::Arc;
+    use crate::config::{CapabilityConfig, Config};
+    use crate::utils::ui::base::tests::CaptureUi;
+    use std::sync::Arc;
 
-fn test_ctx() -> crate::AppContext {
-    crate::AppContext {
-        config: Config::default(),
-        ui: Arc::new(CaptureUi::default()),
+    fn test_ctx() -> crate::AppContext {
+        crate::AppContext {
+            config: Config::default(),
+            ui: Arc::new(CaptureUi::default()),
+        }
     }
-}
 
     fn ctx_with_capability(id: &str) -> crate::AppContext {
         let mut ctx = test_ctx();

--- a/src/commands/capability.rs
+++ b/src/commands/capability.rs
@@ -291,15 +291,16 @@ impl CapabilityCommands {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::config::{CapabilityConfig, Config};
-    use crate::utils::ui::base::tests::CaptureUi;
+use crate::config::{CapabilityConfig, Config};
+use crate::utils::ui::base::tests::CaptureUi;
+use std::sync::Arc;
 
-    fn test_ctx() -> crate::AppContext {
-        crate::AppContext {
-            config: Config::default(),
-            ui: Box::new(CaptureUi::default()),
-        }
+fn test_ctx() -> crate::AppContext {
+    crate::AppContext {
+        config: Config::default(),
+        ui: Arc::new(CaptureUi::default()),
     }
+}
 
     fn ctx_with_capability(id: &str) -> crate::AppContext {
         let mut ctx = test_ctx();

--- a/src/commands/hardware.rs
+++ b/src/commands/hardware.rs
@@ -44,6 +44,7 @@ impl HardwareCommands {
 mod tests {
     use super::*;
     use crate::utils::ui::base::tests::CaptureUi;
+    use std::sync::Arc;
 
     fn ctx() -> crate::AppContext {
         crate::AppContext {

--- a/src/commands/hardware.rs
+++ b/src/commands/hardware.rs
@@ -1,6 +1,7 @@
 // Local
 use crate::utils::hardware::detect_hardware;
 use anyhow::Result;
+use std::sync::Arc;
 
 pub struct HardwareCommands;
 
@@ -48,7 +49,7 @@ mod tests {
     fn ctx() -> crate::AppContext {
         crate::AppContext {
             config: crate::config::Config::default(),
-            ui: Box::new(CaptureUi::default()),
+            ui: Arc::new(CaptureUi::default()),
         }
     }
 

--- a/src/commands/hardware.rs
+++ b/src/commands/hardware.rs
@@ -1,7 +1,6 @@
 // Local
 use crate::utils::hardware::detect_hardware;
 use anyhow::Result;
-use std::sync::Arc;
 
 pub struct HardwareCommands;
 

--- a/src/commands/launcher.rs
+++ b/src/commands/launcher.rs
@@ -251,6 +251,7 @@ mod tests {
     use super::*;
     use crate::config::{Config, LauncherConfig};
     use crate::utils::ui::base::tests::CaptureUi;
+    use std::sync::Arc;
 
     fn test_ctx() -> crate::AppContext {
         crate::AppContext {

--- a/src/commands/launcher.rs
+++ b/src/commands/launcher.rs
@@ -1,6 +1,5 @@
 // Third Party
 use anyhow::Result;
-use std::sync::Arc;
 
 // Local
 use crate::launchers::LAUNCHER_REGISTRY;

--- a/src/commands/launcher.rs
+++ b/src/commands/launcher.rs
@@ -1,5 +1,6 @@
 // Third Party
 use anyhow::Result;
+use std::sync::Arc;
 
 // Local
 use crate::launchers::LAUNCHER_REGISTRY;
@@ -255,7 +256,7 @@ mod tests {
     fn test_ctx() -> crate::AppContext {
         crate::AppContext {
             config: Config::default(),
-            ui: Box::new(CaptureUi::default()),
+            ui: Arc::new(CaptureUi::default()),
         }
     }
 

--- a/src/commands/model.rs
+++ b/src/commands/model.rs
@@ -11,7 +11,6 @@ use crate::providers::{
 use crate::utils::Searchable;
 use crate::utils::hardware::detect_hardware;
 use crate::utils::ui::Ui;
-use std::sync::Arc;
 
 /// Compare semantic versions in descending order (higher versions first).
 /// Handles versions like "3.1", "4.0", "3.0.1".

--- a/src/commands/model.rs
+++ b/src/commands/model.rs
@@ -763,6 +763,7 @@ mod tests {
     use crate::providers::{ModelFormat, ProviderType};
     use crate::registry::ConfigConstructable;
     use crate::utils::ui::base::tests::CaptureUi;
+    use std::sync::Arc;
 
     fn empty_ctx() -> crate::AppContext {
         crate::AppContext {

--- a/src/commands/model.rs
+++ b/src/commands/model.rs
@@ -11,6 +11,7 @@ use crate::providers::{
 use crate::utils::Searchable;
 use crate::utils::hardware::detect_hardware;
 use crate::utils::ui::Ui;
+use std::sync::Arc;
 
 /// Compare semantic versions in descending order (higher versions first).
 /// Handles versions like "3.1", "4.0", "3.0.1".
@@ -767,7 +768,7 @@ mod tests {
     fn empty_ctx() -> crate::AppContext {
         crate::AppContext {
             config: Config::default(),
-            ui: Box::new(CaptureUi::default()),
+            ui: Arc::new(CaptureUi::default()),
         }
     }
 
@@ -1170,7 +1171,7 @@ mod tests {
     fn ctx_with_config(config: Config) -> crate::AppContext {
         crate::AppContext {
             config,
-            ui: Box::new(CaptureUi::default()),
+            ui: Arc::new(CaptureUi::default()),
         }
     }
 

--- a/src/commands/provider.rs
+++ b/src/commands/provider.rs
@@ -250,6 +250,7 @@ mod tests {
     use super::*;
     use crate::config::{Config, ProviderConfig};
     use crate::utils::ui::base::tests::CaptureUi;
+    use std::sync::Arc;
 
     fn test_ctx() -> crate::AppContext {
         crate::AppContext {

--- a/src/commands/provider.rs
+++ b/src/commands/provider.rs
@@ -1,6 +1,5 @@
 // Third Party
 use anyhow::Result;
-use std::sync::Arc;
 
 // Local
 use crate::providers::{HealthStatus, PROVIDER_REGISTRY};

--- a/src/commands/provider.rs
+++ b/src/commands/provider.rs
@@ -1,5 +1,6 @@
 // Third Party
 use anyhow::Result;
+use std::sync::Arc;
 
 // Local
 use crate::providers::{HealthStatus, PROVIDER_REGISTRY};
@@ -254,7 +255,7 @@ mod tests {
     fn test_ctx() -> crate::AppContext {
         crate::AppContext {
             config: Config::default(),
-            ui: Box::new(CaptureUi::default()),
+            ui: Arc::new(CaptureUi::default()),
         }
     }
 

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -1,11 +1,14 @@
 pub mod exports;
 pub mod shell;
 
+use alog::{alog_channel, use_channel, MessageLevel};
 use anyhow::{Context, Result};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::fs;
 use std::path::{Path, PathBuf};
+
+use_channel!("CONF");
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
 pub struct TopLevelConfig {
@@ -237,6 +240,7 @@ impl Config {
 
         // Load top-level config.yaml for shell and routing
         let top_level_path = Self::config_path()?;
+        alog_channel!(MessageLevel::Info, "Config Path: {:#?}", top_level_path);
         if top_level_path.exists() {
             if let Ok(top_config) = Self::load_yaml_from_file::<TopLevelConfig>(&top_level_path) {
                 config.shell = top_config.shell;
@@ -247,11 +251,18 @@ impl Config {
         }
 
         // Load component files
-        config.models = Self::load_dir(&Self::models_dir()?, |s| s.to_string())?;
-        config.providers = Self::load_dir(&Self::providers_dir()?, |s| s.to_string())?;
-        config.capabilities = Self::load_dir(&Self::capabilities_dir()?, |s| s.to_string())?;
-        config.tools = Self::load_dir(&Self::tools_dir()?, |s| s.to_string())?;
-        config.launchers = Self::load_dir(&Self::launchers_dir()?, |s| s.to_string())?;
+        let models_dir = &Self::models_dir()?;
+        let providers_dir = &Self::providers_dir()?;
+        let capabilities_dir = &Self::capabilities_dir()?;
+        let launchers_dir = &Self::launchers_dir()?;
+        alog_channel!(MessageLevel::Debug, "Models Dir: {:#?}", models_dir);
+        alog_channel!(MessageLevel::Debug, "Providers Dir: {:#?}", providers_dir);
+        alog_channel!(MessageLevel::Debug, "Capabilities Dir: {:#?}", capabilities_dir);
+        alog_channel!(MessageLevel::Debug, "Launchers Dir: {:#?}", launchers_dir);
+        config.models = Self::load_dir(models_dir, |s| s.to_string())?;
+        config.providers = Self::load_dir(providers_dir, |s| s.to_string())?;
+        config.capabilities = Self::load_dir(capabilities_dir, |s| s.to_string())?;
+        config.launchers = Self::load_dir(launchers_dir, |s| s.to_string())?;
 
         Ok(config)
     }

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -1,7 +1,7 @@
 pub mod exports;
 pub mod shell;
 
-use alog::{alog_channel, use_channel, MessageLevel};
+use alog::{MessageLevel, alog_channel, use_channel};
 use anyhow::{Context, Result};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
@@ -257,7 +257,11 @@ impl Config {
         let launchers_dir = &Self::launchers_dir()?;
         alog_channel!(MessageLevel::Debug, "Models Dir: {:#?}", models_dir);
         alog_channel!(MessageLevel::Debug, "Providers Dir: {:#?}", providers_dir);
-        alog_channel!(MessageLevel::Debug, "Capabilities Dir: {:#?}", capabilities_dir);
+        alog_channel!(
+            MessageLevel::Debug,
+            "Capabilities Dir: {:#?}",
+            capabilities_dir
+        );
         alog_channel!(MessageLevel::Debug, "Launchers Dir: {:#?}", launchers_dir);
         config.models = Self::load_dir(models_dir, |s| s.to_string())?;
         config.providers = Self::load_dir(providers_dir, |s| s.to_string())?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -323,9 +323,31 @@ fn construct_ui(output: &str) -> Box<dyn Ui> {
         })
 }
 
-fn construct_context(output: &str) -> AppContext {
+fn construct_context(output: &str, log_level: &str, log_filters: &str, log_json: bool, log_thread_id: bool) -> AppContext {
+    // Set up Ui
     let ui = construct_ui(output);
     let ui: std::sync::Arc<dyn Ui> = std::sync::Arc::from(ui);
+
+    // Configure logging
+    let formatter_kind = if log_json {
+        alog::FormatterKind::Json
+    } else {
+        alog::FormatterKind::Pretty
+    };
+    let ui_arc_clone = Arc::clone(&ui);
+    let ui_writer = UiWriter {
+        ui: Arc::clone(&ui),
+    };
+    alog::configure(alog::Config {
+        default_level: log_level.parse().unwrap(),
+        filters: alog::Filters::Spec(log_filters.to_string()),
+        formatter: alog::FormatterKind::Custom(Box::new(UiFormatter::new(formatter_kind, ui_arc_clone))),
+        writer: alog::Writer::Custom(Box::new(ui_writer)),
+        thread_id: log_thread_id,
+    });
+    alog!("MAIN", MessageLevel::Debug, "Welcome to granite-cli!");
+
+    // Initialize config
     let config = config::Config::new().unwrap_or_else(|e| {
         ui.error(&format!("Failed to load config: {e}"));
         std::process::exit(1);
@@ -392,29 +414,6 @@ impl alog::Formatter for UiFormatter {
     }
 }
 
-fn configure_logging(log_level: &str, log_filters: &str, log_json: bool, log_thread_id: bool, ctx: &AppContext) {
-    let formatter_kind = if log_json {
-        alog::FormatterKind::Json
-    } else {
-        alog::FormatterKind::Pretty
-    };
-
-    let ui_arc_clone = Arc::clone(&ctx.ui);
-
-    let ui_writer = UiWriter {
-        ui: Arc::clone(&ctx.ui),
-    };
-
-    alog::configure(alog::Config {
-        default_level: log_level.parse().unwrap(),
-        filters: alog::Filters::Spec(log_filters.to_string()),
-        formatter: alog::FormatterKind::Custom(Box::new(UiFormatter::new(formatter_kind, ui_arc_clone))),
-        writer: alog::Writer::Custom(Box::new(ui_writer)),
-        thread_id: log_thread_id,
-    });
-    alog!("MAIN", MessageLevel::Debug, "Welcome to granite-cli!");
-}
-
 #[tokio::main]
 async fn main() {
     let cli = Cli::parse();
@@ -426,64 +425,55 @@ async fn main() {
 
     let result: Result<(), ()> = match command {
         Some(Commands::Model(wrapper)) => {
-            let mut ctx = construct_context(&wrapper.output);
-            configure_logging(&log_level, &log_filters, log_json, log_thread_id, &ctx);
+            let mut ctx = construct_context(&wrapper.output, &log_level, &log_filters, log_json, log_thread_id);
             run_model_command(&mut ctx, wrapper.subcommand)
                 .await
                 .map_err(|e| ctx.ui.error(&e.to_string()))
         }
         Some(Commands::Capability(wrapper)) => {
-            let mut ctx = construct_context(&wrapper.output);
-            configure_logging(&log_level, &log_filters, log_json, log_thread_id, &ctx);
+            let mut ctx = construct_context(&wrapper.output, &log_level, &log_filters, log_json, log_thread_id);
             run_capability_command(&mut ctx, wrapper.subcommand)
                 .await
                 .map_err(|e| ctx.ui.error(&e.to_string()))
         }
         Some(Commands::Provider(wrapper)) => {
-            let mut ctx = construct_context(&wrapper.output);
-            configure_logging(&log_level, &log_filters, log_json, log_thread_id, &ctx);
+            let mut ctx = construct_context(&wrapper.output, &log_level, &log_filters, log_json, log_thread_id);
             run_provider_command(&mut ctx, wrapper.subcommand)
                 .await
                 .map_err(|e| ctx.ui.error(&e.to_string()))
         }
         Some(Commands::Hardware) => {
-            let ctx = construct_context("terminal");
-            configure_logging(&log_level, &log_filters, log_json, log_thread_id, &ctx);
+            let ctx = construct_context("terminal", &log_level, &log_filters, log_json, log_thread_id);
             HardwareCommands::show(&ctx).map_err(|e| ctx.ui.error(&e.to_string()))
         }
         Some(Commands::Configure(wrapper)) => {
-            let ctx = construct_context("warning");
-            configure_logging(&log_level, &log_filters, log_json, log_thread_id, &ctx);
+            let _ctx = construct_context("warning", &log_level, &log_filters, log_json, log_thread_id);
             let ui = construct_ui(&wrapper.output);
             run_configure(&*ui, wrapper.args)
                 .await
                 .map_err(|e| ui.error(&e.to_string()))
         }
         Some(Commands::Launcher(wrapper)) => {
-            let mut ctx = construct_context(&wrapper.output);
-            configure_logging(&log_level, &log_filters, log_json, log_thread_id, &ctx);
+            let mut ctx = construct_context(&wrapper.output, &log_level, &log_filters, log_json, log_thread_id);
             run_launcher_command(&mut ctx, wrapper.subcommand)
                 .await
                 .map_err(|e| ctx.ui.error(&e.to_string()))
         }
         Some(Commands::Launch(wrapper)) => {
-            let ctx = construct_context(&wrapper.output);
-            configure_logging(&log_level, &log_filters, log_json, log_thread_id, &ctx);
+            let ctx = construct_context(&wrapper.output, &log_level, &log_filters, log_json, log_thread_id);
             run_launch(&*ctx.ui, &wrapper.tool_id, &wrapper.args, wrapper.dry_run)
                 .await
                 .map_err(|e| ctx.ui.error(&e.to_string()))
         }
         Some(Commands::Version) => {
-            let ctx = construct_context("warning");
-            configure_logging(&log_level, &log_filters, log_json, log_thread_id, &ctx);
+            let _ctx = construct_context("warning", &log_level, &log_filters, log_json, log_thread_id);
             println!("{}", version::version_string());
             Ok(())
         }
         None => {
             // `ctx` (and its `ui`) is consumed by value into the TUI `App`
             // before any error can occur, so it can't be used to report one.
-            let ctx = construct_context("terminal");
-            configure_logging(&log_level, &log_filters, log_json, log_thread_id, &ctx);
+            let ctx = construct_context("terminal", &log_level, &log_filters, log_json, log_thread_id);
             run_interactive_tui(ctx)
                 .await
                 .map_err(|e| eprintln!("Error: {e}"))

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,6 +13,7 @@ pub mod version {
 pub mod providers;
 
 // Third Party
+use alog::{alog, MessageLevel};
 use clap::{Parser, Subcommand};
 
 // Local
@@ -30,6 +31,19 @@ extern crate paste;
 struct Cli {
     #[command(subcommand)]
     command: Option<Commands>,
+
+    /// Default logging level
+    #[arg(short, long, global = true, default_value = "warning")]
+    log_level: String,
+    /// Per-level overrides
+    #[arg(long, global = true, default_value = "")]
+    log_filters: String,
+    /// Log with json format
+    #[arg(long, global = true)]
+    log_json: bool,
+    /// Include thread ID in log lines
+    #[arg(long, global = true)]
+    log_thread_id: bool,
 }
 
 #[derive(clap::Args, Debug)]
@@ -319,34 +333,127 @@ fn construct_context(output: &str) -> AppContext {
     AppContext { config, ui }
 }
 
+/*-- private --*/
+
+use std::io::{self, Write};
+use std::sync::Arc;
+
+/// A log sink that routes formatted records through a [`Ui`] backend.
+struct UiWriter {
+    ui: Arc<dyn Ui>,
+}
+
+impl Write for UiWriter {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        let text = std::str::from_utf8(buf).unwrap_or("");
+        // The formatter adds a trailing newline; split and route each line.
+        for line in text.trim_end_matches('\n').split('\n') {
+            if line.is_empty() {
+                continue;
+            }
+            self.ui.info(line);
+        }
+        Ok(buf.len())
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        Ok(())
+    }
+}
+
+/// Wraps an alog formatter and delegates to it.
+struct UiFormatter {
+    inner: Box<dyn alog::Formatter>,
+    ui: Arc<dyn Ui>,
+}
+
+impl UiFormatter {
+    fn new(kind: alog::FormatterKind, ui: Arc<dyn Ui>) -> Self {
+        Self {
+            inner: match kind {
+                alog::FormatterKind::Pretty => Box::new(alog::PrettyFormatter::default()),
+                alog::FormatterKind::Json => Box::new(alog::JsonFormatter),
+                alog::FormatterKind::Custom(c) => c,
+            },
+            ui: ui,
+        }
+    }
+}
+
+impl alog::Formatter for UiFormatter {
+    fn format(&self, record: &alog::LogRecord<'_>) -> String {
+        let formatted = self.inner.format(record);
+        match record.level {
+            MessageLevel::Fatal | MessageLevel::Error => self.ui.error_mark(&formatted),
+            MessageLevel::Warning => self.ui.warn_mark(&formatted),
+            MessageLevel::Info => formatted,
+            _ => self.ui.detail_mark(&formatted),
+        }
+    }
+}
+
+fn configure_logging(log_level: &str, log_filters: &str, log_json: bool, log_thread_id: bool, ctx: &AppContext) {
+    let formatter_kind = if log_json {
+        alog::FormatterKind::Json
+    } else {
+        alog::FormatterKind::Pretty
+    };
+
+    let ui_arc_clone = Arc::clone(&ctx.ui);
+
+    let ui_writer = UiWriter {
+        ui: Arc::clone(&ctx.ui),
+    };
+
+    alog::configure(alog::Config {
+        default_level: log_level.parse().unwrap(),
+        filters: alog::Filters::Spec(log_filters.to_string()),
+        formatter: alog::FormatterKind::Custom(Box::new(UiFormatter::new(formatter_kind, ui_arc_clone))),
+        writer: alog::Writer::Custom(Box::new(ui_writer)),
+        thread_id: log_thread_id,
+    });
+    alog!("MAIN", MessageLevel::Debug, "Welcome to granite-cli!");
+}
+
 #[tokio::main]
 async fn main() {
     let cli = Cli::parse();
+    let log_level = cli.log_level.clone();
+    let log_filters = cli.log_filters.clone();
+    let log_json = cli.log_json;
+    let log_thread_id = cli.log_thread_id;
+    let command = cli.command;
 
-    let result: Result<(), ()> = match cli.command {
+    let result: Result<(), ()> = match command {
         Some(Commands::Model(wrapper)) => {
             let mut ctx = construct_context(&wrapper.output);
+            configure_logging(&log_level, &log_filters, log_json, log_thread_id, &ctx);
             run_model_command(&mut ctx, wrapper.subcommand)
                 .await
                 .map_err(|e| ctx.ui.error(&e.to_string()))
         }
         Some(Commands::Capability(wrapper)) => {
             let mut ctx = construct_context(&wrapper.output);
+            configure_logging(&log_level, &log_filters, log_json, log_thread_id, &ctx);
             run_capability_command(&mut ctx, wrapper.subcommand)
                 .await
                 .map_err(|e| ctx.ui.error(&e.to_string()))
         }
         Some(Commands::Provider(wrapper)) => {
             let mut ctx = construct_context(&wrapper.output);
+            configure_logging(&log_level, &log_filters, log_json, log_thread_id, &ctx);
             run_provider_command(&mut ctx, wrapper.subcommand)
                 .await
                 .map_err(|e| ctx.ui.error(&e.to_string()))
         }
         Some(Commands::Hardware) => {
             let ctx = construct_context("terminal");
+            configure_logging(&log_level, &log_filters, log_json, log_thread_id, &ctx);
             HardwareCommands::show(&ctx).map_err(|e| ctx.ui.error(&e.to_string()))
         }
         Some(Commands::Configure(wrapper)) => {
+            let ctx = construct_context("warning");
+            configure_logging(&log_level, &log_filters, log_json, log_thread_id, &ctx);
             let ui = construct_ui(&wrapper.output);
             run_configure(&*ui, wrapper.args)
                 .await
@@ -354,17 +461,21 @@ async fn main() {
         }
         Some(Commands::Launcher(wrapper)) => {
             let mut ctx = construct_context(&wrapper.output);
+            configure_logging(&log_level, &log_filters, log_json, log_thread_id, &ctx);
             run_launcher_command(&mut ctx, wrapper.subcommand)
                 .await
                 .map_err(|e| ctx.ui.error(&e.to_string()))
         }
         Some(Commands::Launch(wrapper)) => {
             let ctx = construct_context(&wrapper.output);
+            configure_logging(&log_level, &log_filters, log_json, log_thread_id, &ctx);
             run_launch(&*ctx.ui, &wrapper.tool_id, &wrapper.args, wrapper.dry_run)
                 .await
                 .map_err(|e| ctx.ui.error(&e.to_string()))
         }
         Some(Commands::Version) => {
+            let ctx = construct_context("warning");
+            configure_logging(&log_level, &log_filters, log_json, log_thread_id, &ctx);
             println!("{}", version::version_string());
             Ok(())
         }
@@ -372,6 +483,7 @@ async fn main() {
             // `ctx` (and its `ui`) is consumed by value into the TUI `App`
             // before any error can occur, so it can't be used to report one.
             let ctx = construct_context("terminal");
+            configure_logging(&log_level, &log_filters, log_json, log_thread_id, &ctx);
             run_interactive_tui(ctx)
                 .await
                 .map_err(|e| eprintln!("Error: {e}"))

--- a/src/main.rs
+++ b/src/main.rs
@@ -294,7 +294,7 @@ struct ConfigureArgs {
 
 pub struct AppContext {
     pub config: config::Config,
-    pub ui: Box<dyn Ui>,
+    pub ui: std::sync::Arc<dyn Ui>,
 }
 
 /// Construct the `Ui` backend for `--output`, exiting on an unrecognized
@@ -311,6 +311,7 @@ fn construct_ui(output: &str) -> Box<dyn Ui> {
 
 fn construct_context(output: &str) -> AppContext {
     let ui = construct_ui(output);
+    let ui: std::sync::Arc<dyn Ui> = std::sync::Arc::from(ui);
     let config = config::Config::new().unwrap_or_else(|e| {
         ui.error(&format!("Failed to load config: {e}"));
         std::process::exit(1);

--- a/src/main.rs
+++ b/src/main.rs
@@ -33,16 +33,16 @@ struct Cli {
     command: Option<Commands>,
 
     /// Default logging level
-    #[arg(short, long, global = true, default_value = "warning")]
+    #[arg(short, long, global = true, default_value = "warning", env = "LOG_LEVEL")]
     log_level: String,
     /// Per-level overrides
-    #[arg(long, global = true, default_value = "")]
+    #[arg(long, global = true, default_value = "", env = "LOG_FILTERS")]
     log_filters: String,
     /// Log with json format
-    #[arg(long, global = true)]
+    #[arg(long, global = true, env = "LOG_JSON")]
     log_json: bool,
     /// Include thread ID in log lines
-    #[arg(long, global = true)]
+    #[arg(long, global = true, env = "LOG_THREAD_ID")]
     log_thread_id: bool,
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -369,7 +369,7 @@ impl Write for UiWriter {
     fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
         let text = std::str::from_utf8(buf).unwrap_or("");
         // The formatter adds a trailing newline; split and route each line.
-        for line in text.trim_end_matches('\n').split('\n') {
+        for line in text.split('\n') {
             if line.is_empty() {
                 continue;
             }
@@ -404,7 +404,7 @@ impl UiFormatter {
 
 impl alog::Formatter for UiFormatter {
     fn format(&self, record: &alog::LogRecord<'_>) -> String {
-        let formatted = self.inner.format(record);
+        let formatted = self.inner.format(record).trim_end_matches('\n').to_string();
         match record.level {
             MessageLevel::Fatal | MessageLevel::Error => self.ui.error_mark(&formatted),
             MessageLevel::Warning => self.ui.warn_mark(&formatted),

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,7 +13,7 @@ pub mod version {
 pub mod providers;
 
 // Third Party
-use alog::{alog, MessageLevel};
+use alog::{MessageLevel, alog};
 use clap::{Parser, Subcommand};
 
 // Local
@@ -323,7 +323,13 @@ fn construct_ui(output: &str) -> Box<dyn Ui> {
         })
 }
 
-fn construct_context(output: &str, log_level: &str, log_filters: &str, log_json: bool, log_thread_id: bool) -> AppContext {
+fn construct_context(
+    output: &str,
+    log_level: &str,
+    log_filters: &str,
+    log_json: bool,
+    log_thread_id: bool,
+) -> AppContext {
     // Set up Ui
     let ui = construct_ui(output);
     let ui: std::sync::Arc<dyn Ui> = std::sync::Arc::from(ui);
@@ -341,7 +347,10 @@ fn construct_context(output: &str, log_level: &str, log_filters: &str, log_json:
     alog::configure(alog::Config {
         default_level: log_level.parse().unwrap(),
         filters: alog::Filters::Spec(log_filters.to_string()),
-        formatter: alog::FormatterKind::Custom(Box::new(UiFormatter::new(formatter_kind, ui_arc_clone))),
+        formatter: alog::FormatterKind::Custom(Box::new(UiFormatter::new(
+            formatter_kind,
+            ui_arc_clone,
+        ))),
         writer: alog::Writer::Custom(Box::new(ui_writer)),
         thread_id: log_thread_id,
     });
@@ -397,7 +406,7 @@ impl UiFormatter {
                 alog::FormatterKind::Json => Box::new(alog::JsonFormatter),
                 alog::FormatterKind::Custom(c) => c,
             },
-            ui: ui,
+            ui,
         }
     }
 }
@@ -425,55 +434,99 @@ async fn main() {
 
     let result: Result<(), ()> = match command {
         Some(Commands::Model(wrapper)) => {
-            let mut ctx = construct_context(&wrapper.output, &log_level, &log_filters, log_json, log_thread_id);
+            let mut ctx = construct_context(
+                &wrapper.output,
+                &log_level,
+                &log_filters,
+                log_json,
+                log_thread_id,
+            );
             run_model_command(&mut ctx, wrapper.subcommand)
                 .await
                 .map_err(|e| ctx.ui.error(&e.to_string()))
         }
         Some(Commands::Capability(wrapper)) => {
-            let mut ctx = construct_context(&wrapper.output, &log_level, &log_filters, log_json, log_thread_id);
+            let mut ctx = construct_context(
+                &wrapper.output,
+                &log_level,
+                &log_filters,
+                log_json,
+                log_thread_id,
+            );
             run_capability_command(&mut ctx, wrapper.subcommand)
                 .await
                 .map_err(|e| ctx.ui.error(&e.to_string()))
         }
         Some(Commands::Provider(wrapper)) => {
-            let mut ctx = construct_context(&wrapper.output, &log_level, &log_filters, log_json, log_thread_id);
+            let mut ctx = construct_context(
+                &wrapper.output,
+                &log_level,
+                &log_filters,
+                log_json,
+                log_thread_id,
+            );
             run_provider_command(&mut ctx, wrapper.subcommand)
                 .await
                 .map_err(|e| ctx.ui.error(&e.to_string()))
         }
         Some(Commands::Hardware) => {
-            let ctx = construct_context("terminal", &log_level, &log_filters, log_json, log_thread_id);
+            let ctx = construct_context(
+                "terminal",
+                &log_level,
+                &log_filters,
+                log_json,
+                log_thread_id,
+            );
             HardwareCommands::show(&ctx).map_err(|e| ctx.ui.error(&e.to_string()))
         }
         Some(Commands::Configure(wrapper)) => {
-            let _ctx = construct_context("warning", &log_level, &log_filters, log_json, log_thread_id);
+            let _ctx =
+                construct_context("warning", &log_level, &log_filters, log_json, log_thread_id);
             let ui = construct_ui(&wrapper.output);
             run_configure(&*ui, wrapper.args)
                 .await
                 .map_err(|e| ui.error(&e.to_string()))
         }
         Some(Commands::Launcher(wrapper)) => {
-            let mut ctx = construct_context(&wrapper.output, &log_level, &log_filters, log_json, log_thread_id);
+            let mut ctx = construct_context(
+                &wrapper.output,
+                &log_level,
+                &log_filters,
+                log_json,
+                log_thread_id,
+            );
             run_launcher_command(&mut ctx, wrapper.subcommand)
                 .await
                 .map_err(|e| ctx.ui.error(&e.to_string()))
         }
         Some(Commands::Launch(wrapper)) => {
-            let ctx = construct_context(&wrapper.output, &log_level, &log_filters, log_json, log_thread_id);
+            let ctx = construct_context(
+                &wrapper.output,
+                &log_level,
+                &log_filters,
+                log_json,
+                log_thread_id,
+            );
             run_launch(&*ctx.ui, &wrapper.tool_id, &wrapper.args, wrapper.dry_run)
                 .await
                 .map_err(|e| ctx.ui.error(&e.to_string()))
         }
         Some(Commands::Version) => {
-            let _ctx = construct_context("warning", &log_level, &log_filters, log_json, log_thread_id);
+            let _ctx =
+                construct_context("warning", &log_level, &log_filters, log_json, log_thread_id);
             println!("{}", version::version_string());
             Ok(())
         }
         None => {
             // `ctx` (and its `ui`) is consumed by value into the TUI `App`
             // before any error can occur, so it can't be used to report one.
-            let ctx = construct_context("terminal", &log_level, &log_filters, log_json, log_thread_id);
+            let ctx = construct_context(
+                "terminal",
+                &log_level,
+                &log_filters,
+                log_json,
+                log_thread_id,
+            );
             run_interactive_tui(ctx)
                 .await
                 .map_err(|e| eprintln!("Error: {e}"))

--- a/src/utils/ui/app.rs
+++ b/src/utils/ui/app.rs
@@ -725,6 +725,7 @@ mod tests {
     use super::*;
     use crate::config::Config;
     use crate::utils::ui::base::tests::CaptureUi;
+    use std::sync::Arc;
 
     fn app() -> App {
         App::new(crate::AppContext {

--- a/src/utils/ui/app.rs
+++ b/src/utils/ui/app.rs
@@ -6,7 +6,6 @@ use ratatui::{
     text::{Line, Span},
     widgets::{Block, Borders, Cell, List, ListItem, ListState, Paragraph, Row, Table, TableState},
 };
-use std::sync::Arc;
 
 use crate::commands::{HardwareCommands, ModelCommands};
 use crate::dependency::Configured;

--- a/src/utils/ui/app.rs
+++ b/src/utils/ui/app.rs
@@ -6,6 +6,7 @@ use ratatui::{
     text::{Line, Span},
     widgets::{Block, Borders, Cell, List, ListItem, ListState, Paragraph, Row, Table, TableState},
 };
+use std::sync::Arc;
 
 use crate::commands::{HardwareCommands, ModelCommands};
 use crate::dependency::Configured;
@@ -729,7 +730,7 @@ mod tests {
     fn app() -> App {
         App::new(crate::AppContext {
             config: Config::default(),
-            ui: Box::new(CaptureUi::default()),
+            ui: Arc::new(CaptureUi::default()),
         })
     }
 

--- a/src/utils/ui/backends/terminal.rs
+++ b/src/utils/ui/backends/terminal.rs
@@ -232,7 +232,7 @@ impl Ui for TerminalOutput {
         }
         format!(
             "{}{}{}",
-            SetForegroundColor(Color::DarkGrey),
+            SetForegroundColor(Color::Grey),
             msg,
             ResetColor
         )

--- a/src/utils/ui/backends/terminal.rs
+++ b/src/utils/ui/backends/terminal.rs
@@ -230,12 +230,7 @@ impl Ui for TerminalOutput {
         if !self.is_tty {
             return PlainOutput.detail_mark(msg);
         }
-        format!(
-            "{}{}{}",
-            SetForegroundColor(Color::Grey),
-            msg,
-            ResetColor
-        )
+        format!("{}{}{}", SetForegroundColor(Color::Grey), msg, ResetColor)
     }
 
     fn pull_start(&self, label: &str, total_bytes: Option<u64>) -> PullHandle {


### PR DESCRIPTION
## Description

This PR adds logging using `alchemy-logging` / `alog`.

## Changes

- Add `alchemy-logging` dependency
- Add global CLI args for configuration
- Add some useful logging in the config module

## Testing

Tested by hand calls

## Related Issue(s)

Closes #39 

## AI Usage

AI was used for some of the implementation work. All commits were manually reviewed and edited if needed.