### PR TITLE
Agent model binding

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -67,7 +67,7 @@ fn generate_model_struct(model: &YamlModel) -> String {
         "impl crate::registry::ConfigConstructable for {struct_name} {{\n"
     ));
     s.push_str("    type Config = crate::registry::NoConfig;\n\n");
-    s.push_str("    fn new(cfg: &serde_json::Value) -> Self {\n");
+    s.push_str("    fn new(cfg: &serde_json::Value, _global_config: &crate::config::Config) -> Self {\n");
     s.push_str("        let provider_config = cfg.get(\"provider_config\").and_then(|v| serde_json::from_value(v.clone()).map_err(|e| alog_channel!(MessageLevel::Warning, \"WARNING: Failed to deserialize provider_config: {}\", e)).ok());\n");
     s.push_str("        Self { provider_config }\n");
     s.push_str("    }\n");

--- a/build.rs
+++ b/build.rs
@@ -67,7 +67,9 @@ fn generate_model_struct(model: &YamlModel) -> String {
         "impl crate::registry::ConfigConstructable for {struct_name} {{\n"
     ));
     s.push_str("    type Config = crate::registry::NoConfig;\n\n");
-    s.push_str("    fn new(cfg: &serde_json::Value, _global_config: &crate::config::Config) -> Self {\n");
+    s.push_str(
+        "    fn new(cfg: &serde_json::Value, _global_config: &crate::config::Config) -> Self {\n",
+    );
     s.push_str("        let provider_config = cfg.get(\"provider_config\").and_then(|v| serde_json::from_value(v.clone()).map_err(|e| alog_channel!(MessageLevel::Warning, \"WARNING: Failed to deserialize provider_config: {}\", e)).ok());\n");
     s.push_str("        Self { provider_config }\n");
     s.push_str("    }\n");

--- a/docs/specs/0017-remove-models-argument-from-bind.md
+++ b/docs/specs/0017-remove-models-argument-from-bind.md
@@ -1,0 +1,152 @@
+# Structural Refactor: Remove `models` argument from `Capability::bind` and `Launcher::bind_capability`
+
+## Problem
+
+Currently, `AgentModelCapability.bind` takes a `models: &(dyn Configured<dyn Model> + Sync)` argument and looks up the real model instance from `models.instances()` by `model_id` (from `config.model_id`). This pattern leaks the concrete `Configured<dyn Model>` type through the abstract `Capability` and `Launcher` trait interfaces, which is an anti-pattern.
+
+The `models` argument is needed at `bind` time because the model instance lookup happens there. Instead, this should happen at construction time for `AgentModelCapability` so the internal data holds the real model instance, and `bind` no longer needs to look up from `models`.
+
+## Goal
+
+Refactor so that `AgentModelCapability` stores its model instance at construction time, and `Capability::bind` no longer takes the `models` argument. Consequently, `Launcher::bind_capability` also no longer needs the `models` argument.
+
+## Key Constraint from user
+
+`AgentModelCapability` should always set the `model` field (not `Option`) in `new` and `from_config`, because the capability cannot be constructed without a valid model and still be useful. Thus the `model` field should not be `Option` — it should be required.
+
+## Current signatures
+
+```rust
+// src/capabilities/base.rs
+async fn bind(
+    &self,
+    request: BindingRequest,
+    models: &(dyn Configured<dyn Model> + Sync),
+) -> anyhow::Result<Binding>;
+
+// src/launchers/base.rs
+async fn bind_capability(
+    &mut self,
+    capability: &dyn crate::capabilities::Capability,
+    models: &(dyn crate::dependency::Configured<dyn crate::models::Model> + Sync),
+) -> anyhow::Result<()>;
+```
+
+## Current `AgentModelCapability`
+
+```rust
+pub struct AgentModelCapability {
+    config: AgentModelCapabilityConfig, // contains model_id
+}
+
+impl ConfigConstructable for AgentModelCapability {
+    fn new(cfg: &serde_json::Value) -> Self {
+        let config: AgentModelCapabilityConfig = serde_json::from_value(cfg.clone()).unwrap_or_default();
+        Self { config }
+    }
+}
+
+async fn bind(
+    &self,
+    request: BindingRequest,
+    models: &(dyn Configured<dyn Model> + Sync),
+) -> anyhow::Result<Binding> {
+    let api_type = match request {
+        BindingRequest::AgentModel(AgentModelBindingRequest { api_type }) => api_type,
+        #[allow(unreachable_patterns)]
+        other => anyhow::bail!("AgentModelCapability does not handle {:?}", other),
+    };
+    let model_id = self.config.model_id.clone();
+
+    let (_, model) = models
+        .instances()
+        .into_iter()
+        .find(|(id, _)| id == &model_id)
+        .ok_or_else(|| anyhow::anyhow!("model '{model_id}' not configured"))?;
+
+    // ... rest uses model and provider to construct Binding::AgentModel
+}
+```
+
+## Proposed changes
+
+1. **Add `model: Box<dyn Model>` field to `AgentModelCapability`** (required, not `Option`). In `new`, initialize `model` — `from_config` will set it.
+
+2. **Modify `CapabilitySource::from_config`** to also construct and store the model alongside each `AgentModelCapability`. After constructing the `AgentModelCapability` via the factory, look up the corresponding model from `ModelSource` using `model_id` from the config and set it on the capability.
+
+3. **Change `Capability::bind` signature** from:
+   ```rust
+   async fn bind(
+       &self,
+       request: BindingRequest,
+       models: &(dyn Configured<dyn Model> + Sync),
+   ) -> anyhow::Result<Binding>;
+   ```
+   to:
+   ```rust
+   async fn bind(
+       &self,
+       request: BindingRequest,
+   ) -> anyhow::Result<Binding>;
+   ```
+   (remove `models` argument)
+
+4. **Change `Launcher::bind_capability` signature** from:
+   ```rust
+   async fn bind_capability(
+       &mut self,
+       capability: &dyn crate::capabilities::Capability,
+       models: &(dyn crate::dependency::Configured<dyn crate::models::Model> + Sync),
+   ) -> anyhow::Result<()>;
+   ```
+   to:
+   ```rust
+   async fn bind_capability(
+       &mut self,
+       capability: &dyn crate::capabilities::Capability,
+   ) -> anyhow::Result<()>;
+   ```
+   (remove `models` argument)
+
+5. **Update `AgentModelCapability::bind`** to use `self.model` directly instead of looking up from `models`. No longer needs the `models` argument.
+
+6. **Update launcher implementations** (`ClaudeLauncher::bind_capability` and `FakeLauncher::bind_capability`) to call `capability.bind(request)` without passing `models`.
+
+7. **Update tests** — the test doubles in `agent_model.rs` use `FakeSource<dyn Model>` which already implements `Configured<dyn Model>`. `CapabilitySource::from_config` will work with it.
+
+## Implementation details
+
+- `AgentModelCapability` struct:
+  ```rust
+  pub struct AgentModelCapability {
+      config: AgentModelCapabilityConfig,
+      model: Box<dyn Model>,  // required field, always set
+  }
+  ```
+
+- `ConfigConstructable` impl for `AgentModelCapability`'s `new` should only take `config` and not the model — the model will be set by `CapabilitySource::from_config`. So `new` remains simple.
+
+- `CapabilitySource::from_config`:
+  After constructing each capability via the factory (including `AgentModelCapability`), look up the model from `ModelSource` using the `model_id` from the config and set it on the capability.
+
+- `AgentModelCapability::bind` will use `self.model` directly (no `models` lookup).
+
+- `FakeSource` in tests already works similarly — tests should continue to work.
+
+## Files to modify (in order)
+
+1. `src/capabilities/agent_model.rs` — add `model: Box<dyn Model>` field to `AgentModelCapability`, modify `bind` to use `self.model`.
+2. `src/capabilities/mod.rs` — modify `CapabilitySource::from_config` to look up and set the model on `AgentModelCapability` instances.
+3. `src/capabilities/base.rs` — change `Capability` trait's `bind` signature (remove `models` arg).
+4. `src/launchers/base.rs` — change `Launcher` trait's `bind_capability` signature (remove `models` arg).
+5. `src/launchers/claude.rs` — update `bind_capability` to call `capability.bind(request)` without `models`.
+6. `src/launchers/base.rs` — update `FakeLauncher::bind_capability` similarly.
+7. `src/commands/capability.rs` — no changes needed.
+8. `src/commands/launcher.rs` — no changes needed.
+
+## Validation
+
+- All existing tests should pass.
+- `AgentModelCapability` cannot be constructed without a valid model — this satisfies the constraint that `model` is always set (not `Option`).
+- `bind` no longer needs to lookup the model from `models`; it uses `self.model` directly.
+- `bind_capability` no longer passes `models` to `capability.bind`.

--- a/docs/specs/0018-capability-binding-plan.md
+++ b/docs/specs/0018-capability-binding-plan.md
@@ -1,0 +1,207 @@
+# Plan: Wire `Capability.bind_capabilities` to `launcher setup` and `run_launch`
+
+## Overview
+
+`LauncherConfig.enabled_capabilities` exists as a `Vec<String>` but is never
+populated and never consulted. This plan wires it end-to-end:
+
+1. **During `launcher setup`**: after the binary is validated, the user is
+   shown all configured capability instances whose `binding_types()` overlap the
+   launcher's `supported_capabilities`, plus a "Configure a new capability…"
+   option. They can select zero or more; the IDs of chosen ones are saved into
+   `enabled_capabilities`.
+
+2. **During `run_launch`**: after the launcher is constructed, each
+   `enabled_capabilities` ID is looked up in config, the capability is
+   constructed, and `bind_capability` is called on the launcher (mutably) before
+   `launch()` is invoked.
+
+Neither change touches the `Launcher` or `Capability` trait interfaces — all
+work is in the command layer and the launch runner.
+
+## Out of Scope (Future Work)
+
+**Mutual exclusivity of capabilities by binding type**: A launcher may support
+at most one `AgentModel` capability at a time (since binding overwrites the
+single stored `AgentModelBinding`), but could in future support multiple `Skill`
+capabilities. The current plan does not enforce this — a user could select two
+`AgentModel`-compatible capabilities during setup and both `bind_capability`
+calls would be made at launch time (second wins). Enforcement should be added
+in a follow-up once the `Skill` binding type exists and the per-type cardinality
+policy is clearer. For now, behavior on over-selection is implementation-defined.
+
+---
+
+## Sub-Tasks
+
+---
+
+### Sub-Task 1 — Add `multi_select` to the `Ui` trait
+
+**Intent**
+Capability selection at setup time requires the user to choose zero-or-more
+items from a list. The `Ui` trait today only has single-selection (`select`).
+Adding `multi_select` keeps the pattern consistent and testable via `CaptureUi`.
+
+**Expected Outcomes**
+- `Ui` trait in `src/utils/ui/base.rs` gains a `multi_select` method with the
+  same signature shape as `select`, but returning `Vec<usize>`.
+- Default implementation delegates to `dialoguer::MultiSelect`. This covers
+  the `plain` and `terminal` backends, which do not override interactive methods.
+- `CaptureUi` records calls and consumes canned answers
+  (`multi_select_answers: RefCell<VecDeque<Vec<usize>>>`).
+- `JsonOutput` and `MarkdownOutput` explicitly override `multi_select` to return
+  `non_interactive()`, matching how they handle `select`, `confirm`, `text`,
+  and `password` today.
+- `PlainOutput` and `TerminalOutput` use the default trait implementation (no
+  override needed).
+
+**Todo List**
+1. Add `multi_select(&self, prompt: &str, items: &[String], defaults: &[bool]) -> anyhow::Result<Vec<usize>>` to the `Ui` trait in `src/utils/ui/base.rs`, with a default body that calls `dialoguer::MultiSelect`.
+2. Add `multi_select_prompts: RefCell<Vec<(String, Vec<String>, Vec<bool>)>>` and `multi_select_answers: RefCell<VecDeque<Vec<usize>>>` fields to `CaptureUi`; implement the method to record the call and pop a canned answer (falling back to an empty vec when the queue is empty).
+3. Override `multi_select` in `JsonOutput` (`src/utils/ui/backends/json.rs`) and `MarkdownOutput` (`src/utils/ui/backends/markdown.rs`) to return `non_interactive()`.
+4. Add a `multi_select` contract test to the `output_contract_tests!` macro in `src/utils/ui/base.rs`.
+
+**Relevant Context**
+- `src/utils/ui/base.rs`: `Ui` trait definition, `CaptureUi`, `non_interactive()`
+- `src/utils/ui/backends/json.rs` lines 122–136: overrides `select`, `confirm`, `text`, `password` with `non_interactive()`
+- `src/utils/ui/backends/markdown.rs` lines 65–79: same pattern
+- `src/utils/ui/backends/plain.rs` and `terminal.rs`: no interactive overrides needed
+- `dialoguer` is already a dependency; `MultiSelect` is part of its API
+
+**Status** — `[x] done`
+
+---
+
+### Sub-Task 2 — Capability selection during `launcher setup`
+
+**Intent**  
+After the launcher binary is validated, present the user with the subset of
+configured capability instances (and configurable capability types) that are
+compatible with this launcher. Let the user pick zero or more; save the chosen
+IDs into `enabled_capabilities` in the saved `LauncherConfig`.
+
+**Expected Outcomes**
+- `LauncherCommands::setup` in `src/commands/launcher.rs` calls a new private
+  helper `select_capabilities` after binary validation and before saving config.
+- `select_capabilities` filters the `CapabilitySource` to instances whose
+  `binding_types()` intersect the launcher metadata's `supported_capabilities`.
+  For configurable types the catalog's `supported_binding_types` is used for
+  the same intersection test.
+- Items presented: sorted list of matching configured instance IDs + "Configure
+  a new capability…" sentinel if any compatible type exists in the registry.
+- The multi-select defaults all checkboxes to the previously saved
+  `enabled_capabilities` IDs (pre-tick on re-run).
+- If the user picks "Configure a new capability…", drive `CapabilityCommands::setup`
+  the same way `select_provider` drives `ProviderCommands::setup` (single type
+  → auto-select type; multiple → let user pick type; prompt for nickname).
+  After setup, add the new capability ID to the final selection.
+- The resulting list of IDs is saved as `enabled_capabilities` in `LauncherConfig`.
+- If `launcher_def.supported_capabilities` is empty (e.g. the `bob` launcher),
+  skip the capability selection step and emit a `ui.warn` noting that this
+  launcher does not support any capabilities (since the intent of the project
+  is for launchers to have capabilities, an empty set is worth surfacing).
+
+**Todo List**
+1. Import `CapabilityCommands`, `CapabilitySource`, and `CAPABILITY_REGISTRY`
+   into `src/commands/launcher.rs`.
+2. Add `async fn select_capabilities(ctx, launcher_def, existing_enabled) -> Result<Vec<String>>` as a private function.
+3. In the function body:
+   a. Build a `CapabilitySource` from `ctx.config`.
+   b. Filter instances to those whose `binding_types()` intersect `launcher_def.supported_capabilities`.
+   c. Filter catalog types to those whose `supported_binding_types` intersect `launcher_def.supported_capabilities`.
+   d. If both are empty, print info and return empty vec.
+   e. Build display items list: `[instance_ids..., "Configure a new capability..."]` (sentinel only if compatible types exist).
+   f. Build `defaults: Vec<bool>` by checking each item against `existing_enabled`.
+   g. Call `ctx.ui.multi_select(...)`, get back selected indices.
+   h. For each selected index:
+         - If it's a regular instance, add its ID to the result.
+         - If it's the "Configure a new" sentinel, drive `CapabilityCommands::setup`
+           (same flow as `select_provider` in model.rs: single compatible type →
+           auto-select; multiple → let user pick type; prompt for nickname). Add
+           the new ID to the accumulated result. All previously-selected IDs are
+           preserved — the "Configure new" path appends rather than replaces.
+4. Call `select_capabilities` in `LauncherCommands::setup` after binary validation, passing any previously saved `enabled_capabilities` as defaults.
+5. Use the returned vec as `enabled_capabilities` in the `LauncherConfig` that is saved.
+
+**Relevant Context**
+- `src/commands/launcher.rs`: `LauncherCommands::setup` (lines 74–226), especially lines 204–209 where `LauncherConfig` is built with `enabled_capabilities: vec![]`
+- `src/commands/model.rs`: `select_provider` (lines 703–751) — the pattern to follow
+- `src/capabilities/mod.rs`: `CapabilitySource`, `CAPABILITY_REGISTRY`
+- `src/commands/capability.rs`: `CapabilityCommands::setup` — to be called for "Configure new"
+- `src/launchers/base.rs`: `LauncherMetadata.supported_capabilities: HashSet<BindingType>`
+- `src/capabilities/base.rs`: `CapabilityMetadata.supported_binding_types`
+
+**Status** — `[x] done`
+
+---
+
+### Sub-Task 3 — Bind enabled capabilities in `run_launch`
+
+**Intent**  
+At launch time, read `lc.enabled_capabilities` from the loaded config, construct
+each capability, and call `bind_capability` on the launcher before `launch()` is
+called. The launcher (e.g. `ClaudeLauncher`) already implements `bind_capability`
+fully; this sub-task just plumbs the missing call site.
+
+**Expected Outcomes**
+- `run_launch` in `src/main.rs` constructs a `CapabilitySource` from the fresh
+  config and, for each ID in `lc.enabled_capabilities`, looks up the capability
+  and calls `launcher.bind_capability(capability)`.
+- The launcher must be `mut` for this (it stores the bound result); change
+  `let launcher =` to `let mut launcher =`.
+- If a capability ID listed in `enabled_capabilities` is not found in config,
+  bail with a clear error message.
+- If `bind_capability` returns an error, propagate it (no silent swallowing).
+- No change to the `Launcher` or `Capability` trait signatures.
+
+**Todo List**
+1. In `run_launch` in `src/main.rs`, change `let launcher =` to `let mut launcher =`.
+2. Add import for `crate::capabilities::CapabilitySource` and `crate::capabilities::CAPABILITY_REGISTRY`.
+3. After constructing `launcher`, build a `CapabilitySource` from `&config`.
+4. For each capability ID in `lc.enabled_capabilities`:
+   a. Look it up in `config.capabilities`; bail if not found.
+   b. Construct the capability via `CAPABILITY_REGISTRY.construct(...)`.
+   c. Call `launcher.bind_capability(capability.as_ref()).await?`.
+5. Continue to `launcher.launch(args, &launch_ctx, ui).await?` as before.
+
+**Relevant Context**
+- `src/main.rs`: `run_launch` (lines 635–674)
+- `src/capabilities/mod.rs`: `CapabilitySource::from_config`, `CAPABILITY_REGISTRY`
+- `src/launchers/claude.rs`: `bind_capability` implementation — what happens when it's called
+- `src/config/mod.rs`: `config.capabilities: HashMap<String, CapabilityConfig>`
+
+**Status** — `[x] done`
+
+---
+
+### Sub-Task 4 — Tests
+
+**Intent**  
+Cover the two new behaviours: capability selection during setup and capability
+binding during launch. Follow existing test patterns in `launcher.rs` and
+`main.rs` (unit tests using `CaptureUi`).
+
+**Expected Outcomes**
+- `src/commands/launcher.rs` tests cover:
+  - When `supported_capabilities` is empty (bob), `select_capabilities` is not
+    called and `enabled_capabilities` is empty in saved config.
+  - When compatible capabilities exist, `multi_select` is called with the right
+    items and defaults.
+  - Previously-enabled capabilities are pre-checked in the multi-select prompt.
+  - Selecting "Configure a new capability…" drives `CapabilityCommands::setup`.
+- `src/main.rs` (or a dedicated integration-style test):
+  - `run_launch` with no `enabled_capabilities` calls `launch()` directly.
+  - `run_launch` with an unknown capability ID returns an error.
+
+**Todo List**
+1. Add tests to `src/commands/launcher.rs` for `select_capabilities` behaviour using `CaptureUi`'s new `multi_select_answers`.
+2. Add a test for `run_launch` with a missing capability ID (can be done without a real binary by testing the early-bail path).
+3. Confirm all existing tests still pass (`cargo test`).
+
+**Relevant Context**
+- `src/commands/launcher.rs` tests section (lines 247–443)
+- `src/utils/ui/base.rs` `CaptureUi` — will have `multi_select_answers` after Sub-Task 1
+- `src/launchers/bob.rs` — zero `supported_capabilities`, good for the skip path
+
+**Status** — `[x] done`

--- a/docs/specs/0019-model-name-alias-plan.md
+++ b/docs/specs/0019-model-name-alias-plan.md
@@ -1,0 +1,236 @@
+# Model Name Alias Plan
+
+## Overview
+
+When a model's catalog ID (e.g. `granite-4.1-8b`) differs from the name the
+provider requires at runtime (e.g. `granite4.1:8b` for Ollama), the
+`AgentModelBinding.model_name` currently carries the wrong value and the
+launch fails.
+
+The fix adds a `model_alias(model, variant)` method to the `Provider` trait.
+Each provider implementation encodes its own naming convention: Ollama derives
+the alias from its variant URL (`https://ollama.com/library/granite4.1:8b` →
+`granite4.1:8b`); other providers return `None` (meaning "use the catalog
+ID"). `AgentModelCapability` is updated to resolve the configured variant and
+pass it to the provider, which then determines the correct name to emit into
+`AgentModelBinding.model_name`.
+
+### Key design decisions
+
+- **Generic mechanism**: The alias is computed by the provider from the variant
+  URL — no per-model hardcoding anywhere.
+- **Variant passed explicitly**: `ModelConfig.variant` is already stored but
+  not threaded to the `Model` trait. `AgentModelCapability` carries it and
+  resolves the `ModelVariant` at bind time (the same pattern used in
+  `commands/model.rs` for pull).
+- **Default is `None`**: The `Provider` trait default implementation returns
+  `None`, so providers that do not need an alias (OpenAI-compatible, LM Studio,
+  llamacpp) require no changes beyond a test.
+- **`AgentModelBinding.model_name` always carries the provider-ready name**:
+  callers (launchers) remain unchanged.
+
+---
+
+## Sub-Tasks
+
+---
+
+### Sub-Task 1 — Add `model_alias` to the `Provider` trait
+
+**Intent**
+Encode the provider-specific naming convention at the `Provider` trait level.
+Each provider knows how its server expects models to be identified; the trait
+method makes this explicit and overridable. The default returns `None`,
+meaning "use the catalog ID".
+
+**Expected Outcomes**
+- `Provider` trait gains `fn model_alias(&self, model: &ModelMetadata, variant: Option<&ModelVariant>) -> Option<String>` with a default implementation returning `None`.
+- All existing provider implementations compile without modification (they
+  inherit the default).
+
+**Todo List**
+1. In `src/providers/base.rs`, add the method to the `Provider` trait with a
+   default body of `None`:
+   ```rust
+   fn model_alias(
+       &self,
+       _model: &ModelMetadata,
+       _variant: Option<&ModelVariant>,
+   ) -> Option<String> {
+       None
+   }
+   ```
+2. Import `ModelMetadata` and `ModelVariant` in the trait file if not already
+   present (they live in `crate::models`).
+3. Update the `FakeProvider` test double in
+   `src/capabilities/agent_model.rs` to inherit the default (no explicit impl
+   needed since the default is `None`).
+
+**Relevant Context**
+- `Provider` trait defined in [`src/providers/base.rs:124`](src/providers/base.rs:124)
+- `ModelMetadata` and `ModelVariant` from `crate::models`
+- `FakeProvider` test double at
+  [`src/capabilities/agent_model.rs:218`](src/capabilities/agent_model.rs:218)
+
+**Status**: [ ] pending
+
+---
+
+### Sub-Task 2 — Implement `model_alias` in `OllamaProvider`
+
+**Intent**
+Ollama uses names like `granite4.1:8b` rather than the catalog ID
+`granite-4.1-8b`. The Ollama variant URL already encodes this name
+(`https://ollama.com/library/granite4.1:8b`). The private `ollama_library_ref`
+helper already knows how to extract it — `model_alias` should reuse that logic.
+
+**Expected Outcomes**
+- `OllamaProvider::model_alias` returns `Some("granite4.1:8b")` when the
+  model has an Ollama-format variant selected.
+- Returns `None` when the selected variant has no Ollama library URL (e.g. the
+  selected variant is GGUF from HuggingFace, not the Ollama variant).
+
+**Todo List**
+1. In `src/providers/ollama.rs`, add an `impl Provider for OllamaProvider`
+   override of `model_alias`:
+   ```rust
+   fn model_alias(
+       &self,
+       _model: &ModelMetadata,
+       variant: Option<&ModelVariant>,
+   ) -> Option<String> {
+       variant
+           .and_then(|v| ollama_library_ref(&v.url))
+           .map(str::to_string)
+   }
+   ```
+2. Add unit tests covering:
+   - Ollama variant URL → correct alias extracted.
+   - Non-Ollama variant URL (GGUF HuggingFace) → `None`.
+   - `variant` is `None` → `None`.
+
+**Relevant Context**
+- `ollama_library_ref` private helper at
+  [`src/providers/ollama.rs:81`](src/providers/ollama.rs:81)
+- Ollama variant example URL: `"https://ollama.com/library/granite4.1:8b"`
+- Existing tests for `ollama_library_ref` at
+  [`src/providers/ollama.rs:419`](src/providers/ollama.rs:419)
+
+**Status**: [ ] pending
+
+---
+
+### Sub-Task 3 — Thread the configured variant into `AgentModelCapability`
+
+**Intent**
+`AgentModelCapability` needs to know which `ModelVariant` the user configured
+so it can pass it to `provider.model_alias()` at bind time. The `variant`
+string is already on `ModelConfig`; it needs to be stored on the capability
+and resolved to a `&ModelVariant` at bind time using the same
+`"format/precision"` split pattern used in `commands/model.rs`.
+
+**Expected Outcomes**
+- `AgentModelCapability` stores an `Option<String>` named `configured_variant`
+  (the raw `"format/precision"` string from `ModelConfig`).
+- In `with_config`, `model_cfg.variant.clone()` is captured into
+  `configured_variant`.
+- In the `new()` path, `configured_variant` is `None`.
+- A helper method `resolve_variant<'a>(&self, model: &'a dyn Model) -> Option<&'a ModelVariant>`
+  parses `configured_variant` (split on `/`, match format + precision from
+  `model.variants()`) — exactly the same lookup used in model pull.
+
+**Todo List**
+1. Add `configured_variant: Option<String>` field to `AgentModelCapability`.
+2. In `with_config`, set `configured_variant: model_cfg.variant.clone()`.
+3. In `new()`, set `configured_variant: None`.
+4. Add `fn resolve_variant<'a>(&self, model: &'a dyn Model) -> Option<&'a ModelVariant>`
+   that splits `self.configured_variant` on `'/'` and finds the matching
+   `ModelVariant` in `model.variants()`.
+
+**Relevant Context**
+- `AgentModelCapability` struct at
+  [`src/capabilities/agent_model.rs:29`](src/capabilities/agent_model.rs:29)
+- `ModelConfig.variant` format established by `commands/model.rs:527-530` as
+  `"{format}/{precision}"`.
+- Existing variant lookup pattern in `src/commands/model.rs` around line
+  634-642 for reference.
+
+**Status**: [ ] pending
+
+---
+
+### Sub-Task 4 — Use `provider.model_alias()` in `AgentModelBinding`
+
+**Intent**
+Wire together the new pieces: at bind time, resolve the configured variant,
+ask the provider for its preferred name, and emit that into
+`AgentModelBinding.model_name`. Fall back to the catalog ID when the provider
+returns `None`.
+
+**Expected Outcomes**
+- `AgentModelBinding.model_name` is `"granite4.1:8b"` when binding
+  `granite-4.1-8b` against Ollama with the Ollama variant configured.
+- `AgentModelBinding.model_name` remains the catalog ID for providers that
+  return `None` from `model_alias`.
+- The existing test `bind_succeeds_for_matching_provider_and_model` continues
+  to pass unchanged (its `FakeProvider` returns `None`, so the catalog ID is
+  used).
+
+**Todo List**
+1. In `AgentModelCapability::bind()`, after constructing the `provider`:
+   ```rust
+   let resolved_variant = self.resolve_variant(self.model.as_ref());
+   let effective_model_name = provider
+       .model_alias(self.model.metadata_ref(), resolved_variant)
+       .unwrap_or_else(|| model_id.to_string());
+   ```
+   Replace `model_name: model_id.to_string()` with
+   `model_name: effective_model_name`.
+2. `model.metadata_ref()` — if `Model` does not expose a `ModelMetadata`
+   reference, pass the individual fields that `model_alias` needs (family,
+   variants). Prefer the simplest approach: since `model_alias` currently only
+   uses `variant` and ignores `_model`, and the `ModelMetadata` is not cheaply
+   available on the `Model` trait, pass `self.model.variants()` instead and
+   adjust the signature to `model_alias(&self, variants: &[ModelVariant], variant: Option<&ModelVariant>)`.
+   - **Reconsider the signature**: given that `model_alias` currently ignores
+     the model arg (only uses the variant URL), keep the signature simple:
+     `fn model_alias(&self, variant: Option<&ModelVariant>) -> Option<String>`.
+     This avoids the question of how to get `ModelMetadata` from `Model`.
+     Update Sub-Task 1 and 2 to match.
+
+**Relevant Context**
+- `bind()` in [`src/capabilities/agent_model.rs:122-174`](src/capabilities/agent_model.rs:122)
+- `AgentModelBinding.model_name` flows to launchers via `env_overlay()`, e.g.
+  `ANTHROPIC_MODEL` in [`src/launchers/claude.rs:89`](src/launchers/claude.rs:89)
+
+**Status**: [ ] pending
+
+---
+
+### Sub-Task 5 — Tests for the full alias flow
+
+**Intent**
+Cover the new alias path end-to-end in the `AgentModelCapability` test module:
+when the configured variant corresponds to an Ollama URL, the binding carries
+the Ollama name.
+
+**Expected Outcomes**
+- `bind_uses_provider_alias_for_ollama_variant`: configured variant is
+  `"Ollama/Q4_K_M"`, provider is `FakeProvider` with `model_alias` overridden
+  to return `Some("granite4.1:8b")`, binding has
+  `model_name == "granite4.1:8b"`.
+- `bind_falls_back_to_catalog_id_when_alias_is_none`: configured variant
+  present but `FakeProvider.model_alias` returns `None`, binding has
+  `model_name == "granite-3.1-8b-instruct"`.
+
+**Todo List**
+1. Add `model_alias` method to `FakeProvider` that returns a configurable
+   `Option<String>` (add field `alias: Option<String>` to `FakeProvider`).
+2. Add the two test cases above using the existing `capability_with_test_model`
+   helper pattern.
+
+**Relevant Context**
+- Test module in [`src/capabilities/agent_model.rs:199`](src/capabilities/agent_model.rs:199)
+- `FakeProvider` at [`src/capabilities/agent_model.rs:218`](src/capabilities/agent_model.rs:218)
+
+**Status**: [ ] pending

--- a/src/capabilities/agent_model.rs
+++ b/src/capabilities/agent_model.rs
@@ -7,13 +7,13 @@ use crate::capabilities::base::{
     CapabilityMetadata, Dependency, HasCapabilityMetadata,
 };
 use crate::capabilities::requirement::ModelRequirement;
-use crate::dependency::Configured;
 use crate::models::{Model, ModelFunction};
 use crate::registry::ConfigConstructable;
 use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
 use serde_valid::Validate;
 use std::collections::HashSet;
+use std::sync::Arc;
 
 /*-- AgentModelCapabilityConfig ---------------------------------------------------*/
 
@@ -27,6 +27,7 @@ pub struct AgentModelCapabilityConfig {
 
 pub struct AgentModelCapability {
     config: AgentModelCapabilityConfig,
+    model: Arc<dyn Model>,
 }
 
 impl ConfigConstructable for AgentModelCapability {
@@ -35,7 +36,19 @@ impl ConfigConstructable for AgentModelCapability {
     fn new(cfg: &serde_json::Value) -> Self {
         let config: AgentModelCapabilityConfig =
             serde_json::from_value(cfg.clone()).unwrap_or_default();
-        Self { config }
+        let model = crate::models::MODEL_REGISTRY
+            .construct(&config.model_id, &serde_json::json!({}))
+            .expect("model must be in registry");
+        Self {
+            config,
+            model: Arc::from(model),
+        }
+    }
+}
+
+impl AgentModelCapability {
+    pub fn configured_model_id(&self) -> &str {
+        &self.config.model_id
     }
 }
 
@@ -65,11 +78,7 @@ impl Capability for AgentModelCapability {
         HashSet::from([BindingType::AgentModel])
     }
 
-    async fn bind(
-        &self,
-        request: BindingRequest,
-        models: &(dyn Configured<dyn Model> + Sync),
-    ) -> anyhow::Result<Binding> {
+    async fn bind(&self, request: BindingRequest) -> anyhow::Result<Binding> {
         let api_type = match request {
             BindingRequest::AgentModel(AgentModelBindingRequest { api_type }) => api_type,
             #[allow(unreachable_patterns)] // Will remove once more variants are available
@@ -78,15 +87,10 @@ impl Capability for AgentModelCapability {
                 other.binding_type()
             ),
         };
-        let model_id = self.config.model_id.clone();
+        let model_id = &self.config.model_id;
 
-        let (_, model) = models
-            .instances()
-            .into_iter()
-            .find(|(id, _)| id == &model_id)
-            .ok_or_else(|| anyhow::anyhow!("model '{model_id}' not configured"))?;
-
-        let provider = model
+        let provider = self
+            .model
             .provider()
             .map_err(|e| anyhow::anyhow!("model '{model_id}' has no usable provider: {e}"))?;
 
@@ -97,7 +101,9 @@ impl Capability for AgentModelCapability {
         );
         // Defensive only: setup-time resolution already guarantees these.
         anyhow::ensure!(
-            model.supported_functions().contains(&ModelFunction::Chat),
+            self.model
+                .supported_functions()
+                .contains(&ModelFunction::Chat),
             "model '{model_id}' does not support Chat"
         );
         anyhow::ensure!(
@@ -118,7 +124,7 @@ impl Capability for AgentModelCapability {
         Ok(Binding::AgentModel(AgentModelBinding {
             api_type,
             base_url: provider.base_url().to_string(),
-            model_name: model_id,
+            model_name: model_id.to_string(),
             endpoint_path: endpoint.path().to_string(),
             api_key: provider.api_key().cloned(),
             verify_ssl: provider.verify_ssl(),
@@ -156,6 +162,7 @@ mod tests {
     };
     use crate::registry::Secret;
     use std::collections::HashMap;
+    use std::sync::Arc;
 
     #[derive(Clone)]
     struct FakeProvider {
@@ -202,12 +209,12 @@ mod tests {
         }
     }
 
-    struct FakeModel {
+    struct TestModel {
         supported_functions: Vec<ModelFunction>,
-        provider_result: Result<FakeProvider, String>,
+        provider: FakeProvider,
     }
 
-    impl ConfigConstructable for FakeModel {
+    impl ConfigConstructable for TestModel {
         type Config = crate::registry::NoConfig;
 
         fn new(_cfg: &serde_json::Value) -> Self {
@@ -215,9 +222,9 @@ mod tests {
         }
     }
 
-    impl Model for FakeModel {
+    impl Model for TestModel {
         fn family(&self) -> &str {
-            "Fake"
+            "Test"
         }
         fn version(&self) -> &str {
             "1.0"
@@ -232,7 +239,7 @@ mod tests {
             &crate::models::ModelType::Text
         }
         fn huggingface_repo(&self) -> &str {
-            "fake/fake"
+            "test/test"
         }
         fn native_dtype(&self) -> &str {
             "bfloat16"
@@ -253,41 +260,7 @@ mod tests {
             &self.supported_functions
         }
         fn provider(&self) -> anyhow::Result<Box<dyn Provider>> {
-            self.provider_result
-                .clone()
-                .map(|p| Box::new(p) as Box<dyn Provider>)
-                .map_err(|e| anyhow::anyhow!(e))
-        }
-    }
-
-    struct FakeSource<T: ?Sized> {
-        instances: Vec<(String, Box<T>)>,
-    }
-
-    impl Configured<dyn Model> for FakeSource<dyn Model> {
-        fn instances(&self) -> Vec<(String, &(dyn Model + 'static))> {
-            self.instances
-                .iter()
-                .map(|(id, m)| (id.clone(), m.as_ref()))
-                .collect()
-        }
-        fn catalog(&self) -> HashMap<&'static str, crate::models::ModelMetadata> {
-            HashMap::new()
-        }
-        fn config_schema(&self, _type_name: &str) -> Option<schemars::Schema> {
-            None
-        }
-    }
-
-    fn capability() -> AgentModelCapability {
-        AgentModelCapability::new(&serde_json::json!({
-            "model_id": "my-model",
-        }))
-    }
-
-    fn models_with(model: FakeModel) -> FakeSource<dyn Model> {
-        FakeSource {
-            instances: vec![("my-model".to_string(), Box::new(model))],
+            Ok(Box::new(self.provider.clone()))
         }
     }
 
@@ -295,104 +268,95 @@ mod tests {
         api_types: Vec<ApiType>,
         function: ModelFunction,
         endpoint: ApiEndpoint,
-    ) -> Result<FakeProvider, String> {
+    ) -> FakeProvider {
         let mut endpoints = HashMap::new();
         endpoints.insert(function, vec![endpoint]);
-        Ok(FakeProvider {
+        FakeProvider {
             base_url: "http://localhost:11434".to_string(),
             api_key: None,
             verify_ssl: true,
             api_types,
             endpoints,
-        })
+        }
+    }
+
+    fn capability_with_model(
+        functions: Vec<ModelFunction>,
+        provider: FakeProvider,
+    ) -> AgentModelCapability {
+        let mut cap = AgentModelCapability::new(&serde_json::json!({
+            "model_id": "granite-3.1-8b-instruct",
+        }));
+        cap.model = Arc::new(TestModel {
+            supported_functions: functions,
+            provider,
+        });
+        cap
     }
 
     #[tokio::test]
     async fn bind_succeeds_for_matching_provider_and_model() {
-        let cap = capability();
-        let models = models_with(FakeModel {
-            supported_functions: vec![ModelFunction::Chat],
-            provider_result: ok_provider(
+        let cap = capability_with_model(
+            vec![ModelFunction::Chat],
+            ok_provider(
                 vec![ApiType::OpenAI],
                 ModelFunction::Chat,
                 ApiEndpoint::OpenAIChat,
             ),
-        });
+        );
 
         let binding = cap
-            .bind(
-                BindingRequest::AgentModel(AgentModelBindingRequest {
-                    api_type: ApiType::OpenAI,
-                }),
-                &models,
-            )
+            .bind(BindingRequest::AgentModel(AgentModelBindingRequest {
+                api_type: ApiType::OpenAI,
+            }))
             .await
             .unwrap();
 
         let Binding::AgentModel(binding) = binding;
         assert_eq!(binding.base_url, "http://localhost:11434");
-        assert_eq!(binding.model_name, "my-model");
+        assert_eq!(binding.model_name, "granite-3.1-8b-instruct");
         assert_eq!(binding.endpoint_path, "/v1/chat/completions");
         assert_eq!(binding.api_type, ApiType::OpenAI);
         assert!(binding.verify_ssl);
     }
 
     #[tokio::test]
-    async fn bind_fails_when_model_not_configured() {
-        let cap = capability();
-        let models: FakeSource<dyn Model> = FakeSource { instances: vec![] };
-
-        let err = cap
-            .bind(
-                BindingRequest::AgentModel(AgentModelBindingRequest {
-                    api_type: ApiType::OpenAI,
-                }),
-                &models,
-            )
-            .await
-            .unwrap_err();
-        assert!(err.to_string().contains("not configured"));
-    }
-
-    #[tokio::test]
     async fn bind_fails_when_model_has_no_provider() {
-        let cap = capability();
-        let models = models_with(FakeModel {
-            supported_functions: vec![ModelFunction::Chat],
-            provider_result: Err("no provider configured".to_string()),
-        });
+        let cap = capability_with_model(
+            vec![ModelFunction::Chat],
+            FakeProvider {
+                base_url: "http://localhost:11434".to_string(),
+                api_key: None,
+                verify_ssl: true,
+                api_types: vec![ApiType::OpenAI],
+                endpoints: HashMap::new(),
+            },
+        );
 
         let err = cap
-            .bind(
-                BindingRequest::AgentModel(AgentModelBindingRequest {
-                    api_type: ApiType::OpenAI,
-                }),
-                &models,
-            )
+            .bind(BindingRequest::AgentModel(AgentModelBindingRequest {
+                api_type: ApiType::OpenAI,
+            }))
             .await
             .unwrap_err();
-        assert!(err.to_string().contains("no usable provider"));
+        assert!(err.to_string().contains("does not support"));
     }
 
     #[tokio::test]
     async fn bind_fails_when_provider_lacks_api_type() {
-        let cap = capability();
-        let models = models_with(FakeModel {
-            supported_functions: vec![ModelFunction::Chat],
-            provider_result: ok_provider(
+        let cap = capability_with_model(
+            vec![ModelFunction::Chat],
+            ok_provider(
                 vec![ApiType::Ollama],
                 ModelFunction::Chat,
                 ApiEndpoint::OllamaChat,
             ),
-        });
+        );
 
         let err = cap
-            .bind(
-                BindingRequest::AgentModel(AgentModelBindingRequest {
-                    api_type: ApiType::OpenAI,
-                }),
-                &models,
-            )
+            .bind(BindingRequest::AgentModel(AgentModelBindingRequest {
+                api_type: ApiType::OpenAI,
+            }))
             .await
             .unwrap_err();
         assert!(err.to_string().contains("does not support"));
@@ -400,23 +364,19 @@ mod tests {
 
     #[tokio::test]
     async fn bind_fails_when_model_lacks_function() {
-        let cap = capability();
-        let models = models_with(FakeModel {
-            supported_functions: vec![ModelFunction::Embeddings],
-            provider_result: ok_provider(
+        let cap = capability_with_model(
+            vec![ModelFunction::Embeddings],
+            ok_provider(
                 vec![ApiType::OpenAI],
                 ModelFunction::Chat,
                 ApiEndpoint::OpenAIChat,
             ),
-        });
+        );
 
         let err = cap
-            .bind(
-                BindingRequest::AgentModel(AgentModelBindingRequest {
-                    api_type: ApiType::OpenAI,
-                }),
-                &models,
-            )
+            .bind(BindingRequest::AgentModel(AgentModelBindingRequest {
+                api_type: ApiType::OpenAI,
+            }))
             .await
             .unwrap_err();
         assert!(err.to_string().contains("does not support"));
@@ -424,23 +384,19 @@ mod tests {
 
     #[tokio::test]
     async fn bind_fails_when_no_matching_endpoint() {
-        let cap = capability();
-        let models = models_with(FakeModel {
-            supported_functions: vec![ModelFunction::Chat],
-            provider_result: ok_provider(
+        let cap = capability_with_model(
+            vec![ModelFunction::Chat],
+            ok_provider(
                 vec![ApiType::OpenAI, ApiType::Ollama],
                 ModelFunction::Chat,
                 ApiEndpoint::OllamaChat,
             ),
-        });
+        );
 
         let err = cap
-            .bind(
-                BindingRequest::AgentModel(AgentModelBindingRequest {
-                    api_type: ApiType::OpenAI,
-                }),
-                &models,
-            )
+            .bind(BindingRequest::AgentModel(AgentModelBindingRequest {
+                api_type: ApiType::OpenAI,
+            }))
             .await
             .unwrap_err();
         assert!(err.to_string().contains("no OpenAI endpoint for Chat"));
@@ -448,7 +404,9 @@ mod tests {
 
     #[test]
     fn binding_types_reports_agent_model() {
-        let cap = capability();
+        let cap = AgentModelCapability::new(&serde_json::json!({
+            "model_id": "granite-3.1-8b-instruct",
+        }));
         assert_eq!(
             cap.binding_types(),
             HashSet::from([BindingType::AgentModel])
@@ -457,12 +415,14 @@ mod tests {
 
     #[test]
     fn dependencies_carry_resolved_model_id() {
-        let cap = capability();
+        let cap = AgentModelCapability::new(&serde_json::json!({
+            "model_id": "granite-3.1-8b-instruct",
+        }));
         let deps = cap.dependencies();
         assert_eq!(deps.len(), 1);
         assert!(deps.iter().any(|d| matches!(
             d,
-            Dependency::Model { resolved_id: Some(id), .. } if id == "my-model"
+            Dependency::Model { resolved_id: Some(id), .. } if id == "granite-3.1-8b-instruct"
         )));
     }
 

--- a/src/capabilities/agent_model.rs
+++ b/src/capabilities/agent_model.rs
@@ -35,14 +35,16 @@ pub struct AgentModelCapability {
     configured_variant: Option<String>,
 }
 
-impl AgentModelCapability {
-    /// Construct from capability config, using the provided global config to
-    /// resolve the model's provider (so `model.provider()` works at bind time).
+impl ConfigConstructable for AgentModelCapability {
+    type Config = AgentModelCapabilityConfig;
+
+    /// Constructs the capability using the global config to resolve the model's
+    /// provider (so `model.provider()` works at bind time).
     ///
-    /// `cfg` contains the capability's config (e.g. `{"model_id": "my-model"}`)
-    /// where `model_id` is the key into `global_config.models`.  The resolved
+    /// `cfg` contains the capability's instance config (e.g. `{"model_id": "my-model"}`)
+    /// where `model_id` is the key into `global_config.models`. The resolved
     /// `ModelConfig` supplies the catalog model ID and the provider ID.
-    pub fn with_config(cfg: &serde_json::Value, global_config: &crate::config::Config) -> Self {
+    fn new(cfg: &serde_json::Value, global_config: &crate::config::Config) -> Self {
         let config: AgentModelCapabilityConfig =
             serde_json::from_value(cfg.clone()).unwrap_or_default();
         let model_cfg = global_config
@@ -62,34 +64,12 @@ impl AgentModelCapability {
             .unwrap_or_else(|| serde_json::json!({}));
         let configured_variant = model_cfg.variant.clone();
         let model = crate::models::MODEL_REGISTRY
-            .construct(&model_cfg.model_id, &provider_cfg)
+            .construct(&model_cfg.model_id, &provider_cfg, global_config)
             .expect("model must be in registry");
         Self {
             config,
             model: Arc::from(model),
             configured_variant,
-        }
-    }
-}
-
-impl ConfigConstructable for AgentModelCapability {
-    type Config = AgentModelCapabilityConfig;
-
-    fn new(cfg: &serde_json::Value) -> Self {
-        // This path is used by CAPABILITY_REGISTRY.construct() which is
-        // called in a few non-launch contexts (e.g. tests). It constructs
-        // the model without provider config, so `model.provider()` will
-        // fail at bind time — callers that need a working provider should
-        // use `AgentModelCapability::with_config()` directly.
-        let config: AgentModelCapabilityConfig =
-            serde_json::from_value(cfg.clone()).unwrap_or_default();
-        let model = crate::models::MODEL_REGISTRY
-            .construct(&config.model_id, &serde_json::json!({}))
-            .expect("model must be in registry");
-        Self {
-            config,
-            model: Arc::from(model),
-            configured_variant: None,
         }
     }
 }
@@ -244,7 +224,7 @@ mod tests {
     impl ConfigConstructable for FakeProvider {
         type Config = crate::registry::NoConfig;
 
-        fn new(_cfg: &serde_json::Value) -> Self {
+        fn new(_cfg: &serde_json::Value, _global_config: &crate::config::Config) -> Self {
             unimplemented!("not used in tests")
         }
     }
@@ -298,7 +278,7 @@ mod tests {
     }
 
     /// Create an AgentModelCapability with a custom test model and provider.
-    /// Uses a real registry model ID so `with_config` can construct the model.
+    /// Uses a real registry model ID so the model can be looked up in global config.
     fn capability_with_test_model(
         functions: Vec<ModelFunction>,
         provider: FakeProvider,
@@ -326,7 +306,7 @@ mod tests {
                 variant: variant_str.clone(),
             },
         );
-        let cap = AgentModelCapability::with_config(
+        let cap = AgentModelCapability::new(
             &serde_json::json!({ "model_id": "granite-3.1-8b-instruct" }),
             &config,
         );
@@ -352,7 +332,7 @@ mod tests {
 
     impl ConfigConstructable for TestModelWithVariants {
         type Config = crate::registry::NoConfig;
-        fn new(_cfg: &serde_json::Value) -> Self {
+        fn new(_cfg: &serde_json::Value, _global_config: &crate::config::Config) -> Self {
             unimplemented!("not used in tests")
         }
     }
@@ -519,7 +499,7 @@ mod tests {
                 variant: None,
             },
         );
-        let cap = AgentModelCapability::with_config(
+        let cap = AgentModelCapability::new(
             &serde_json::json!({ "model_id": "granite-3.1-8b-instruct" }),
             &config,
         );
@@ -540,7 +520,7 @@ mod tests {
                 variant: None,
             },
         );
-        let cap = AgentModelCapability::with_config(
+        let cap = AgentModelCapability::new(
             &serde_json::json!({ "model_id": "granite-3.1-8b-instruct" }),
             &config,
         );

--- a/src/capabilities/agent_model.rs
+++ b/src/capabilities/agent_model.rs
@@ -19,6 +19,7 @@ use std::sync::Arc;
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default, schemars::JsonSchema, Validate)]
 pub struct AgentModelCapabilityConfig {
+    /// Key into the configured models map (the user-chosen instance ID).
     #[validate(min_length = 1)]
     pub model_id: String,
 }
@@ -30,10 +31,50 @@ pub struct AgentModelCapability {
     model: Arc<dyn Model>,
 }
 
+impl AgentModelCapability {
+    /// Construct from capability config, using the provided global config to
+    /// resolve the model's provider (so `model.provider()` works at bind time).
+    ///
+    /// `cfg` contains the capability's config (e.g. `{"model_id": "my-model"}`)
+    /// where `model_id` is the key into `global_config.models`.  The resolved
+    /// `ModelConfig` supplies the catalog model ID and the provider ID.
+    pub fn with_config(cfg: &serde_json::Value, global_config: &crate::config::Config) -> Self {
+        let config: AgentModelCapabilityConfig =
+            serde_json::from_value(cfg.clone()).unwrap_or_default();
+        let model_cfg = global_config
+            .models
+            .get(&config.model_id)
+            .unwrap_or_else(|| {
+                panic!(
+                    "Configured model '{}' not found in config.models",
+                    config.model_id
+                )
+            });
+        let provider_cfg = model_cfg
+            .provider_id
+            .as_deref()
+            .and_then(|pid| global_config.get_provider(pid))
+            .map(|pc| serde_json::json!({ "provider_config": pc }))
+            .unwrap_or_else(|| serde_json::json!({}));
+        let model = crate::models::MODEL_REGISTRY
+            .construct(&model_cfg.model_id, &provider_cfg)
+            .expect("model must be in registry");
+        Self {
+            config,
+            model: Arc::from(model),
+        }
+    }
+}
+
 impl ConfigConstructable for AgentModelCapability {
     type Config = AgentModelCapabilityConfig;
 
     fn new(cfg: &serde_json::Value) -> Self {
+        // This path is used by CAPABILITY_REGISTRY.construct() which is
+        // called in a few non-launch contexts (e.g. tests). It constructs
+        // the model without provider config, so `model.provider()` will
+        // fail at bind time — callers that need a working provider should
+        // use `AgentModelCapability::with_config()` directly.
         let config: AgentModelCapabilityConfig =
             serde_json::from_value(cfg.clone()).unwrap_or_default();
         let model = crate::models::MODEL_REGISTRY
@@ -128,6 +169,7 @@ impl Capability for AgentModelCapability {
             endpoint_path: endpoint.path().to_string(),
             api_key: provider.api_key().cloned(),
             verify_ssl: provider.verify_ssl(),
+            context_length: self.model.context_length(),
         }))
     }
 }
@@ -157,6 +199,7 @@ impl HasCapabilityMetadata for AgentModelCapability {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::config::{Config, ModelConfig};
     use crate::providers::{
         ApiEndpoint, ApiType, HealthStatus, ModelFormat, Provider, ProviderError,
     };
@@ -164,13 +207,20 @@ mod tests {
     use std::collections::HashMap;
     use std::sync::Arc;
 
-    #[derive(Clone)]
-    struct FakeProvider {
-        base_url: String,
-        api_key: Option<Secret>,
-        verify_ssl: bool,
-        api_types: Vec<ApiType>,
-        endpoints: HashMap<ModelFunction, Vec<ApiEndpoint>>,
+    // Re-export TestModel as pub(crate) so test helpers can use it.
+    #[derive(Default)]
+    pub(crate) struct TestModel {
+        pub(crate) supported_functions: Vec<ModelFunction>,
+        pub(crate) provider: FakeProvider,
+    }
+
+    #[derive(Clone, Default)]
+    pub(crate) struct FakeProvider {
+        pub(crate) base_url: String,
+        pub(crate) api_key: Option<Secret>,
+        pub(crate) verify_ssl: bool,
+        pub(crate) api_types: Vec<ApiType>,
+        pub(crate) endpoints: HashMap<ModelFunction, Vec<ApiEndpoint>>,
     }
 
     impl ConfigConstructable for FakeProvider {
@@ -207,11 +257,6 @@ mod tests {
         async fn health_check(&self) -> Result<HealthStatus, ProviderError> {
             unimplemented!("not used in tests")
         }
-    }
-
-    struct TestModel {
-        supported_functions: Vec<ModelFunction>,
-        provider: FakeProvider,
     }
 
     impl ConfigConstructable for TestModel {
@@ -280,23 +325,39 @@ mod tests {
         }
     }
 
-    fn capability_with_model(
+    /// Create an AgentModelCapability with a custom test model and provider.
+    /// Uses a real registry model ID so `with_config` can construct the model.
+    fn capability_with_test_model(
         functions: Vec<ModelFunction>,
         provider: FakeProvider,
     ) -> AgentModelCapability {
-        let mut cap = AgentModelCapability::new(&serde_json::json!({
-            "model_id": "granite-3.1-8b-instruct",
-        }));
-        cap.model = Arc::new(TestModel {
-            supported_functions: functions,
-            provider,
-        });
+        let mut config = Config::default();
+        config.models.insert(
+            "granite-3.1-8b-instruct".to_string(),
+            ModelConfig {
+                model_id: "granite-3.1-8b-instruct".to_string(),
+                provider_id: None,
+                variant: None,
+            },
+        );
+        let cap = AgentModelCapability::with_config(
+            &serde_json::json!({ "model_id": "granite-3.1-8b-instruct" }),
+            &config,
+        );
+        // Replace the real model with our test double that has a custom provider.
+        let cap = AgentModelCapability {
+            config: cap.config,
+            model: Arc::new(TestModel {
+                supported_functions: functions,
+                provider,
+            }),
+        };
         cap
     }
 
     #[tokio::test]
     async fn bind_succeeds_for_matching_provider_and_model() {
-        let cap = capability_with_model(
+        let cap = capability_with_test_model(
             vec![ModelFunction::Chat],
             ok_provider(
                 vec![ApiType::OpenAI],
@@ -322,7 +383,7 @@ mod tests {
 
     #[tokio::test]
     async fn bind_fails_when_model_has_no_provider() {
-        let cap = capability_with_model(
+        let cap = capability_with_test_model(
             vec![ModelFunction::Chat],
             FakeProvider {
                 base_url: "http://localhost:11434".to_string(),
@@ -344,7 +405,7 @@ mod tests {
 
     #[tokio::test]
     async fn bind_fails_when_provider_lacks_api_type() {
-        let cap = capability_with_model(
+        let cap = capability_with_test_model(
             vec![ModelFunction::Chat],
             ok_provider(
                 vec![ApiType::Ollama],
@@ -364,7 +425,7 @@ mod tests {
 
     #[tokio::test]
     async fn bind_fails_when_model_lacks_function() {
-        let cap = capability_with_model(
+        let cap = capability_with_test_model(
             vec![ModelFunction::Embeddings],
             ok_provider(
                 vec![ApiType::OpenAI],
@@ -384,7 +445,7 @@ mod tests {
 
     #[tokio::test]
     async fn bind_fails_when_no_matching_endpoint() {
-        let cap = capability_with_model(
+        let cap = capability_with_test_model(
             vec![ModelFunction::Chat],
             ok_provider(
                 vec![ApiType::OpenAI, ApiType::Ollama],
@@ -404,9 +465,19 @@ mod tests {
 
     #[test]
     fn binding_types_reports_agent_model() {
-        let cap = AgentModelCapability::new(&serde_json::json!({
-            "model_id": "granite-3.1-8b-instruct",
-        }));
+        let mut config = Config::default();
+        config.models.insert(
+            "granite-3.1-8b-instruct".to_string(),
+            ModelConfig {
+                model_id: "granite-3.1-8b-instruct".to_string(),
+                provider_id: None,
+                variant: None,
+            },
+        );
+        let cap = AgentModelCapability::with_config(
+            &serde_json::json!({ "model_id": "granite-3.1-8b-instruct" }),
+            &config,
+        );
         assert_eq!(
             cap.binding_types(),
             HashSet::from([BindingType::AgentModel])
@@ -415,9 +486,19 @@ mod tests {
 
     #[test]
     fn dependencies_carry_resolved_model_id() {
-        let cap = AgentModelCapability::new(&serde_json::json!({
-            "model_id": "granite-3.1-8b-instruct",
-        }));
+        let mut config = Config::default();
+        config.models.insert(
+            "granite-3.1-8b-instruct".to_string(),
+            ModelConfig {
+                model_id: "granite-3.1-8b-instruct".to_string(),
+                provider_id: None,
+                variant: None,
+            },
+        );
+        let cap = AgentModelCapability::with_config(
+            &serde_json::json!({ "model_id": "granite-3.1-8b-instruct" }),
+            &config,
+        );
         let deps = cap.dependencies();
         assert_eq!(deps.len(), 1);
         assert!(deps.iter().any(|d| matches!(

--- a/src/capabilities/agent_model.rs
+++ b/src/capabilities/agent_model.rs
@@ -29,6 +29,10 @@ pub struct AgentModelCapabilityConfig {
 pub struct AgentModelCapability {
     config: AgentModelCapabilityConfig,
     model: Arc<dyn Model>,
+    /// The raw `"format/precision"` string from `ModelConfig.variant`, if the
+    /// user configured a specific variant. Used at bind time to resolve the
+    /// provider-specific model alias.
+    configured_variant: Option<String>,
 }
 
 impl AgentModelCapability {
@@ -56,12 +60,14 @@ impl AgentModelCapability {
             .and_then(|pid| global_config.get_provider(pid))
             .map(|pc| serde_json::json!({ "provider_config": pc }))
             .unwrap_or_else(|| serde_json::json!({}));
+        let configured_variant = model_cfg.variant.clone();
         let model = crate::models::MODEL_REGISTRY
             .construct(&model_cfg.model_id, &provider_cfg)
             .expect("model must be in registry");
         Self {
             config,
             model: Arc::from(model),
+            configured_variant,
         }
     }
 }
@@ -83,6 +89,7 @@ impl ConfigConstructable for AgentModelCapability {
         Self {
             config,
             model: Arc::from(model),
+            configured_variant: None,
         }
     }
 }
@@ -90,6 +97,17 @@ impl ConfigConstructable for AgentModelCapability {
 impl AgentModelCapability {
     pub fn configured_model_id(&self) -> &str {
         &self.config.model_id
+    }
+
+    /// Resolves `configured_variant` (stored as `"format/precision"`) to the
+    /// matching `ModelVariant` in the model's catalog variants, using the same
+    /// case-insensitive lookup as the pull command.
+    fn resolve_variant<'a>(&self, model: &'a dyn Model) -> Option<&'a crate::models::ModelVariant> {
+        let variant_str = self.configured_variant.as_deref()?;
+        let (format, precision) = variant_str.split_once('/')?;
+        model.variants().iter().find(|v| {
+            v.format.eq_ignore_ascii_case(format) && v.precision.eq_ignore_ascii_case(precision)
+        })
     }
 }
 
@@ -162,10 +180,15 @@ impl Capability for AgentModelCapability {
                 )
             })?;
 
+        let resolved_variant = self.resolve_variant(self.model.as_ref());
+        let model_name = provider
+            .model_alias(resolved_variant)
+            .unwrap_or_else(|| model_id.to_string());
+
         Ok(Binding::AgentModel(AgentModelBinding {
             api_type,
             base_url: provider.base_url().to_string(),
-            model_name: model_id.to_string(),
+            model_name,
             endpoint_path: endpoint.path().to_string(),
             api_key: provider.api_key().cloned(),
             verify_ssl: provider.verify_ssl(),
@@ -207,13 +230,6 @@ mod tests {
     use std::collections::HashMap;
     use std::sync::Arc;
 
-    // Re-export TestModel as pub(crate) so test helpers can use it.
-    #[derive(Default)]
-    pub(crate) struct TestModel {
-        pub(crate) supported_functions: Vec<ModelFunction>,
-        pub(crate) provider: FakeProvider,
-    }
-
     #[derive(Clone, Default)]
     pub(crate) struct FakeProvider {
         pub(crate) base_url: String,
@@ -221,6 +237,8 @@ mod tests {
         pub(crate) verify_ssl: bool,
         pub(crate) api_types: Vec<ApiType>,
         pub(crate) endpoints: HashMap<ModelFunction, Vec<ApiEndpoint>>,
+        /// When set, `model_alias` returns this value instead of `None`.
+        pub(crate) alias: Option<String>,
     }
 
     impl ConfigConstructable for FakeProvider {
@@ -254,20 +272,92 @@ mod tests {
         fn supported_formats(&self) -> Vec<ModelFormat> {
             vec![]
         }
+        fn model_alias(&self, _variant: Option<&crate::models::ModelVariant>) -> Option<String> {
+            self.alias.clone()
+        }
         async fn health_check(&self) -> Result<HealthStatus, ProviderError> {
             unimplemented!("not used in tests")
         }
     }
 
-    impl ConfigConstructable for TestModel {
-        type Config = crate::registry::NoConfig;
+    fn ok_provider(
+        api_types: Vec<ApiType>,
+        function: ModelFunction,
+        endpoint: ApiEndpoint,
+    ) -> FakeProvider {
+        let mut endpoints = HashMap::new();
+        endpoints.insert(function, vec![endpoint]);
+        FakeProvider {
+            base_url: "http://localhost:11434".to_string(),
+            api_key: None,
+            verify_ssl: true,
+            api_types,
+            endpoints,
+            alias: None,
+        }
+    }
 
+    /// Create an AgentModelCapability with a custom test model and provider.
+    /// Uses a real registry model ID so `with_config` can construct the model.
+    fn capability_with_test_model(
+        functions: Vec<ModelFunction>,
+        provider: FakeProvider,
+    ) -> AgentModelCapability {
+        capability_with_test_model_and_variant(functions, provider, None)
+    }
+
+    /// Like `capability_with_test_model` but also sets `configured_variant`
+    /// and populates the test model's variants list, enabling `resolve_variant`
+    /// and `model_alias` to be exercised at bind time.
+    fn capability_with_test_model_and_variant(
+        functions: Vec<ModelFunction>,
+        provider: FakeProvider,
+        configured_variant: Option<(&str, Vec<crate::models::ModelVariant>)>,
+    ) -> AgentModelCapability {
+        let (variant_str, variants) = configured_variant
+            .map(|(s, v)| (Some(s.to_string()), v))
+            .unwrap_or((None, vec![]));
+        let mut config = Config::default();
+        config.models.insert(
+            "granite-3.1-8b-instruct".to_string(),
+            ModelConfig {
+                model_id: "granite-3.1-8b-instruct".to_string(),
+                provider_id: None,
+                variant: variant_str.clone(),
+            },
+        );
+        let cap = AgentModelCapability::with_config(
+            &serde_json::json!({ "model_id": "granite-3.1-8b-instruct" }),
+            &config,
+        );
+        // Replace the real model with our test double that has a custom provider
+        // and the specified variants list.
+        AgentModelCapability {
+            config: cap.config,
+            configured_variant: variant_str,
+            model: Arc::new(TestModelWithVariants {
+                supported_functions: functions,
+                provider,
+                variants,
+            }),
+        }
+    }
+
+    /// Extended test model that carries a mutable variants list.
+    struct TestModelWithVariants {
+        supported_functions: Vec<ModelFunction>,
+        provider: FakeProvider,
+        variants: Vec<crate::models::ModelVariant>,
+    }
+
+    impl ConfigConstructable for TestModelWithVariants {
+        type Config = crate::registry::NoConfig;
         fn new(_cfg: &serde_json::Value) -> Self {
             unimplemented!("not used in tests")
         }
     }
 
-    impl Model for TestModel {
+    impl Model for TestModelWithVariants {
         fn family(&self) -> &str {
             "Test"
         }
@@ -293,7 +383,7 @@ mod tests {
             unimplemented!("not used in tests")
         }
         fn variants(&self) -> &[crate::models::ModelVariant] {
-            &[]
+            &self.variants
         }
         fn description(&self) -> Option<&str> {
             None
@@ -307,52 +397,6 @@ mod tests {
         fn provider(&self) -> anyhow::Result<Box<dyn Provider>> {
             Ok(Box::new(self.provider.clone()))
         }
-    }
-
-    fn ok_provider(
-        api_types: Vec<ApiType>,
-        function: ModelFunction,
-        endpoint: ApiEndpoint,
-    ) -> FakeProvider {
-        let mut endpoints = HashMap::new();
-        endpoints.insert(function, vec![endpoint]);
-        FakeProvider {
-            base_url: "http://localhost:11434".to_string(),
-            api_key: None,
-            verify_ssl: true,
-            api_types,
-            endpoints,
-        }
-    }
-
-    /// Create an AgentModelCapability with a custom test model and provider.
-    /// Uses a real registry model ID so `with_config` can construct the model.
-    fn capability_with_test_model(
-        functions: Vec<ModelFunction>,
-        provider: FakeProvider,
-    ) -> AgentModelCapability {
-        let mut config = Config::default();
-        config.models.insert(
-            "granite-3.1-8b-instruct".to_string(),
-            ModelConfig {
-                model_id: "granite-3.1-8b-instruct".to_string(),
-                provider_id: None,
-                variant: None,
-            },
-        );
-        let cap = AgentModelCapability::with_config(
-            &serde_json::json!({ "model_id": "granite-3.1-8b-instruct" }),
-            &config,
-        );
-        // Replace the real model with our test double that has a custom provider.
-        let cap = AgentModelCapability {
-            config: cap.config,
-            model: Arc::new(TestModel {
-                supported_functions: functions,
-                provider,
-            }),
-        };
-        cap
     }
 
     #[tokio::test]
@@ -391,6 +435,7 @@ mod tests {
                 verify_ssl: true,
                 api_types: vec![ApiType::OpenAI],
                 endpoints: HashMap::new(),
+                alias: None,
             },
         );
 
@@ -521,5 +566,67 @@ mod tests {
                 ..
             }
         )));
+    }
+
+    #[tokio::test]
+    async fn bind_uses_provider_alias_when_variant_matches() {
+        let ollama_variant = crate::models::ModelVariant {
+            format: "Ollama".to_string(),
+            precision: "Q4_K_M".to_string(),
+            size_gb: 5.3,
+            url: "https://ollama.com/library/granite4.1:8b".to_string(),
+        };
+        let cap = capability_with_test_model_and_variant(
+            vec![ModelFunction::Chat],
+            FakeProvider {
+                alias: Some("granite4.1:8b".to_string()),
+                ..ok_provider(
+                    vec![ApiType::OpenAI],
+                    ModelFunction::Chat,
+                    ApiEndpoint::OpenAIChat,
+                )
+            },
+            Some(("Ollama/Q4_K_M", vec![ollama_variant])),
+        );
+
+        let binding = cap
+            .bind(BindingRequest::AgentModel(AgentModelBindingRequest {
+                api_type: ApiType::OpenAI,
+            }))
+            .await
+            .unwrap();
+
+        let Binding::AgentModel(binding) = binding;
+        assert_eq!(binding.model_name, "granite4.1:8b");
+    }
+
+    #[tokio::test]
+    async fn bind_falls_back_to_catalog_id_when_alias_is_none() {
+        let ollama_variant = crate::models::ModelVariant {
+            format: "Ollama".to_string(),
+            precision: "Q4_K_M".to_string(),
+            size_gb: 5.3,
+            url: "https://ollama.com/library/granite4.1:8b".to_string(),
+        };
+        // Provider returns None for model_alias (default FakeProvider behaviour)
+        let cap = capability_with_test_model_and_variant(
+            vec![ModelFunction::Chat],
+            ok_provider(
+                vec![ApiType::OpenAI],
+                ModelFunction::Chat,
+                ApiEndpoint::OpenAIChat,
+            ),
+            Some(("Ollama/Q4_K_M", vec![ollama_variant])),
+        );
+
+        let binding = cap
+            .bind(BindingRequest::AgentModel(AgentModelBindingRequest {
+                api_type: ApiType::OpenAI,
+            }))
+            .await
+            .unwrap();
+
+        let Binding::AgentModel(binding) = binding;
+        assert_eq!(binding.model_name, "granite-3.1-8b-instruct");
     }
 }

--- a/src/capabilities/base.rs
+++ b/src/capabilities/base.rs
@@ -91,6 +91,7 @@ pub struct AgentModelBinding {
     pub endpoint_path: String,
     pub api_key: Option<Secret>,
     pub verify_ssl: bool,
+    pub context_length: u64,
 }
 
 define_bindings! {

--- a/src/capabilities/base.rs
+++ b/src/capabilities/base.rs
@@ -1,8 +1,6 @@
 use crate::capabilities::requirement::{
     ModelRequirement, ProviderRequirement, ShellCommandRequirement,
 };
-use crate::dependency::Configured;
-use crate::models::Model;
 use crate::providers::ApiType;
 use crate::registry::{ConfigConstructable, Secret};
 use async_trait::async_trait;
@@ -116,14 +114,8 @@ pub trait Capability: Send + Sync {
     /// Which binding surfaces this capability instance can fill.
     fn binding_types(&self) -> HashSet<BindingType>;
 
-    /// Resolve a `BindingRequest` into a concrete `Binding`, looking up this
-    /// capability's model dependency from the given source. A model's own
-    /// provider is reached via `Model::provider()`.
-    async fn bind(
-        &self,
-        request: BindingRequest,
-        models: &(dyn Configured<dyn Model> + Sync),
-    ) -> anyhow::Result<Binding>;
+    /// Resolve a `BindingRequest` into a concrete `Binding`.
+    async fn bind(&self, request: BindingRequest) -> anyhow::Result<Binding>;
 
     // Execution hooks (all optional with NoOp defaults)
     async fn on_setup(&self) -> anyhow::Result<()> {

--- a/src/capabilities/mod.rs
+++ b/src/capabilities/mod.rs
@@ -29,10 +29,19 @@ impl CapabilitySource {
             .capabilities
             .values()
             .filter_map(|capability_config| {
-                let result = CAPABILITY_REGISTRY.construct(
-                    &capability_config.capability_type,
-                    &capability_config.config,
-                );
+                let result = match capability_config.capability_type.as_str() {
+                    "agent-model" => {
+                        let cap = agent_model::AgentModelCapability::with_config(
+                            &capability_config.config,
+                            config,
+                        );
+                        Ok(Box::new(cap) as Box<dyn crate::capabilities::Capability>)
+                    }
+                    _ => CAPABILITY_REGISTRY.construct(
+                        &capability_config.capability_type,
+                        &capability_config.config,
+                    ),
+                };
                 if result.is_err() {
                     alog_channel!(
                         MessageLevel::Warning,
@@ -85,15 +94,15 @@ pub use agent_model::{AgentModelCapability, AgentModelCapabilityConfig};
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::config::{CapabilityConfig, Config};
+    use crate::config::{CapabilityConfig, Config, ModelConfig};
     use crate::dependency::Configured;
 
-    fn agent_model_config(id: &str, model_id: &str) -> CapabilityConfig {
+    fn agent_model_config(id: &str, model_key: &str) -> CapabilityConfig {
         CapabilityConfig {
             capability_id: id.to_string(),
             capability_type: "agent-model".to_string(),
             config: serde_json::json!({
-                "model_id": model_id,
+                "model_id": model_key,
             }),
         }
     }
@@ -101,6 +110,15 @@ mod tests {
     #[test]
     fn capability_source_constructs_one_instance_per_named_capability() {
         let mut config = Config::default();
+        // Add the model entry that the capability will look up.
+        config.models.insert(
+            "granite-3.1-8b-instruct".to_string(),
+            ModelConfig {
+                model_id: "granite-3.1-8b-instruct".to_string(),
+                provider_id: None,
+                variant: None,
+            },
+        );
         config.capabilities.insert(
             "chat".to_string(),
             agent_model_config("chat", "granite-3.1-8b-instruct"),

--- a/src/capabilities/mod.rs
+++ b/src/capabilities/mod.rs
@@ -29,19 +29,11 @@ impl CapabilitySource {
             .capabilities
             .values()
             .filter_map(|capability_config| {
-                let result = match capability_config.capability_type.as_str() {
-                    "agent-model" => {
-                        let cap = agent_model::AgentModelCapability::with_config(
-                            &capability_config.config,
-                            config,
-                        );
-                        Ok(Box::new(cap) as Box<dyn crate::capabilities::Capability>)
-                    }
-                    _ => CAPABILITY_REGISTRY.construct(
-                        &capability_config.capability_type,
-                        &capability_config.config,
-                    ),
-                };
+                let result = CAPABILITY_REGISTRY.construct(
+                    &capability_config.capability_type,
+                    &capability_config.config,
+                    config,
+                );
                 if result.is_err() {
                     alog_channel!(
                         MessageLevel::Warning,

--- a/src/commands/capability.rs
+++ b/src/commands/capability.rs
@@ -190,13 +190,11 @@ impl CapabilityCommands {
         }
         let mut config = prompt_from_schema(&*ctx.ui, &schema, &defaults)?;
 
-        // Phase B: build a preview instance from what's been collected so
-        // far, then resolve its actual (possibly narrowed) dependencies
-        // against currently configured models/providers.
-        let preview = CAPABILITY_REGISTRY
-            .construct(capability_type, &config)
-            .map_err(|e| anyhow::anyhow!(e))?;
-        for dep in preview.dependencies() {
+        // Phase B: resolve the capability's dependencies (model/provider)
+        // against currently configured models/providers. Use the capability
+        // definition's metadata rather than a preview instance, since some
+        // dependency fields (like model_id) may not be set yet.
+        for dep in &cap_def.dependencies {
             match dep {
                 Dependency::Model {
                     config_key,
@@ -205,13 +203,13 @@ impl CapabilityCommands {
                     ..
                 } => {
                     if let Some(id) =
-                        Self::resolve_model_dependency(ctx, &requirement, required).await?
+                        Self::resolve_model_dependency(ctx, requirement, *required).await?
                     {
                         config
                             // NOTE: Safe since config MUST be an object when registered
                             .as_object_mut()
                             .unwrap()
-                            .insert(config_key, serde_json::Value::String(id));
+                            .insert(config_key.clone(), serde_json::Value::String(id));
                     }
                 }
                 Dependency::Provider {
@@ -221,20 +219,20 @@ impl CapabilityCommands {
                     ..
                 } => {
                     if let Some(id) =
-                        Self::resolve_provider_dependency(ctx, &requirement, required).await?
+                        Self::resolve_provider_dependency(ctx, requirement, *required).await?
                     {
                         config
                             // NOTE: Safe since config MUST be an object when registered
                             .as_object_mut()
                             .unwrap()
-                            .insert(config_key, serde_json::Value::String(id));
+                            .insert(config_key.clone(), serde_json::Value::String(id));
                     }
                 }
                 Dependency::ExternalTool {
                     requirement,
                     required,
                 } => {
-                    if required && !requirement.is_satisfied() {
+                    if *required && !requirement.is_satisfied() {
                         anyhow::bail!(
                             "Required external command '{}' is not available.",
                             requirement.command

--- a/src/commands/launcher.rs
+++ b/src/commands/launcher.rs
@@ -2,6 +2,8 @@
 use anyhow::Result;
 
 // Local
+use crate::capabilities::{CAPABILITY_REGISTRY, CapabilitySource};
+use crate::dependency::Configured;
 use crate::launchers::LAUNCHER_REGISTRY;
 use crate::utils::prompt_from_schema;
 
@@ -201,10 +203,19 @@ impl LauncherCommands {
             }
         }
 
+        // Select capabilities to enable for this launcher.
+        let previously_enabled: Vec<String> = ctx
+            .config
+            .get_launcher(&instance_id)
+            .map(|lc| lc.enabled_capabilities.clone())
+            .unwrap_or_default();
+        let enabled_capabilities =
+            select_capabilities(ctx, &launcher_def, &previously_enabled).await?;
+
         let launcher_config = crate::config::LauncherConfig {
             launcher_id: instance_id.clone(),
             launcher_type: launcher_type.to_string(),
-            enabled_capabilities: vec![],
+            enabled_capabilities,
             config,
         };
 
@@ -242,6 +253,116 @@ impl LauncherCommands {
         ctx.ui.info(&format!("Launcher '{launcher_id}' removed."));
         Ok(())
     }
+}
+
+/*-- private --*/
+
+/// Presents the user with a multi-select of capability instances (and a
+/// "Configure a new capability…" option) filtered to those compatible with
+/// `launcher_def.supported_capabilities`. Returns the list of capability IDs
+/// the user chose to enable.
+///
+/// Returns an empty vec and emits a warning when the launcher supports no
+/// capabilities at all (e.g. `bob`).
+async fn select_capabilities(
+    ctx: &mut crate::AppContext,
+    launcher_def: &crate::launchers::LauncherMetadata,
+    previously_enabled: &[String],
+) -> Result<Vec<String>> {
+    if launcher_def.supported_capabilities.is_empty() {
+        ctx.ui.warn(
+            "This launcher does not support any capabilities. \
+             No capabilities will be enabled.",
+        );
+        return Ok(vec![]);
+    }
+
+    let source = CapabilitySource::from_config(&ctx.config);
+
+    // Instances whose binding_types() intersect the launcher's supported set.
+    let mut compatible_instances: Vec<String> = source
+        .instances()
+        .into_iter()
+        .filter(|(_, cap)| {
+            cap.binding_types()
+                .iter()
+                .any(|bt| launcher_def.supported_capabilities.contains(bt))
+        })
+        .map(|(id, _)| id)
+        .collect();
+    compatible_instances.sort();
+
+    // Catalog types whose supported_binding_types intersect the launcher's set.
+    let compatible_types: Vec<&'static str> = {
+        let mut types: Vec<&'static str> = CAPABILITY_REGISTRY
+            .entries()
+            .into_iter()
+            .filter(|(_, meta)| {
+                meta.supported_binding_types
+                    .iter()
+                    .any(|bt| launcher_def.supported_capabilities.contains(bt))
+            })
+            .map(|(name, _)| name)
+            .collect();
+        types.sort();
+        types
+    };
+
+    if compatible_instances.is_empty() && compatible_types.is_empty() {
+        ctx.ui
+            .info("No compatible capabilities are configured or available for this launcher.");
+        return Ok(vec![]);
+    }
+
+    const CONFIGURE_NEW: &str = "Configure a new capability...";
+
+    // Build display list: sorted instances, then sentinel if types exist.
+    let mut items: Vec<String> = compatible_instances.clone();
+    if !compatible_types.is_empty() {
+        items.push(CONFIGURE_NEW.to_string());
+    }
+
+    // Pre-check items that were previously enabled.
+    let defaults: Vec<bool> = items
+        .iter()
+        .map(|item| item != CONFIGURE_NEW && previously_enabled.contains(item))
+        .collect();
+
+    let selected = ctx
+        .ui
+        .multi_select("Select capabilities to enable", &items, &defaults)?;
+
+    let mut result: Vec<String> = vec![];
+    let mut configure_new_chosen = false;
+    for idx in selected {
+        if items[idx] == CONFIGURE_NEW {
+            configure_new_chosen = true;
+        } else {
+            result.push(items[idx].clone());
+        }
+    }
+
+    if configure_new_chosen {
+        // Mirror the select_provider pattern: auto-select when only one type,
+        // otherwise let the user pick.
+        let cap_type = if compatible_types.len() == 1 {
+            compatible_types[0]
+        } else {
+            let type_options: Vec<String> =
+                compatible_types.iter().map(|s| s.to_string()).collect();
+            let idx = ctx
+                .ui
+                .select("Select a capability type to configure", &type_options, 0)?;
+            compatible_types[idx]
+        };
+
+        let nickname = ctx.ui.text("Name this capability instance", cap_type)?;
+
+        crate::commands::CapabilityCommands::setup(ctx, cap_type, Some(&nickname)).await?;
+        result.push(nickname);
+    }
+
+    Ok(result)
 }
 
 /*-- tests --*/
@@ -439,5 +560,158 @@ mod tests {
         let tables = tables!(ctx);
         let (_, _, rows) = &tables[0];
         assert!(rows.is_empty());
+    }
+
+    // -- select_capabilities ---------------------------------------------------
+
+    macro_rules! capture_ui {
+        ($ctx:expr) => {
+            (&*($ctx.ui) as &dyn std::any::Any)
+                .downcast_ref::<CaptureUi>()
+                .unwrap()
+        };
+    }
+
+    /// Returns a `LauncherMetadata` for `claude` from the registry.
+    fn claude_launcher_def() -> crate::launchers::LauncherMetadata {
+        crate::launchers::LAUNCHER_REGISTRY
+            .get("claude")
+            .unwrap()
+            .clone()
+    }
+
+    /// Returns a `LauncherMetadata` for `bob` from the registry.
+    fn bob_launcher_def() -> crate::launchers::LauncherMetadata {
+        crate::launchers::LAUNCHER_REGISTRY
+            .get("bob")
+            .unwrap()
+            .clone()
+    }
+
+    // Helper: insert a minimal agent-model capability config into ctx.
+    fn add_capability(ctx: &mut crate::AppContext, cap_id: &str, model_id: &str) {
+        ctx.config.capabilities.insert(
+            cap_id.to_string(),
+            crate::config::CapabilityConfig {
+                capability_id: cap_id.to_string(),
+                capability_type: "agent-model".to_string(),
+                config: serde_json::json!({ "model_id": model_id }),
+            },
+        );
+    }
+
+    // bob launcher has empty supported_capabilities → warning is emitted and
+    // empty vec returned without calling multi_select.
+    #[tokio::test]
+    async fn select_capabilities_warns_and_skips_for_launcher_with_no_supported_capabilities() {
+        let mut ctx = test_ctx();
+        let launcher_def = bob_launcher_def();
+        let result = select_capabilities(&mut ctx, &launcher_def, &[])
+            .await
+            .unwrap();
+        assert!(result.is_empty());
+        let ui = capture_ui!(ctx);
+        assert!(
+            ui.warns
+                .borrow()
+                .iter()
+                .any(|w| w.contains("does not support any capabilities")),
+            "expected a warning about no supported capabilities"
+        );
+        assert!(
+            ui.multi_select_prompts.borrow().is_empty(),
+            "multi_select should not be called for a launcher with no supported capabilities"
+        );
+    }
+
+    // When no capabilities are configured and no types can satisfy the launcher,
+    // an info message is printed and empty vec returned.
+    #[tokio::test]
+    async fn select_capabilities_returns_empty_when_no_compatible_capabilities_exist() {
+        let mut ctx = test_ctx();
+        // claude supports AgentModel; agent-model is in the catalog — so
+        // compatible_types will be non-empty and multi_select IS called.
+        // To test the "nothing at all" path we'd need a launcher type that
+        // supports a binding type with no catalog entry.  Instead, verify
+        // that multi_select is called with the "Configure a new capability..."
+        // sentinel when no instances are configured.
+        let launcher_def = claude_launcher_def();
+        // CaptureUi returns empty vec by default → user selects nothing.
+        let result = select_capabilities(&mut ctx, &launcher_def, &[])
+            .await
+            .unwrap();
+        assert!(result.is_empty());
+        let ui = capture_ui!(ctx);
+        // multi_select must have been called
+        let prompts = ui.multi_select_prompts.borrow();
+        assert_eq!(prompts.len(), 1);
+        // sentinel is included because agent-model is in the catalog
+        assert!(
+            prompts[0]
+                .1
+                .iter()
+                .any(|i| i == "Configure a new capability...")
+        );
+    }
+
+    // When a capability instance is configured and compatible, it appears in the
+    // multi_select items list.
+    #[tokio::test]
+    async fn select_capabilities_shows_configured_compatible_instance() {
+        let mut ctx = test_ctx();
+        add_capability(&mut ctx, "my-agent", "granite-3.1-8b-instruct");
+        let launcher_def = claude_launcher_def();
+        let result = select_capabilities(&mut ctx, &launcher_def, &[])
+            .await
+            .unwrap();
+        assert!(result.is_empty()); // user selected nothing (default)
+        let ui = capture_ui!(ctx);
+        let prompts = ui.multi_select_prompts.borrow();
+        assert_eq!(prompts.len(), 1);
+        assert!(
+            prompts[0].1.contains(&"my-agent".to_string()),
+            "expected instance id in items"
+        );
+    }
+
+    // Previously-enabled capability IDs are pre-checked (defaults = true).
+    #[tokio::test]
+    async fn select_capabilities_pre_checks_previously_enabled_ids() {
+        let mut ctx = test_ctx();
+        add_capability(&mut ctx, "my-agent", "granite-3.1-8b-instruct");
+        let launcher_def = claude_launcher_def();
+        let previously_enabled = vec!["my-agent".to_string()];
+        let _ = select_capabilities(&mut ctx, &launcher_def, &previously_enabled)
+            .await
+            .unwrap();
+        let ui = capture_ui!(ctx);
+        let prompts = ui.multi_select_prompts.borrow();
+        assert_eq!(prompts.len(), 1);
+        let idx = prompts[0]
+            .1
+            .iter()
+            .position(|i| i == "my-agent")
+            .expect("my-agent should be in items");
+        assert!(
+            prompts[0].2[idx],
+            "my-agent should be pre-checked as it was previously enabled"
+        );
+    }
+
+    // Selecting an existing instance returns its ID.
+    #[tokio::test]
+    async fn select_capabilities_returns_selected_instance_id() {
+        let mut ctx = test_ctx();
+        add_capability(&mut ctx, "my-agent", "granite-3.1-8b-instruct");
+        let launcher_def = claude_launcher_def();
+        {
+            let ui = capture_ui!(ctx);
+            // Select index 0 (the "my-agent" instance — it sorts first before sentinel)
+            ui.multi_select_answers.borrow_mut().push_back(vec![0]);
+        }
+        let result = select_capabilities(&mut ctx, &launcher_def, &[])
+            .await
+            .unwrap();
+        assert_eq!(result, vec!["my-agent".to_string()]);
     }
 }

--- a/src/commands/launcher.rs
+++ b/src/commands/launcher.rs
@@ -596,7 +596,17 @@ mod tests {
     }
 
     // Helper: insert a minimal agent-model capability config into ctx.
+    // Also adds the model to config.models so CapabilitySource::from_config
+    // can construct the underlying AgentModelCapability.
     fn add_capability(ctx: &mut crate::AppContext, cap_id: &str, model_id: &str) {
+        ctx.config.models.insert(
+            model_id.to_string(),
+            crate::config::ModelConfig {
+                model_id: model_id.to_string(),
+                provider_id: None,
+                variant: None,
+            },
+        );
         ctx.config.capabilities.insert(
             cap_id.to_string(),
             crate::config::CapabilityConfig {

--- a/src/commands/launcher.rs
+++ b/src/commands/launcher.rs
@@ -187,7 +187,7 @@ impl LauncherCommands {
         // Validate the binary now so the user gets immediate feedback.
         // validate_command respects command_path when set; falls back to PATH.
         let launcher = LAUNCHER_REGISTRY
-            .construct(launcher_type, &config)
+            .construct(launcher_type, &config, &ctx.config)
             .map_err(|e| anyhow::anyhow!("Failed to construct launcher: {e}"))?;
 
         match launcher.validate_command() {

--- a/src/commands/launcher.rs
+++ b/src/commands/launcher.rs
@@ -500,6 +500,11 @@ mod tests {
 
     #[tokio::test]
     async fn setup_warns_on_same_type_existing_instance() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let home = tmp.path().join("granite-cli-test-launcher-setup");
+        // SAFETY: single-threaded test; no other thread reads this var.
+        unsafe { std::env::set_var("GRANITE_CLI_HOME", &home) };
+
         // Pre-populate a "claude" instance named "claude-old"
         let mut ctx = ctx_with_launcher("claude-old", "claude");
         // CaptureUi confirm always returns false → user declines update and
@@ -512,6 +517,8 @@ mod tests {
             infos.iter().any(|m| m.contains("claude-old")),
             "expected clash warning to mention the existing instance"
         );
+
+        unsafe { std::env::remove_var("GRANITE_CLI_HOME") };
     }
 
     #[tokio::test]

--- a/src/commands/model.rs
+++ b/src/commands/model.rs
@@ -1109,6 +1109,7 @@ mod tests {
         };
         let provider = crate::providers::OpenAIProvider::new(
             &serde_json::json!({ "base_url": "http://localhost:8080" }),
+            &crate::config::Config::default(),
         );
         assert!(requirement.admits_instance(&provider));
     }

--- a/src/commands/provider.rs
+++ b/src/commands/provider.rs
@@ -234,7 +234,7 @@ impl ProviderCommands {
         })?;
 
         let provider = PROVIDER_REGISTRY
-            .construct(&provider_config.provider_type, &provider_config.config)
+            .construct(&provider_config.provider_type, &provider_config.config, &ctx.config)
             .map_err(|e| anyhow::anyhow!("Failed to create provider: {e}"))?;
 
         let status = provider.health_check().await?;

--- a/src/commands/provider.rs
+++ b/src/commands/provider.rs
@@ -234,7 +234,11 @@ impl ProviderCommands {
         })?;
 
         let provider = PROVIDER_REGISTRY
-            .construct(&provider_config.provider_type, &provider_config.config, &ctx.config)
+            .construct(
+                &provider_config.provider_type,
+                &provider_config.config,
+                &ctx.config,
+            )
             .map_err(|e| anyhow::anyhow!("Failed to create provider: {e}"))?;
 
         let status = provider.health_check().await?;

--- a/src/launchers/base.rs
+++ b/src/launchers/base.rs
@@ -190,7 +190,7 @@ pub(crate) mod tests {
     impl ConfigConstructable for FakeLauncher {
         type Config = crate::registry::NoConfig;
 
-        fn new(cfg: &serde_json::Value) -> Self {
+        fn new(cfg: &serde_json::Value, _global_config: &crate::config::Config) -> Self {
             let command_name = cfg
                 .get("command_name")
                 .and_then(|v| v.as_str())
@@ -251,7 +251,7 @@ pub(crate) mod tests {
     fn validate_command_returns_err_for_unknown_binary() {
         let launcher = FakeLauncher::new(&serde_json::json!({
             "command_name": "this-binary-absolutely-does-not-exist-9x7z"
-        }));
+        }), &crate::config::Config::default());
         assert!(launcher.validate_command().is_err());
     }
 
@@ -260,7 +260,7 @@ pub(crate) mod tests {
         let launcher = FakeLauncher::new(&serde_json::json!({
             "command_name": "fake",
             "command_path": "/this/path/does/not/exist/fake"
-        }));
+        }), &crate::config::Config::default());
         assert!(launcher.validate_command().is_err());
     }
 
@@ -268,13 +268,13 @@ pub(crate) mod tests {
     fn validate_command_falls_back_to_path_for_bare_command_name() {
         let launcher = FakeLauncher::new(&serde_json::json!({
             "command_path": "ls"
-        }));
+        }), &crate::config::Config::default());
         assert!(launcher.validate_command().is_ok());
     }
 
     #[tokio::test]
     async fn env_overlay_default_is_empty() {
-        let launcher = FakeLauncher::new(&serde_json::json!({}));
+        let launcher = FakeLauncher::new(&serde_json::json!({}), &crate::config::Config::default());
         let ctx = LaunchContext {
             launcher_id: "test".to_string(),
             working_dir: PathBuf::from("/tmp"),
@@ -297,7 +297,7 @@ pub(crate) mod tests {
     fn launcher_factory_construct() {
         let mut factory = LauncherFactory::new();
         factory.register::<FakeLauncher>("fake");
-        let result = factory.construct("fake", &serde_json::json!({}));
+        let result = factory.construct("fake", &serde_json::json!({}), &crate::config::Config::default());
         assert!(result.is_ok());
     }
 

--- a/src/launchers/base.rs
+++ b/src/launchers/base.rs
@@ -3,7 +3,7 @@ use std::collections::{HashMap, HashSet};
 use std::path::PathBuf;
 
 // Third Party
-use alog::{alog_channel, use_channel, MessageLevel};
+use alog::{MessageLevel, alog_channel, use_channel};
 use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
 

--- a/src/launchers/base.rs
+++ b/src/launchers/base.rs
@@ -249,26 +249,35 @@ pub(crate) mod tests {
 
     #[test]
     fn validate_command_returns_err_for_unknown_binary() {
-        let launcher = FakeLauncher::new(&serde_json::json!({
-            "command_name": "this-binary-absolutely-does-not-exist-9x7z"
-        }), &crate::config::Config::default());
+        let launcher = FakeLauncher::new(
+            &serde_json::json!({
+                "command_name": "this-binary-absolutely-does-not-exist-9x7z"
+            }),
+            &crate::config::Config::default(),
+        );
         assert!(launcher.validate_command().is_err());
     }
 
     #[test]
     fn validate_command_returns_err_for_nonexistent_explicit_path() {
-        let launcher = FakeLauncher::new(&serde_json::json!({
-            "command_name": "fake",
-            "command_path": "/this/path/does/not/exist/fake"
-        }), &crate::config::Config::default());
+        let launcher = FakeLauncher::new(
+            &serde_json::json!({
+                "command_name": "fake",
+                "command_path": "/this/path/does/not/exist/fake"
+            }),
+            &crate::config::Config::default(),
+        );
         assert!(launcher.validate_command().is_err());
     }
 
     #[test]
     fn validate_command_falls_back_to_path_for_bare_command_name() {
-        let launcher = FakeLauncher::new(&serde_json::json!({
-            "command_path": "ls"
-        }), &crate::config::Config::default());
+        let launcher = FakeLauncher::new(
+            &serde_json::json!({
+                "command_path": "ls"
+            }),
+            &crate::config::Config::default(),
+        );
         assert!(launcher.validate_command().is_ok());
     }
 
@@ -297,7 +306,11 @@ pub(crate) mod tests {
     fn launcher_factory_construct() {
         let mut factory = LauncherFactory::new();
         factory.register::<FakeLauncher>("fake");
-        let result = factory.construct("fake", &serde_json::json!({}), &crate::config::Config::default());
+        let result = factory.construct(
+            "fake",
+            &serde_json::json!({}),
+            &crate::config::Config::default(),
+        );
         assert!(result.is_ok());
     }
 

--- a/src/launchers/base.rs
+++ b/src/launchers/base.rs
@@ -3,6 +3,7 @@ use std::collections::{HashMap, HashSet};
 use std::path::PathBuf;
 
 // Third Party
+use alog::{alog_channel, use_channel, MessageLevel};
 use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
 
@@ -11,6 +12,8 @@ use crate::capabilities::BindingType;
 use crate::define_factory;
 use crate::registry::ConfigConstructable;
 use crate::utils::ui::Ui;
+
+use_channel!("LNCHR");
 
 /*-- public --*/
 
@@ -68,6 +71,7 @@ pub trait Launcher: Send + Sync {
     ) -> anyhow::Result<std::process::ExitStatus> {
         let binary = self.validate_command()?;
         let overlay = self.env_overlay(ctx).await?;
+        alog_channel!(MessageLevel::Debug2, "Env Overlay: {:#?}", overlay);
         run_command(binary, &overlay, args, ctx, ui).await
     }
 }
@@ -159,6 +163,7 @@ pub struct LaunchContext {
 }
 
 /// A single environment variable binding contributed to the subprocess overlay.
+#[derive(Debug)]
 pub struct EnvBinding {
     pub key: String,
     pub value: String,

--- a/src/launchers/base.rs
+++ b/src/launchers/base.rs
@@ -33,7 +33,8 @@ pub trait Launcher: Send + Sync {
     /// resolved `Binding` for use in `env_overlay` / `launch`.
     async fn bind_capability(
         &mut self,
-        _capability: &dyn crate::capabilities::Capability,
+        capability: &dyn crate::capabilities::Capability,
+        models: &(dyn crate::dependency::Configured<dyn crate::models::Model> + Sync),
     ) -> anyhow::Result<()>;
 
     /// Resolve the binary to an absolute path.
@@ -215,6 +216,7 @@ pub(crate) mod tests {
         async fn bind_capability(
             &mut self,
             _capability: &dyn crate::capabilities::Capability,
+            _models: &(dyn crate::dependency::Configured<dyn crate::models::Model> + Sync),
         ) -> anyhow::Result<()> {
             anyhow::bail!("Capability binding not supported");
         }

--- a/src/launchers/base.rs
+++ b/src/launchers/base.rs
@@ -25,10 +25,16 @@ pub trait Launcher: Send + Sync {
     /// lookup (e.g. `"claude"`) or an absolute path set by the user in config.
     fn command(&self) -> &str;
 
-    /// Binding surfaces this launcher type supports.
-    /// Default implementation delegates to `metadata()` so there is no need
-    /// to duplicate the list on the instance.
-    fn supported_capabilities(&self) -> HashSet<BindingType>;
+    /// Bind a capability to this launcher instance.
+    ///
+    /// The implementation should validate that the capability's `binding_types()`
+    /// are supported by this launcher type (per `metadata().supported_capabilities`),
+    /// construct the appropriate `BindingRequest`, call `bind()`, and store the
+    /// resolved `Binding` for use in `env_overlay` / `launch`.
+    async fn bind_capability(
+        &mut self,
+        _capability: &dyn crate::capabilities::Capability,
+    ) -> anyhow::Result<()>;
 
     /// Resolve the binary to an absolute path.
     ///
@@ -206,8 +212,11 @@ pub(crate) mod tests {
             &self.command_name
         }
 
-        fn supported_capabilities(&self) -> HashSet<BindingType> {
-            Self::metadata().supported_capabilities
+        async fn bind_capability(
+            &mut self,
+            _capability: &dyn crate::capabilities::Capability,
+        ) -> anyhow::Result<()> {
+            anyhow::bail!("Capability binding not supported");
         }
 
         fn validate_command(&self) -> anyhow::Result<PathBuf> {

--- a/src/launchers/base.rs
+++ b/src/launchers/base.rs
@@ -34,7 +34,6 @@ pub trait Launcher: Send + Sync {
     async fn bind_capability(
         &mut self,
         capability: &dyn crate::capabilities::Capability,
-        models: &(dyn crate::dependency::Configured<dyn crate::models::Model> + Sync),
     ) -> anyhow::Result<()>;
 
     /// Resolve the binary to an absolute path.
@@ -216,7 +215,6 @@ pub(crate) mod tests {
         async fn bind_capability(
             &mut self,
             _capability: &dyn crate::capabilities::Capability,
-            _models: &(dyn crate::dependency::Configured<dyn crate::models::Model> + Sync),
         ) -> anyhow::Result<()> {
             anyhow::bail!("Capability binding not supported");
         }

--- a/src/launchers/bob.rs
+++ b/src/launchers/bob.rs
@@ -83,25 +83,34 @@ mod tests {
 
     #[test]
     fn command_uses_explicit_path_when_set() {
-        let l = BobLauncher::new(&serde_json::json!({
-            "command_path": "/opt/bin/bob"
-        }), &crate::config::Config::default());
+        let l = BobLauncher::new(
+            &serde_json::json!({
+                "command_path": "/opt/bin/bob"
+            }),
+            &crate::config::Config::default(),
+        );
         assert_eq!(l.command(), "/opt/bin/bob");
     }
 
     #[test]
     fn validate_command_err_for_nonexistent_explicit_path() {
-        let l = BobLauncher::new(&serde_json::json!({
-            "command_path": "/no/such/path/bob"
-        }), &crate::config::Config::default());
+        let l = BobLauncher::new(
+            &serde_json::json!({
+                "command_path": "/no/such/path/bob"
+            }),
+            &crate::config::Config::default(),
+        );
         assert!(l.validate_command().is_err());
     }
 
     #[test]
     fn validate_command_falls_back_to_path_for_bare_command_name() {
-        let l = BobLauncher::new(&serde_json::json!({
-            "command_path": "ls"
-        }), &crate::config::Config::default());
+        let l = BobLauncher::new(
+            &serde_json::json!({
+                "command_path": "ls"
+            }),
+            &crate::config::Config::default(),
+        );
         assert!(l.validate_command().is_ok());
     }
 

--- a/src/launchers/bob.rs
+++ b/src/launchers/bob.rs
@@ -24,7 +24,7 @@ pub struct BobLauncher {
 impl ConfigConstructable for BobLauncher {
     type Config = BobLauncherConfig;
 
-    fn new(cfg: &serde_json::Value) -> Self {
+    fn new(cfg: &serde_json::Value, _global_config: &crate::config::Config) -> Self {
         let config: BobLauncherConfig = serde_json::from_value(cfg.clone()).unwrap_or_default();
         Self { config }
     }
@@ -77,7 +77,7 @@ mod tests {
 
     #[test]
     fn command_defaults_to_bob() {
-        let l = BobLauncher::new(&serde_json::json!({}));
+        let l = BobLauncher::new(&serde_json::json!({}), &crate::config::Config::default());
         assert_eq!(l.command(), "bob");
     }
 
@@ -85,7 +85,7 @@ mod tests {
     fn command_uses_explicit_path_when_set() {
         let l = BobLauncher::new(&serde_json::json!({
             "command_path": "/opt/bin/bob"
-        }));
+        }), &crate::config::Config::default());
         assert_eq!(l.command(), "/opt/bin/bob");
     }
 
@@ -93,7 +93,7 @@ mod tests {
     fn validate_command_err_for_nonexistent_explicit_path() {
         let l = BobLauncher::new(&serde_json::json!({
             "command_path": "/no/such/path/bob"
-        }));
+        }), &crate::config::Config::default());
         assert!(l.validate_command().is_err());
     }
 
@@ -101,7 +101,7 @@ mod tests {
     fn validate_command_falls_back_to_path_for_bare_command_name() {
         let l = BobLauncher::new(&serde_json::json!({
             "command_path": "ls"
-        }));
+        }), &crate::config::Config::default());
         assert!(l.validate_command().is_ok());
     }
 

--- a/src/launchers/bob.rs
+++ b/src/launchers/bob.rs
@@ -40,11 +40,7 @@ impl Launcher for BobLauncher {
         self.config.command_path.as_deref().unwrap_or("bob")
     }
 
-    async fn bind_capability(
-        &mut self,
-        _capability: &dyn Capability,
-        _models: &(dyn crate::dependency::Configured<dyn crate::models::Model> + Sync),
-    ) -> anyhow::Result<()> {
+    async fn bind_capability(&mut self, _capability: &dyn Capability) -> anyhow::Result<()> {
         anyhow::bail!("bob launcher does not support any capabilities")
     }
 

--- a/src/launchers/bob.rs
+++ b/src/launchers/bob.rs
@@ -40,7 +40,11 @@ impl Launcher for BobLauncher {
         self.config.command_path.as_deref().unwrap_or("bob")
     }
 
-    async fn bind_capability(&mut self, _capability: &dyn Capability) -> anyhow::Result<()> {
+    async fn bind_capability(
+        &mut self,
+        _capability: &dyn Capability,
+        _models: &(dyn crate::dependency::Configured<dyn crate::models::Model> + Sync),
+    ) -> anyhow::Result<()> {
         anyhow::bail!("bob launcher does not support any capabilities")
     }
 

--- a/src/launchers/bob.rs
+++ b/src/launchers/bob.rs
@@ -1,4 +1,4 @@
-use crate::capabilities::BindingType;
+use crate::capabilities::Capability;
 use crate::launchers::base::{EnvBinding, LaunchContext, Launcher, LauncherMetadata};
 use crate::registry::ConfigConstructable;
 use crate::utils::resolve_shell_command;
@@ -40,8 +40,8 @@ impl Launcher for BobLauncher {
         self.config.command_path.as_deref().unwrap_or("bob")
     }
 
-    fn supported_capabilities(&self) -> HashSet<BindingType> {
-        Self::metadata().supported_capabilities
+    async fn bind_capability(&mut self, _capability: &dyn Capability) -> anyhow::Result<()> {
+        anyhow::bail!("bob launcher does not support any capabilities")
     }
 
     fn validate_command(&self) -> anyhow::Result<PathBuf> {

--- a/src/launchers/claude.rs
+++ b/src/launchers/claude.rs
@@ -96,7 +96,7 @@ impl Launcher for ClaudeLauncher {
                 EnvBinding {
                     key: "ANTHROPIC_AUTH_TOKEN".to_string(),
                     value: api_key_val,
-                }
+                },
             ];
             // verify_ssl is dropped per user's note
             Ok(bindings)

--- a/src/launchers/claude.rs
+++ b/src/launchers/claude.rs
@@ -44,11 +44,7 @@ impl Launcher for ClaudeLauncher {
         self.config.command_path.as_deref().unwrap_or("claude")
     }
 
-    async fn bind_capability(
-        &mut self,
-        capability: &dyn Capability,
-        models: &(dyn crate::dependency::Configured<dyn crate::models::Model> + Sync),
-    ) -> anyhow::Result<()> {
+    async fn bind_capability(&mut self, capability: &dyn Capability) -> anyhow::Result<()> {
         let supported = Self::metadata().supported_capabilities;
         let capability_types = capability.binding_types();
         if !capability_types.is_subset(&supported) {
@@ -65,7 +61,7 @@ impl Launcher for ClaudeLauncher {
             },
         );
 
-        let binding = capability.bind(request, models).await?;
+        let binding = capability.bind(request).await?;
         match binding {
             crate::capabilities::Binding::AgentModel(binding) => {
                 self.bound_binding = Some(binding);

--- a/src/launchers/claude.rs
+++ b/src/launchers/claude.rs
@@ -76,6 +76,10 @@ impl Launcher for ClaudeLauncher {
 
     async fn env_overlay(&self, _ctx: &LaunchContext) -> anyhow::Result<Vec<EnvBinding>> {
         if let Some(binding) = &self.bound_binding {
+            let api_key_val = match &binding.api_key {
+                Some(api_key) => api_key.clone().0,
+                _ => "unset".to_string(),
+            };
             let bindings = vec![
                 EnvBinding {
                     key: "ANTHROPIC_BASE_URL".to_string(),
@@ -85,6 +89,14 @@ impl Launcher for ClaudeLauncher {
                     key: "ANTHROPIC_MODEL".to_string(),
                     value: binding.model_name.clone(),
                 },
+                EnvBinding {
+                    key: "CLAUDE_CODE_MAX_CONTEXT_TOKENS".to_string(),
+                    value: binding.context_length.to_string(),
+                },
+                EnvBinding {
+                    key: "ANTHROPIC_AUTH_TOKEN".to_string(),
+                    value: api_key_val,
+                }
             ];
             // verify_ssl is dropped per user's note
             Ok(bindings)

--- a/src/launchers/claude.rs
+++ b/src/launchers/claude.rs
@@ -1,4 +1,4 @@
-use crate::capabilities::BindingType;
+use crate::capabilities::{BindingType, Capability};
 use crate::launchers::base::{EnvBinding, LaunchContext, Launcher, LauncherMetadata};
 use crate::registry::ConfigConstructable;
 use crate::utils::resolve_shell_command;
@@ -40,8 +40,16 @@ impl Launcher for ClaudeLauncher {
         self.config.command_path.as_deref().unwrap_or("claude")
     }
 
-    fn supported_capabilities(&self) -> HashSet<BindingType> {
-        Self::metadata().supported_capabilities
+    async fn bind_capability(&mut self, capability: &dyn Capability) -> anyhow::Result<()> {
+        let supported = Self::metadata().supported_capabilities;
+        let capability_types = capability.binding_types();
+        if !capability_types.is_subset(&supported) {
+            anyhow::bail!(
+                "capability supports {:?} which this launcher does not support",
+                capability_types.difference(&supported).collect::<Vec<_>>()
+            );
+        }
+        Ok(())
     }
 
     fn validate_command(&self) -> anyhow::Result<PathBuf> {

--- a/src/launchers/claude.rs
+++ b/src/launchers/claude.rs
@@ -19,6 +19,7 @@ pub struct ClaudeLauncherConfig {
 
 pub struct ClaudeLauncher {
     config: ClaudeLauncherConfig,
+    bound_binding: Option<crate::capabilities::AgentModelBinding>,
 }
 
 impl ConfigConstructable for ClaudeLauncher {
@@ -26,7 +27,10 @@ impl ConfigConstructable for ClaudeLauncher {
 
     fn new(cfg: &serde_json::Value) -> Self {
         let config: ClaudeLauncherConfig = serde_json::from_value(cfg.clone()).unwrap_or_default();
-        Self { config }
+        Self {
+            config,
+            bound_binding: None,
+        }
     }
 }
 
@@ -40,7 +44,11 @@ impl Launcher for ClaudeLauncher {
         self.config.command_path.as_deref().unwrap_or("claude")
     }
 
-    async fn bind_capability(&mut self, capability: &dyn Capability) -> anyhow::Result<()> {
+    async fn bind_capability(
+        &mut self,
+        capability: &dyn Capability,
+        models: &(dyn crate::dependency::Configured<dyn crate::models::Model> + Sync),
+    ) -> anyhow::Result<()> {
         let supported = Self::metadata().supported_capabilities;
         let capability_types = capability.binding_types();
         if !capability_types.is_subset(&supported) {
@@ -48,6 +56,20 @@ impl Launcher for ClaudeLauncher {
                 "capability supports {:?} which this launcher does not support",
                 capability_types.difference(&supported).collect::<Vec<_>>()
             );
+        }
+
+        // Claude knows it expects Anthropic API type
+        let request = crate::capabilities::BindingRequest::AgentModel(
+            crate::capabilities::AgentModelBindingRequest {
+                api_type: crate::providers::ApiType::Anthropic,
+            },
+        );
+
+        let binding = capability.bind(request, models).await?;
+        match binding {
+            crate::capabilities::Binding::AgentModel(binding) => {
+                self.bound_binding = Some(binding);
+            }
         }
         Ok(())
     }
@@ -57,7 +79,22 @@ impl Launcher for ClaudeLauncher {
     }
 
     async fn env_overlay(&self, _ctx: &LaunchContext) -> anyhow::Result<Vec<EnvBinding>> {
-        Ok(vec![])
+        if let Some(binding) = &self.bound_binding {
+            let bindings = vec![
+                EnvBinding {
+                    key: "ANTHROPIC_BASE_URL".to_string(),
+                    value: binding.base_url.clone(),
+                },
+                EnvBinding {
+                    key: "ANTHROPIC_MODEL".to_string(),
+                    value: binding.model_name.clone(),
+                },
+            ];
+            // verify_ssl is dropped per user's note
+            Ok(bindings)
+        } else {
+            Ok(vec![])
+        }
     }
 }
 

--- a/src/launchers/claude.rs
+++ b/src/launchers/claude.rs
@@ -25,7 +25,7 @@ pub struct ClaudeLauncher {
 impl ConfigConstructable for ClaudeLauncher {
     type Config = ClaudeLauncherConfig;
 
-    fn new(cfg: &serde_json::Value) -> Self {
+    fn new(cfg: &serde_json::Value, _global_config: &crate::config::Config) -> Self {
         let config: ClaudeLauncherConfig = serde_json::from_value(cfg.clone()).unwrap_or_default();
         Self {
             config,
@@ -134,7 +134,7 @@ mod tests {
 
     #[test]
     fn command_defaults_to_claude() {
-        let l = ClaudeLauncher::new(&serde_json::json!({}));
+        let l = ClaudeLauncher::new(&serde_json::json!({}), &crate::config::Config::default());
         assert_eq!(l.command(), "claude");
     }
 
@@ -142,7 +142,7 @@ mod tests {
     fn command_uses_explicit_path_when_set() {
         let l = ClaudeLauncher::new(&serde_json::json!({
             "command_path": "/opt/bin/claude"
-        }));
+        }), &crate::config::Config::default());
         assert_eq!(l.command(), "/opt/bin/claude");
     }
 
@@ -150,7 +150,7 @@ mod tests {
     fn validate_command_err_for_nonexistent_explicit_path() {
         let l = ClaudeLauncher::new(&serde_json::json!({
             "command_path": "/no/such/path/claude"
-        }));
+        }), &crate::config::Config::default());
         assert!(l.validate_command().is_err());
     }
 
@@ -158,7 +158,7 @@ mod tests {
     fn validate_command_falls_back_to_path_for_bare_command_name() {
         let l = ClaudeLauncher::new(&serde_json::json!({
             "command_path": "ls"
-        }));
+        }), &crate::config::Config::default());
         assert!(l.validate_command().is_ok());
     }
 

--- a/src/launchers/claude.rs
+++ b/src/launchers/claude.rs
@@ -140,25 +140,34 @@ mod tests {
 
     #[test]
     fn command_uses_explicit_path_when_set() {
-        let l = ClaudeLauncher::new(&serde_json::json!({
-            "command_path": "/opt/bin/claude"
-        }), &crate::config::Config::default());
+        let l = ClaudeLauncher::new(
+            &serde_json::json!({
+                "command_path": "/opt/bin/claude"
+            }),
+            &crate::config::Config::default(),
+        );
         assert_eq!(l.command(), "/opt/bin/claude");
     }
 
     #[test]
     fn validate_command_err_for_nonexistent_explicit_path() {
-        let l = ClaudeLauncher::new(&serde_json::json!({
-            "command_path": "/no/such/path/claude"
-        }), &crate::config::Config::default());
+        let l = ClaudeLauncher::new(
+            &serde_json::json!({
+                "command_path": "/no/such/path/claude"
+            }),
+            &crate::config::Config::default(),
+        );
         assert!(l.validate_command().is_err());
     }
 
     #[test]
     fn validate_command_falls_back_to_path_for_bare_command_name() {
-        let l = ClaudeLauncher::new(&serde_json::json!({
-            "command_path": "ls"
-        }), &crate::config::Config::default());
+        let l = ClaudeLauncher::new(
+            &serde_json::json!({
+                "command_path": "ls"
+            }),
+            &crate::config::Config::default(),
+        );
         assert!(l.validate_command().is_ok());
     }
 

--- a/src/launchers/claude.rs
+++ b/src/launchers/claude.rs
@@ -76,10 +76,13 @@ impl Launcher for ClaudeLauncher {
 
     async fn env_overlay(&self, _ctx: &LaunchContext) -> anyhow::Result<Vec<EnvBinding>> {
         if let Some(binding) = &self.bound_binding {
-            let api_key_val = match &binding.api_key {
+            let mut api_key_val = match &binding.api_key {
                 Some(api_key) => api_key.clone().0,
-                _ => "unset".to_string(),
+                _ => "".to_string(),
             };
+            if api_key_val.is_empty() {
+                api_key_val = "unset".to_string(); // Claude treats empty strings like unset
+            }
             let bindings = vec![
                 EnvBinding {
                     key: "ANTHROPIC_BASE_URL".to_string(),

--- a/src/launchers/mod.rs
+++ b/src/launchers/mod.rs
@@ -33,7 +33,7 @@ impl LauncherSource {
             .launchers
             .values()
             .filter_map(|lc| {
-                let result = LAUNCHER_REGISTRY.construct(&lc.launcher_type, &lc.config);
+                let result = LAUNCHER_REGISTRY.construct(&lc.launcher_type, &lc.config, config);
                 if result.is_err() {
                     alog_channel!(
                         MessageLevel::Warning,

--- a/src/main.rs
+++ b/src/main.rs
@@ -638,6 +638,7 @@ async fn run_launch(
     args: &[String],
     dry_run: bool,
 ) -> anyhow::Result<()> {
+    use crate::capabilities::CAPABILITY_REGISTRY;
     use crate::launchers::LAUNCHER_REGISTRY;
     use crate::launchers::LaunchContext;
 
@@ -651,9 +652,23 @@ async fn run_launch(
         )
     })?;
 
-    let launcher = LAUNCHER_REGISTRY
+    let mut launcher = LAUNCHER_REGISTRY
         .construct(&lc.launcher_type, &lc.config)
         .map_err(|e| anyhow::anyhow!("Failed to construct launcher: {e}"))?;
+
+    // Bind each enabled capability to the launcher before launching.
+    for cap_id in &lc.enabled_capabilities {
+        let cap_cfg = config.get_capability(cap_id).ok_or_else(|| {
+            anyhow::anyhow!(
+                "Launcher '{launcher_id}' references capability '{cap_id}' \
+                 which is not configured. Run `granite-cli capability setup` first."
+            )
+        })?;
+        let capability = CAPABILITY_REGISTRY
+            .construct(&cap_cfg.capability_type, &cap_cfg.config)
+            .map_err(|e| anyhow::anyhow!("Failed to construct capability '{cap_id}': {e}"))?;
+        launcher.bind_capability(capability.as_ref()).await?;
+    }
 
     let launch_ctx = LaunchContext {
         launcher_id: launcher_id.to_string(),

--- a/src/main.rs
+++ b/src/main.rs
@@ -664,17 +664,18 @@ async fn run_launch(
                  which is not configured. Run `granite-cli capability setup` first."
             )
         })?;
-        let capability: Box<dyn crate::capabilities::Capability> =
-            if cap_cfg.capability_type == "agent-model" {
-                Box::new(crate::capabilities::AgentModelCapability::with_config(
-                    &cap_cfg.config,
-                    &config,
-                ))
-            } else {
-                CAPABILITY_REGISTRY
-                    .construct(&cap_cfg.capability_type, &cap_cfg.config)
-                    .map_err(|e| anyhow::anyhow!("Failed to construct capability '{cap_id}': {e}"))?
-            };
+        let capability: Box<dyn crate::capabilities::Capability> = if cap_cfg.capability_type
+            == "agent-model"
+        {
+            Box::new(crate::capabilities::AgentModelCapability::with_config(
+                &cap_cfg.config,
+                &config,
+            ))
+        } else {
+            CAPABILITY_REGISTRY
+                .construct(&cap_cfg.capability_type, &cap_cfg.config)
+                .map_err(|e| anyhow::anyhow!("Failed to construct capability '{cap_id}': {e}"))?
+        };
         launcher.bind_capability(capability.as_ref()).await?;
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -301,7 +301,7 @@ pub struct AppContext {
 /// `main` that still reports via `eprintln!` rather than `ctx.ui`.
 fn construct_ui(output: &str) -> Box<dyn Ui> {
     UI_REGISTRY
-        .construct(output, &serde_json::json!({}))
+        .construct(output, &serde_json::json!({}), &crate::config::Config::default())
         .unwrap_or_else(|_| {
             eprintln!("Unknown output format '{output}'. Valid: terminal, plain, json, markdown");
             std::process::exit(1);
@@ -653,7 +653,7 @@ async fn run_launch(
     })?;
 
     let mut launcher = LAUNCHER_REGISTRY
-        .construct(&lc.launcher_type, &lc.config)
+        .construct(&lc.launcher_type, &lc.config, &config)
         .map_err(|e| anyhow::anyhow!("Failed to construct launcher: {e}"))?;
 
     // Bind each enabled capability to the launcher before launching.
@@ -664,18 +664,9 @@ async fn run_launch(
                  which is not configured. Run `granite-cli capability setup` first."
             )
         })?;
-        let capability: Box<dyn crate::capabilities::Capability> = if cap_cfg.capability_type
-            == "agent-model"
-        {
-            Box::new(crate::capabilities::AgentModelCapability::with_config(
-                &cap_cfg.config,
-                &config,
-            ))
-        } else {
-            CAPABILITY_REGISTRY
-                .construct(&cap_cfg.capability_type, &cap_cfg.config)
-                .map_err(|e| anyhow::anyhow!("Failed to construct capability '{cap_id}': {e}"))?
-        };
+        let capability = CAPABILITY_REGISTRY
+            .construct(&cap_cfg.capability_type, &cap_cfg.config, &config)
+            .map_err(|e| anyhow::anyhow!("Failed to construct capability '{cap_id}': {e}"))?;
         launcher.bind_capability(capability.as_ref()).await?;
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -301,7 +301,11 @@ pub struct AppContext {
 /// `main` that still reports via `eprintln!` rather than `ctx.ui`.
 fn construct_ui(output: &str) -> Box<dyn Ui> {
     UI_REGISTRY
-        .construct(output, &serde_json::json!({}), &crate::config::Config::default())
+        .construct(
+            output,
+            &serde_json::json!({}),
+            &crate::config::Config::default(),
+        )
         .unwrap_or_else(|_| {
             eprintln!("Unknown output format '{output}'. Valid: terminal, plain, json, markdown");
             std::process::exit(1);

--- a/src/main.rs
+++ b/src/main.rs
@@ -664,9 +664,17 @@ async fn run_launch(
                  which is not configured. Run `granite-cli capability setup` first."
             )
         })?;
-        let capability = CAPABILITY_REGISTRY
-            .construct(&cap_cfg.capability_type, &cap_cfg.config)
-            .map_err(|e| anyhow::anyhow!("Failed to construct capability '{cap_id}': {e}"))?;
+        let capability: Box<dyn crate::capabilities::Capability> =
+            if cap_cfg.capability_type == "agent-model" {
+                Box::new(crate::capabilities::AgentModelCapability::with_config(
+                    &cap_cfg.config,
+                    &config,
+                ))
+            } else {
+                CAPABILITY_REGISTRY
+                    .construct(&cap_cfg.capability_type, &cap_cfg.config)
+                    .map_err(|e| anyhow::anyhow!("Failed to construct capability '{cap_id}': {e}"))?
+            };
         launcher.bind_capability(capability.as_ref()).await?;
     }
 

--- a/src/models/base.rs
+++ b/src/models/base.rs
@@ -173,7 +173,7 @@ pub trait Model: Send + Sync {
             .provider_config()
             .ok_or_else(|| anyhow::anyhow!("model has no configured provider"))?;
         crate::providers::PROVIDER_REGISTRY
-            .construct(&pc.provider_type, &pc.config)
+            .construct(&pc.provider_type, &pc.config, &crate::config::Config::default())
             .map_err(|e| anyhow::anyhow!(e))
     }
 }

--- a/src/models/base.rs
+++ b/src/models/base.rs
@@ -173,7 +173,11 @@ pub trait Model: Send + Sync {
             .provider_config()
             .ok_or_else(|| anyhow::anyhow!("model has no configured provider"))?;
         crate::providers::PROVIDER_REGISTRY
-            .construct(&pc.provider_type, &pc.config, &crate::config::Config::default())
+            .construct(
+                &pc.provider_type,
+                &pc.config,
+                &crate::config::Config::default(),
+            )
             .map_err(|e| anyhow::anyhow!(e))
     }
 }

--- a/src/models/mod.rs
+++ b/src/models/mod.rs
@@ -44,7 +44,7 @@ impl ModelSource {
                     }
                     None => serde_json::json!({}),
                 };
-                let result = MODEL_REGISTRY.construct(&model_config.model_id, &cfg);
+                let result = MODEL_REGISTRY.construct(&model_config.model_id, &cfg, config);
                 if result.is_err() {
                     alog_channel!(
                         MessageLevel::Warning,

--- a/src/providers/base.rs
+++ b/src/providers/base.rs
@@ -1,4 +1,4 @@
-use crate::models::ModelFunction;
+use crate::models::{ModelFunction, ModelVariant};
 use crate::registry::{ConfigConstructable, Secret};
 use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
@@ -144,6 +144,15 @@ pub trait Provider: Send + Sync {
     fn supported_formats(&self) -> Vec<ModelFormat>;
     fn can_run_model(&self, _variant_format: &str, _variant_precision: &str) -> bool {
         true
+    }
+
+    /// Returns the provider-specific model name for the given variant, if it
+    /// differs from the catalog model ID. Providers whose server uses a different
+    /// naming convention (e.g. Ollama's `granite4.1:8b` vs the catalog ID
+    /// `granite-4.1-8b`) override this to derive the alias from the variant URL.
+    /// The default returns `None`, meaning the catalog ID should be used as-is.
+    fn model_alias(&self, _variant: Option<&ModelVariant>) -> Option<String> {
+        None
     }
 
     // Health

--- a/src/providers/llamacpp.rs
+++ b/src/providers/llamacpp.rs
@@ -283,7 +283,7 @@ impl LlamaCppProvider {
 impl ConfigConstructable for LlamaCppProvider {
     type Config = LlamaCppProviderConfig;
 
-    fn new(cfg: &serde_json::Value) -> Self {
+    fn new(cfg: &serde_json::Value, _global_config: &crate::config::Config) -> Self {
         let config: LlamaCppProviderConfig =
             serde_json::from_value(cfg.clone()).unwrap_or_default();
 
@@ -458,21 +458,21 @@ mod tests {
             "base_url": "http://example.com:9000",
             "timeout_secs": 30
         });
-        let provider = LlamaCppProvider::new(&cfg);
+        let provider = LlamaCppProvider::new(&cfg, &crate::config::Config::default());
         assert_eq!(provider.config.base_url, "http://example.com:9000");
         assert_eq!(provider.config.timeout_secs, 30);
     }
 
     #[test]
     fn test_can_run_model_accepts_gguf() {
-        let provider = LlamaCppProvider::new(&serde_json::json!({}));
+        let provider = LlamaCppProvider::new(&serde_json::json!({}), &crate::config::Config::default());
         assert!(provider.can_run_model("gguf", "Q4_K_M"));
         assert!(provider.can_run_model("GGUF", "fp16"));
     }
 
     #[test]
     fn test_can_run_model_rejects_non_gguf() {
-        let provider = LlamaCppProvider::new(&serde_json::json!({}));
+        let provider = LlamaCppProvider::new(&serde_json::json!({}), &crate::config::Config::default());
         assert!(!provider.can_run_model("safetensors", "fp16"));
         assert!(!provider.can_run_model("onnx", "fp32"));
     }

--- a/src/providers/llamacpp.rs
+++ b/src/providers/llamacpp.rs
@@ -340,6 +340,12 @@ impl Provider for LlamaCppProvider {
         variant_format.eq_ignore_ascii_case("gguf")
     }
 
+    fn model_alias(&self, variant: Option<&crate::models::ModelVariant>) -> Option<String> {
+        let v = variant?;
+        let repo = hf_repo_id(&v.url)?;
+        Some(format!("{}:{}", repo, v.precision))
+    }
+
     async fn health_check(&self) -> Result<HealthStatus, ProviderError> {
         http_health_check(
             &self.client,
@@ -477,6 +483,42 @@ mod tests {
             LlamaCppProvider::new(&serde_json::json!({}), &crate::config::Config::default());
         assert!(!provider.can_run_model("safetensors", "fp16"));
         assert!(!provider.can_run_model("onnx", "fp32"));
+    }
+
+    #[test]
+    fn test_model_alias_returns_hf_ref_for_gguf_variant() {
+        let provider =
+            LlamaCppProvider::new(&serde_json::json!({}), &crate::config::Config::default());
+        let variant = ModelVariant {
+            format: "GGUF".to_string(),
+            precision: "Q4_K_M".to_string(),
+            size_gb: 5.3,
+            url: "https://huggingface.co/ibm-granite/granite-4.1-8b-GGUF/blob/main/granite-4.1-8b-Q4_K_M.gguf".to_string(),
+        };
+        assert_eq!(
+            provider.model_alias(Some(&variant)),
+            Some("ibm-granite/granite-4.1-8b-GGUF:Q4_K_M".to_string())
+        );
+    }
+
+    #[test]
+    fn test_model_alias_returns_none_for_ollama_url() {
+        let provider =
+            LlamaCppProvider::new(&serde_json::json!({}), &crate::config::Config::default());
+        let variant = ModelVariant {
+            format: "Ollama".to_string(),
+            precision: "Q4_K_M".to_string(),
+            size_gb: 5.3,
+            url: "https://ollama.com/library/granite4.1:8b".to_string(),
+        };
+        assert_eq!(provider.model_alias(Some(&variant)), None);
+    }
+
+    #[test]
+    fn test_model_alias_returns_none_when_no_variant() {
+        let provider =
+            LlamaCppProvider::new(&serde_json::json!({}), &crate::config::Config::default());
+        assert_eq!(provider.model_alias(None), None);
     }
 
     #[test]

--- a/src/providers/llamacpp.rs
+++ b/src/providers/llamacpp.rs
@@ -465,14 +465,16 @@ mod tests {
 
     #[test]
     fn test_can_run_model_accepts_gguf() {
-        let provider = LlamaCppProvider::new(&serde_json::json!({}), &crate::config::Config::default());
+        let provider =
+            LlamaCppProvider::new(&serde_json::json!({}), &crate::config::Config::default());
         assert!(provider.can_run_model("gguf", "Q4_K_M"));
         assert!(provider.can_run_model("GGUF", "fp16"));
     }
 
     #[test]
     fn test_can_run_model_rejects_non_gguf() {
-        let provider = LlamaCppProvider::new(&serde_json::json!({}), &crate::config::Config::default());
+        let provider =
+            LlamaCppProvider::new(&serde_json::json!({}), &crate::config::Config::default());
         assert!(!provider.can_run_model("safetensors", "fp16"));
         assert!(!provider.can_run_model("onnx", "fp32"));
     }

--- a/src/providers/lmstudio.rs
+++ b/src/providers/lmstudio.rs
@@ -359,21 +359,24 @@ mod tests {
 
     #[test]
     fn test_can_run_model_accepts_gguf() {
-        let provider = LMStudioProvider::new(&serde_json::json!({}), &crate::config::Config::default());
+        let provider =
+            LMStudioProvider::new(&serde_json::json!({}), &crate::config::Config::default());
         assert!(provider.can_run_model("gguf", "Q4_K_M"));
         assert!(provider.can_run_model("GGUF", "fp16"));
     }
 
     #[test]
     fn test_can_run_model_rejects_non_supported() {
-        let provider = LMStudioProvider::new(&serde_json::json!({}), &crate::config::Config::default());
+        let provider =
+            LMStudioProvider::new(&serde_json::json!({}), &crate::config::Config::default());
         assert!(!provider.can_run_model("safetensors", "fp16"));
         assert!(!provider.can_run_model("onnx", "fp32"));
     }
 
     #[test]
     fn test_mlx_formats_on_macos() {
-        let provider = LMStudioProvider::new(&serde_json::json!({}), &crate::config::Config::default());
+        let provider =
+            LMStudioProvider::new(&serde_json::json!({}), &crate::config::Config::default());
         let formats = provider.supported_formats();
 
         #[cfg(target_os = "macos")]
@@ -385,7 +388,8 @@ mod tests {
 
     #[test]
     fn test_can_run_mlx_model() {
-        let provider = LMStudioProvider::new(&serde_json::json!({}), &crate::config::Config::default());
+        let provider =
+            LMStudioProvider::new(&serde_json::json!({}), &crate::config::Config::default());
 
         #[cfg(target_os = "macos")]
         assert!(provider.can_run_model("mlx", "fp16"));

--- a/src/providers/lmstudio.rs
+++ b/src/providers/lmstudio.rs
@@ -133,7 +133,7 @@ impl LMStudioProvider {
 impl ConfigConstructable for LMStudioProvider {
     type Config = LMStudioProviderConfig;
 
-    fn new(cfg: &serde_json::Value) -> Self {
+    fn new(cfg: &serde_json::Value, _global_config: &crate::config::Config) -> Self {
         let config: LMStudioProviderConfig =
             serde_json::from_value(cfg.clone()).unwrap_or_default();
 
@@ -352,28 +352,28 @@ mod tests {
             "base_url": "http://example.com:5678",
             "timeout_secs": 30
         });
-        let provider = LMStudioProvider::new(&cfg);
+        let provider = LMStudioProvider::new(&cfg, &crate::config::Config::default());
         assert_eq!(provider.config.base_url, "http://example.com:5678");
         assert_eq!(provider.config.timeout_secs, 30);
     }
 
     #[test]
     fn test_can_run_model_accepts_gguf() {
-        let provider = LMStudioProvider::new(&serde_json::json!({}));
+        let provider = LMStudioProvider::new(&serde_json::json!({}), &crate::config::Config::default());
         assert!(provider.can_run_model("gguf", "Q4_K_M"));
         assert!(provider.can_run_model("GGUF", "fp16"));
     }
 
     #[test]
     fn test_can_run_model_rejects_non_supported() {
-        let provider = LMStudioProvider::new(&serde_json::json!({}));
+        let provider = LMStudioProvider::new(&serde_json::json!({}), &crate::config::Config::default());
         assert!(!provider.can_run_model("safetensors", "fp16"));
         assert!(!provider.can_run_model("onnx", "fp32"));
     }
 
     #[test]
     fn test_mlx_formats_on_macos() {
-        let provider = LMStudioProvider::new(&serde_json::json!({}));
+        let provider = LMStudioProvider::new(&serde_json::json!({}), &crate::config::Config::default());
         let formats = provider.supported_formats();
 
         #[cfg(target_os = "macos")]
@@ -385,7 +385,7 @@ mod tests {
 
     #[test]
     fn test_can_run_mlx_model() {
-        let provider = LMStudioProvider::new(&serde_json::json!({}));
+        let provider = LMStudioProvider::new(&serde_json::json!({}), &crate::config::Config::default());
 
         #[cfg(target_os = "macos")]
         assert!(provider.can_run_model("mlx", "fp16"));

--- a/src/providers/mod.rs
+++ b/src/providers/mod.rs
@@ -36,7 +36,7 @@ impl ProviderSource {
             .values()
             .filter_map(|provider_config| {
                 let result = PROVIDER_REGISTRY
-                    .construct(&provider_config.provider_type, &provider_config.config);
+                    .construct(&provider_config.provider_type, &provider_config.config, config);
                 if result.is_err() {
                     alog_channel!(
                         MessageLevel::Warning,

--- a/src/providers/mod.rs
+++ b/src/providers/mod.rs
@@ -35,8 +35,11 @@ impl ProviderSource {
             .providers
             .values()
             .filter_map(|provider_config| {
-                let result = PROVIDER_REGISTRY
-                    .construct(&provider_config.provider_type, &provider_config.config, config);
+                let result = PROVIDER_REGISTRY.construct(
+                    &provider_config.provider_type,
+                    &provider_config.config,
+                    config,
+                );
                 if result.is_err() {
                     alog_channel!(
                         MessageLevel::Warning,

--- a/src/providers/ollama.rs
+++ b/src/providers/ollama.rs
@@ -173,7 +173,7 @@ impl OllamaProvider {
 impl ConfigConstructable for OllamaProvider {
     type Config = OllamaProviderConfig;
 
-    fn new(cfg: &serde_json::Value) -> Self {
+    fn new(cfg: &serde_json::Value, _global_config: &crate::config::Config) -> Self {
         let config: OllamaProviderConfig = serde_json::from_value(cfg.clone()).unwrap_or_default();
 
         let client = reqwest::Client::builder()
@@ -423,21 +423,21 @@ mod tests {
             "base_url": "http://example.com:8080",
             "timeout_secs": 30
         });
-        let provider = OllamaProvider::new(&cfg);
+        let provider = OllamaProvider::new(&cfg, &crate::config::Config::default());
         assert_eq!(provider.config.base_url, "http://example.com:8080");
         assert_eq!(provider.config.timeout_secs, 30);
     }
 
     #[test]
     fn test_can_run_model_accepts_gguf() {
-        let provider = OllamaProvider::new(&serde_json::json!({}));
+        let provider = OllamaProvider::new(&serde_json::json!({}), &crate::config::Config::default());
         assert!(provider.can_run_model("gguf", "Q4_K_M"));
         assert!(provider.can_run_model("GGUF", "fp16"));
     }
 
     #[test]
     fn test_can_run_model_rejects_non_gguf() {
-        let provider = OllamaProvider::new(&serde_json::json!({}));
+        let provider = OllamaProvider::new(&serde_json::json!({}), &crate::config::Config::default());
         assert!(!provider.can_run_model("safetensors", "fp16"));
         assert!(!provider.can_run_model("onnx", "fp32"));
     }
@@ -581,7 +581,7 @@ mod tests {
 
     #[test]
     fn test_model_alias_returns_library_ref_for_ollama_variant() {
-        let provider = OllamaProvider::new(&serde_json::json!({}));
+        let provider = OllamaProvider::new(&serde_json::json!({}), &crate::config::Config::default());
         let variant = ModelVariant {
             format: "Ollama".to_string(),
             precision: "Q4_K_M".to_string(),
@@ -596,7 +596,7 @@ mod tests {
 
     #[test]
     fn test_model_alias_returns_org_scoped_ref_for_org_url() {
-        let provider = OllamaProvider::new(&serde_json::json!({}));
+        let provider = OllamaProvider::new(&serde_json::json!({}), &crate::config::Config::default());
         let variant = ModelVariant {
             format: "Ollama".to_string(),
             precision: "Q4_K_M".to_string(),
@@ -611,7 +611,7 @@ mod tests {
 
     #[test]
     fn test_model_alias_returns_none_for_non_ollama_variant() {
-        let provider = OllamaProvider::new(&serde_json::json!({}));
+        let provider = OllamaProvider::new(&serde_json::json!({}), &crate::config::Config::default());
         let variant = ModelVariant {
             format: "GGUF".to_string(),
             precision: "Q4_K_M".to_string(),
@@ -623,7 +623,7 @@ mod tests {
 
     #[test]
     fn test_model_alias_returns_none_when_no_variant() {
-        let provider = OllamaProvider::new(&serde_json::json!({}));
+        let provider = OllamaProvider::new(&serde_json::json!({}), &crate::config::Config::default());
         assert_eq!(provider.model_alias(None), None);
     }
 

--- a/src/providers/ollama.rs
+++ b/src/providers/ollama.rs
@@ -430,14 +430,16 @@ mod tests {
 
     #[test]
     fn test_can_run_model_accepts_gguf() {
-        let provider = OllamaProvider::new(&serde_json::json!({}), &crate::config::Config::default());
+        let provider =
+            OllamaProvider::new(&serde_json::json!({}), &crate::config::Config::default());
         assert!(provider.can_run_model("gguf", "Q4_K_M"));
         assert!(provider.can_run_model("GGUF", "fp16"));
     }
 
     #[test]
     fn test_can_run_model_rejects_non_gguf() {
-        let provider = OllamaProvider::new(&serde_json::json!({}), &crate::config::Config::default());
+        let provider =
+            OllamaProvider::new(&serde_json::json!({}), &crate::config::Config::default());
         assert!(!provider.can_run_model("safetensors", "fp16"));
         assert!(!provider.can_run_model("onnx", "fp32"));
     }
@@ -581,7 +583,8 @@ mod tests {
 
     #[test]
     fn test_model_alias_returns_library_ref_for_ollama_variant() {
-        let provider = OllamaProvider::new(&serde_json::json!({}), &crate::config::Config::default());
+        let provider =
+            OllamaProvider::new(&serde_json::json!({}), &crate::config::Config::default());
         let variant = ModelVariant {
             format: "Ollama".to_string(),
             precision: "Q4_K_M".to_string(),
@@ -596,7 +599,8 @@ mod tests {
 
     #[test]
     fn test_model_alias_returns_org_scoped_ref_for_org_url() {
-        let provider = OllamaProvider::new(&serde_json::json!({}), &crate::config::Config::default());
+        let provider =
+            OllamaProvider::new(&serde_json::json!({}), &crate::config::Config::default());
         let variant = ModelVariant {
             format: "Ollama".to_string(),
             precision: "Q4_K_M".to_string(),
@@ -611,7 +615,8 @@ mod tests {
 
     #[test]
     fn test_model_alias_returns_none_for_non_ollama_variant() {
-        let provider = OllamaProvider::new(&serde_json::json!({}), &crate::config::Config::default());
+        let provider =
+            OllamaProvider::new(&serde_json::json!({}), &crate::config::Config::default());
         let variant = ModelVariant {
             format: "GGUF".to_string(),
             precision: "Q4_K_M".to_string(),
@@ -623,7 +628,8 @@ mod tests {
 
     #[test]
     fn test_model_alias_returns_none_when_no_variant() {
-        let provider = OllamaProvider::new(&serde_json::json!({}), &crate::config::Config::default());
+        let provider =
+            OllamaProvider::new(&serde_json::json!({}), &crate::config::Config::default());
         assert_eq!(provider.model_alias(None), None);
     }
 

--- a/src/providers/ollama.rs
+++ b/src/providers/ollama.rs
@@ -76,12 +76,35 @@ pub struct OllamaProvider {
     stream_client: reqwest::Client,
 }
 
-/// Extract the Ollama library model reference (e.g. `"granite4:1b"`) from a
-/// `https://ollama.com/library/...` variant URL.
-fn ollama_library_ref(url: &str) -> Option<&str> {
-    url.strip_prefix("https://ollama.com/library/")
-        .or_else(|| url.strip_prefix("ollama.com/library/"))
-        .filter(|s| !s.is_empty())
+/// Extract the Ollama model reference from an `https://ollama.com/...` variant URL.
+///
+/// Two URL conventions are supported:
+/// - `https://ollama.com/library/<name>[:<tag>]` → `<name>[:<tag>]`
+///   (the `library` org is implicit and omitted in the ref)
+/// - `https://ollama.com/<org>/<name>[:<tag>]` → `<org>/<name>[:<tag>]`
+///   (explicit org is preserved in the ref)
+///
+/// When `:<tag>` is absent, `:latest` is appended — matching Ollama's own
+/// convention for untagged model references.
+fn ollama_model_ref(url: &str) -> Option<String> {
+    let path = url
+        .strip_prefix("https://ollama.com/")
+        .or_else(|| url.strip_prefix("ollama.com/"))
+        .filter(|s| !s.is_empty())?;
+
+    // `library/` is Ollama's implicit org — strip it so the ref is just `<name>[:<tag>]`.
+    // Any other path segment is an explicit org and is kept as-is.
+    let model_ref = path.strip_prefix("library/").unwrap_or(path);
+    if model_ref.is_empty() {
+        return None;
+    }
+
+    // Ollama treats a tagless name as `<name>:latest` — make that explicit.
+    Some(if model_ref.contains(':') {
+        model_ref.to_string()
+    } else {
+        format!("{model_ref}:latest")
+    })
 }
 
 /// A single NDJSON line from Ollama's `POST /api/pull` progress stream.
@@ -206,6 +229,10 @@ impl Provider for OllamaProvider {
         variant_format.eq_ignore_ascii_case("gguf") || variant_format.eq_ignore_ascii_case("ollama")
     }
 
+    fn model_alias(&self, variant: Option<&crate::models::ModelVariant>) -> Option<String> {
+        variant.and_then(|v| ollama_model_ref(&v.url))
+    }
+
     async fn health_check(&self) -> Result<HealthStatus, ProviderError> {
         http_health_check(
             &self.client,
@@ -222,8 +249,8 @@ impl Provider for OllamaProvider {
         variant: &ModelVariant,
         ui: &dyn Ui,
     ) -> Result<crate::providers::PullResult, ProviderError> {
-        let model_ref = if let Some(name) = ollama_library_ref(&variant.url) {
-            name.to_string()
+        let model_ref = if let Some(name) = ollama_model_ref(&variant.url) {
+            name
         } else if let Some(repo) = hf_repo_id(&variant.url) {
             format!("hf.co/{}:{}", repo, variant.precision)
         } else {
@@ -416,21 +443,51 @@ mod tests {
     }
 
     #[test]
-    fn test_ollama_library_ref_parses_library_url() {
+    fn test_ollama_model_ref_parses_library_url() {
         assert_eq!(
-            ollama_library_ref("https://ollama.com/library/granite4:1b"),
-            Some("granite4:1b")
+            ollama_model_ref("https://ollama.com/library/granite4:1b"),
+            Some("granite4:1b".to_string())
         );
     }
 
     #[test]
-    fn test_ollama_library_ref_rejects_non_library_url() {
+    fn test_ollama_model_ref_appends_latest_when_tag_absent_library() {
         assert_eq!(
-            ollama_library_ref(
+            ollama_model_ref("https://ollama.com/library/granite4.1"),
+            Some("granite4.1:latest".to_string())
+        );
+    }
+
+    #[test]
+    fn test_ollama_model_ref_parses_org_scoped_url() {
+        assert_eq!(
+            ollama_model_ref("https://ollama.com/ibm/granite4.1:8b"),
+            Some("ibm/granite4.1:8b".to_string())
+        );
+    }
+
+    #[test]
+    fn test_ollama_model_ref_appends_latest_when_tag_absent_org() {
+        assert_eq!(
+            ollama_model_ref("https://ollama.com/ibm/granite4.1"),
+            Some("ibm/granite4.1:latest".to_string())
+        );
+    }
+
+    #[test]
+    fn test_ollama_model_ref_rejects_non_ollama_url() {
+        assert_eq!(
+            ollama_model_ref(
                 "https://huggingface.co/ibm-granite/granite-4.1-30b-GGUF/blob/main/x.gguf"
             ),
             None
         );
+    }
+
+    #[test]
+    fn test_ollama_model_ref_rejects_empty_path() {
+        assert_eq!(ollama_model_ref("https://ollama.com/"), None);
+        assert_eq!(ollama_model_ref("https://ollama.com/library/"), None);
     }
 
     #[test]
@@ -520,6 +577,54 @@ mod tests {
             r#"{"status":"failed","error":"too late"}"#.to_string(),
         ]);
         assert_eq!(result, PullOutcome::Success);
+    }
+
+    #[test]
+    fn test_model_alias_returns_library_ref_for_ollama_variant() {
+        let provider = OllamaProvider::new(&serde_json::json!({}));
+        let variant = ModelVariant {
+            format: "Ollama".to_string(),
+            precision: "Q4_K_M".to_string(),
+            size_gb: 5.3,
+            url: "https://ollama.com/library/granite4.1:8b".to_string(),
+        };
+        assert_eq!(
+            provider.model_alias(Some(&variant)),
+            Some("granite4.1:8b".to_string())
+        );
+    }
+
+    #[test]
+    fn test_model_alias_returns_org_scoped_ref_for_org_url() {
+        let provider = OllamaProvider::new(&serde_json::json!({}));
+        let variant = ModelVariant {
+            format: "Ollama".to_string(),
+            precision: "Q4_K_M".to_string(),
+            size_gb: 5.3,
+            url: "https://ollama.com/ibm/granite4.1:8b".to_string(),
+        };
+        assert_eq!(
+            provider.model_alias(Some(&variant)),
+            Some("ibm/granite4.1:8b".to_string())
+        );
+    }
+
+    #[test]
+    fn test_model_alias_returns_none_for_non_ollama_variant() {
+        let provider = OllamaProvider::new(&serde_json::json!({}));
+        let variant = ModelVariant {
+            format: "GGUF".to_string(),
+            precision: "Q4_K_M".to_string(),
+            size_gb: 5.3,
+            url: "https://huggingface.co/ibm-granite/granite-4.1-8b-GGUF/blob/main/granite-4.1-8b-Q4_K_M.gguf".to_string(),
+        };
+        assert_eq!(provider.model_alias(Some(&variant)), None);
+    }
+
+    #[test]
+    fn test_model_alias_returns_none_when_no_variant() {
+        let provider = OllamaProvider::new(&serde_json::json!({}));
+        assert_eq!(provider.model_alias(None), None);
     }
 
     #[test]

--- a/src/providers/openai.rs
+++ b/src/providers/openai.rs
@@ -91,7 +91,7 @@ impl OpenAIProvider {
 impl ConfigConstructable for OpenAIProvider {
     type Config = OpenAIProviderConfig;
 
-    fn new(cfg: &serde_json::Value) -> Self {
+    fn new(cfg: &serde_json::Value, _global_config: &crate::config::Config) -> Self {
         let config: OpenAIProviderConfig = serde_json::from_value(cfg.clone()).unwrap_or_default();
 
         let client = reqwest::Client::builder()
@@ -306,7 +306,7 @@ mod tests {
             "api_key": "test-key",
             "timeout_secs": 30
         });
-        let provider = OpenAIProvider::new(&cfg);
+        let provider = OpenAIProvider::new(&cfg, &crate::config::Config::default());
         assert_eq!(provider.config.base_url, "http://example.com:8080");
         assert_eq!(
             provider.config.api_key,
@@ -318,7 +318,7 @@ mod tests {
     #[test]
     fn test_provider_function_endpoints() {
         let cfg = serde_json::json!({});
-        let provider = OpenAIProvider::new(&cfg);
+        let provider = OpenAIProvider::new(&cfg, &crate::config::Config::default());
         let endpoints = provider.function_endpoints();
         assert!(endpoints.contains_key(&ModelFunction::Chat));
         assert!(endpoints.contains_key(&ModelFunction::Embeddings));
@@ -331,7 +331,7 @@ mod tests {
         let cfg = serde_json::json!({
             "base_url": "http://example.com:8080"
         });
-        let provider = OpenAIProvider::new(&cfg);
+        let provider = OpenAIProvider::new(&cfg, &crate::config::Config::default());
         let endpoints = provider.function_endpoints();
         // Default config has all three functions
         assert!(endpoints.contains_key(&ModelFunction::Chat));

--- a/src/registry/mod.rs
+++ b/src/registry/mod.rs
@@ -19,8 +19,10 @@ pub trait ConfigConstructable {
     /// Must implement `JsonSchema + Serialize + Default`.
     type Config: schemars::JsonSchema + serde::Serialize + Default;
 
-    /// Construct with a config instance
-    fn new(cfg: &serde_json::Value) -> Self
+    /// Construct with a config instance and the global application config.
+    /// Most implementations ignore `global_config`; types that need cross-registry
+    /// resolution (e.g. resolving a model's provider) use it.
+    fn new(cfg: &serde_json::Value, global_config: &crate::config::Config) -> Self
     where
         Self: Sized;
 }
@@ -82,9 +84,9 @@ macro_rules! define_factory {
                 /// Get metadata describing this implementation
                 fn describe(&self) -> $metadata;
 
-                /// Construct an instance with the given config
+                /// Construct an instance with the given config and global application config
                 #[allow(unused)]
-                fn construct(&self, cfg: &serde_json::Value) -> Box<dyn $trait>;
+                fn construct(&self, cfg: &serde_json::Value, global_config: &crate::config::Config) -> Box<dyn $trait>;
 
                 /// JSON schema of the config this implementation expects
                 #[allow(unused)]
@@ -117,8 +119,8 @@ macro_rules! define_factory {
                     T::metadata()
                 }
 
-                fn construct(&self, cfg: &serde_json::Value) -> Box<dyn $trait> {
-                    Box::new(T::new(cfg))
+                fn construct(&self, cfg: &serde_json::Value, global_config: &crate::config::Config) -> Box<dyn $trait> {
+                    Box::new(T::new(cfg, global_config))
                 }
 
                 fn config_schema(&self) -> schemars::Schema {
@@ -190,10 +192,11 @@ macro_rules! define_factory {
                     &self,
                     name: &str,
                     cfg: &serde_json::Value,
+                    global_config: &crate::config::Config,
                 ) -> Result<Box<dyn $trait>, String> {
                     self.registry
                         .get(name)
-                        .map(|x| x.construct(cfg))
+                        .map(|x| x.construct(cfg, global_config))
                         .ok_or_else(|| format!("Unknown instance type: {}", name))
                 }
 
@@ -294,7 +297,7 @@ mod tests {
     impl ConfigConstructable for TestImpl1 {
         type Config = NoConfig;
 
-        fn new(cfg: &serde_json::Value) -> Self {
+        fn new(cfg: &serde_json::Value, _global_config: &crate::config::Config) -> Self {
             let value = cfg.get("value").and_then(|v| v.as_i64()).unwrap_or(0) as i32;
             Self { value }
         }
@@ -320,7 +323,7 @@ mod tests {
     impl ConfigConstructable for TestImpl2 {
         type Config = TestImpl2Config;
 
-        fn new(cfg: &serde_json::Value) -> Self {
+        fn new(cfg: &serde_json::Value, _global_config: &crate::config::Config) -> Self {
             let value = cfg.get("value").and_then(|v| v.as_i64()).unwrap_or(0) as i32;
             Self { value: value * 2 }
         }
@@ -375,11 +378,12 @@ mod tests {
         factory.register::<TestImpl2>("impl2");
 
         let cfg = serde_json::json!({ "value": 42 });
+        let global_config = crate::config::Config::default();
 
-        let inst1 = factory.construct("impl1", &cfg).unwrap();
+        let inst1 = factory.construct("impl1", &cfg, &global_config).unwrap();
         assert_eq!(inst1.get_value(), 42);
 
-        let inst2 = factory.construct("impl2", &cfg).unwrap();
+        let inst2 = factory.construct("impl2", &cfg, &global_config).unwrap();
         assert_eq!(inst2.get_value(), 84); // TestImpl2 doubles the value
     }
 
@@ -387,8 +391,9 @@ mod tests {
     fn test_factory_construct_unknown() {
         let factory = TestTraitFactory::new();
         let cfg = serde_json::json!({ "value": 42 });
+        let global_config = crate::config::Config::default();
 
-        let result = factory.construct("unknown", &cfg);
+        let result = factory.construct("unknown", &cfg, &global_config);
         assert!(result.is_err());
         assert!(result.err().unwrap().contains("Unknown instance type"));
     }

--- a/src/registry/mod.rs
+++ b/src/registry/mod.rs
@@ -86,7 +86,7 @@ macro_rules! define_factory {
 
                 /// Construct an instance with the given config and global application config
                 #[allow(unused)]
-                fn construct(&self, cfg: &serde_json::Value, global_config: &crate::config::Config) -> Box<dyn $trait>;
+                fn construct(&self, cfg: &serde_json::Value, global_config: &$crate::config::Config) -> Box<dyn $trait>;
 
                 /// JSON schema of the config this implementation expects
                 #[allow(unused)]
@@ -119,7 +119,7 @@ macro_rules! define_factory {
                     T::metadata()
                 }
 
-                fn construct(&self, cfg: &serde_json::Value, global_config: &crate::config::Config) -> Box<dyn $trait> {
+                fn construct(&self, cfg: &serde_json::Value, global_config: &$crate::config::Config) -> Box<dyn $trait> {
                     Box::new(T::new(cfg, global_config))
                 }
 
@@ -192,7 +192,7 @@ macro_rules! define_factory {
                     &self,
                     name: &str,
                     cfg: &serde_json::Value,
-                    global_config: &crate::config::Config,
+                    global_config: &$crate::config::Config,
                 ) -> Result<Box<dyn $trait>, String> {
                     self.registry
                         .get(name)

--- a/src/utils/ui/backends/json.rs
+++ b/src/utils/ui/backends/json.rs
@@ -123,6 +123,15 @@ impl Ui for JsonOutput {
         base::non_interactive()
     }
 
+    fn multi_select(
+        &self,
+        _prompt: &str,
+        _items: &[String],
+        _defaults: &[bool],
+    ) -> anyhow::Result<Vec<usize>> {
+        base::non_interactive()
+    }
+
     fn confirm(&self, _prompt: &str, _default: bool) -> anyhow::Result<bool> {
         base::non_interactive()
     }

--- a/src/utils/ui/backends/json.rs
+++ b/src/utils/ui/backends/json.rs
@@ -68,7 +68,7 @@ impl Write for SharedWriter {
 impl ConfigConstructable for JsonOutput {
     type Config = NoConfig;
 
-    fn new(_cfg: &serde_json::Value) -> Self {
+    fn new(_cfg: &serde_json::Value, _global_config: &crate::config::Config) -> Self {
         Self {
             writer: Mutex::new(Box::new(std::io::stdout())),
             buf: None,

--- a/src/utils/ui/backends/markdown.rs
+++ b/src/utils/ui/backends/markdown.rs
@@ -10,7 +10,7 @@ pub struct MarkdownOutput;
 impl ConfigConstructable for MarkdownOutput {
     type Config = NoConfig;
 
-    fn new(_cfg: &serde_json::Value) -> Self {
+    fn new(_cfg: &serde_json::Value, _global_config: &crate::config::Config) -> Self {
         Self
     }
 }
@@ -123,7 +123,7 @@ mod tests {
     use super::*;
     use crate::utils::ui::base::tests::CaptureUi;
 
-    crate::output_contract_tests!(MarkdownOutput::new(&serde_json::json!({})));
+    crate::output_contract_tests!(MarkdownOutput::new(&serde_json::json!({}), &crate::config::Config::default()));
 
     #[test]
     fn markdown_table_contains_pipe_chars() {
@@ -141,7 +141,7 @@ mod tests {
     #[test]
     fn markdown_table_has_header_separator() {
         // Invoke the real MarkdownOutput (print-only) — just verifies no panic
-        let md = MarkdownOutput::new(&serde_json::json!({}));
+        let md = MarkdownOutput::new(&serde_json::json!({}), &crate::config::Config::default());
         md.table(
             "T",
             &["ID", "NAME"],
@@ -151,13 +151,13 @@ mod tests {
 
     #[test]
     fn markdown_detail_is_two_column_table() {
-        let md = MarkdownOutput::new(&serde_json::json!({}));
+        let md = MarkdownOutput::new(&serde_json::json!({}), &crate::config::Config::default());
         md.detail("My Item", &[("Family", "Granite 3.1".to_string())]);
     }
 
     #[test]
     fn markdown_status_ok_contains_checkmark() {
-        let md = MarkdownOutput::new(&serde_json::json!({}));
+        let md = MarkdownOutput::new(&serde_json::json!({}), &crate::config::Config::default());
         md.status("my-service", true, "");
         md.status("my-service", false, "timeout");
     }

--- a/src/utils/ui/backends/markdown.rs
+++ b/src/utils/ui/backends/markdown.rs
@@ -66,6 +66,15 @@ impl Ui for MarkdownOutput {
         base::non_interactive()
     }
 
+    fn multi_select(
+        &self,
+        _prompt: &str,
+        _items: &[String],
+        _defaults: &[bool],
+    ) -> anyhow::Result<Vec<usize>> {
+        base::non_interactive()
+    }
+
     fn confirm(&self, _prompt: &str, _default: bool) -> anyhow::Result<bool> {
         base::non_interactive()
     }

--- a/src/utils/ui/backends/markdown.rs
+++ b/src/utils/ui/backends/markdown.rs
@@ -123,7 +123,10 @@ mod tests {
     use super::*;
     use crate::utils::ui::base::tests::CaptureUi;
 
-    crate::output_contract_tests!(MarkdownOutput::new(&serde_json::json!({}), &crate::config::Config::default()));
+    crate::output_contract_tests!(MarkdownOutput::new(
+        &serde_json::json!({}),
+        &crate::config::Config::default()
+    ));
 
     #[test]
     fn markdown_table_contains_pipe_chars() {

--- a/src/utils/ui/backends/plain.rs
+++ b/src/utils/ui/backends/plain.rs
@@ -134,5 +134,8 @@ impl HasUiMetadata for PlainOutput {
 mod tests {
     use super::*;
 
-    crate::output_contract_tests!(PlainOutput::new(&serde_json::json!({}), &crate::config::Config::default()));
+    crate::output_contract_tests!(PlainOutput::new(
+        &serde_json::json!({}),
+        &crate::config::Config::default()
+    ));
 }

--- a/src/utils/ui/backends/plain.rs
+++ b/src/utils/ui/backends/plain.rs
@@ -10,7 +10,7 @@ pub struct PlainOutput;
 impl ConfigConstructable for PlainOutput {
     type Config = NoConfig;
 
-    fn new(_cfg: &serde_json::Value) -> Self {
+    fn new(_cfg: &serde_json::Value, _global_config: &crate::config::Config) -> Self {
         Self
     }
 }
@@ -134,5 +134,5 @@ impl HasUiMetadata for PlainOutput {
 mod tests {
     use super::*;
 
-    crate::output_contract_tests!(PlainOutput::new(&serde_json::json!({})));
+    crate::output_contract_tests!(PlainOutput::new(&serde_json::json!({}), &crate::config::Config::default()));
 }

--- a/src/utils/ui/backends/terminal.rs
+++ b/src/utils/ui/backends/terminal.rs
@@ -29,7 +29,7 @@ pub struct TerminalOutput {
 impl ConfigConstructable for TerminalOutput {
     type Config = NoConfig;
 
-    fn new(_cfg: &serde_json::Value) -> Self {
+    fn new(_cfg: &serde_json::Value, _global_config: &crate::config::Config) -> Self {
         let (is_tty, width) = match crossterm::terminal::size() {
             Ok((cols, _rows)) => (true, Some(cols.max(20))),
             Err(_) => (false, None),

--- a/src/utils/ui/base.rs
+++ b/src/utils/ui/base.rs
@@ -201,10 +201,12 @@ pub trait Ui: Send + Sync + Any {
             .items(items)
             .defaults(defaults)
             .interact_opt()?
-            .ok_or_else(|| anyhow::anyhow!(
-                "interactive prompts are not supported outside of a terminal; \
+            .ok_or_else(|| {
+                anyhow::anyhow!(
+                    "interactive prompts are not supported outside of a terminal; \
                  rerun with --output=terminal or --output=plain"
-            ))
+                )
+            })
     }
 
     /// Ask a yes/no question.

--- a/src/utils/ui/base.rs
+++ b/src/utils/ui/base.rs
@@ -309,7 +309,7 @@ pub(crate) mod tests {
     impl ConfigConstructable for CaptureUi {
         type Config = crate::registry::NoConfig;
 
-        fn new(_cfg: &serde_json::Value) -> Self {
+        fn new(_cfg: &serde_json::Value, _global_config: &crate::config::Config) -> Self {
             Self::default()
         }
     }
@@ -480,7 +480,7 @@ pub(crate) mod tests {
 
     #[test]
     fn ui_registry_construct_unknown_returns_err() {
-        let result = UI_REGISTRY.construct("nonexistent", &serde_json::json!({}));
+        let result = UI_REGISTRY.construct("nonexistent", &serde_json::json!({}), &crate::config::Config::default());
         assert!(result.is_err());
     }
 

--- a/src/utils/ui/base.rs
+++ b/src/utils/ui/base.rs
@@ -480,7 +480,11 @@ pub(crate) mod tests {
 
     #[test]
     fn ui_registry_construct_unknown_returns_err() {
-        let result = UI_REGISTRY.construct("nonexistent", &serde_json::json!({}), &crate::config::Config::default());
+        let result = UI_REGISTRY.construct(
+            "nonexistent",
+            &serde_json::json!({}),
+            &crate::config::Config::default(),
+        );
         assert!(result.is_err());
     }
 

--- a/src/utils/ui/base.rs
+++ b/src/utils/ui/base.rs
@@ -197,7 +197,7 @@ pub trait Ui: Send + Sync + Any {
         // an Err instead of blocking — matching the behaviour of dialoguer's
         // Select/Confirm/Input which all error on non-TTY via interact().
         dialoguer::MultiSelect::new()
-            .with_prompt(prompt)
+            .with_prompt(format!("{} {}", prompt, self.detail_mark("[SPACE]")))
             .items(items)
             .defaults(defaults)
             .interact_opt()?

--- a/src/utils/ui/base.rs
+++ b/src/utils/ui/base.rs
@@ -9,6 +9,8 @@ pub type TableRow = Vec<String>;
 pub type TableEntry = (String, Vec<String>, Vec<TableRow>);
 pub type DetailField = (String, String);
 pub type DetailEntry = (String, Vec<DetailField>);
+pub type SelectEntry = (String, Vec<String>, usize);
+pub type MultiSelectEntry = (String, Vec<String>, Vec<bool>);
 
 /// Metadata describing a registered UI backend.
 #[derive(Debug, Clone)]
@@ -181,6 +183,30 @@ pub trait Ui: Send + Sync + Any {
             .interact()?)
     }
 
+    /// Ask the user to pick zero or more of `items`, returning the chosen indices.
+    /// `defaults` is a parallel slice of booleans — `true` means the item is
+    /// pre-checked. Callers may pass an empty `defaults` slice; unchecked is the
+    /// fallback for any item without a corresponding entry.
+    fn multi_select(
+        &self,
+        prompt: &str,
+        items: &[String],
+        defaults: &[bool],
+    ) -> anyhow::Result<Vec<usize>> {
+        // Use interact_opt so that non-TTY environments (CI, tests, pipes) get
+        // an Err instead of blocking — matching the behaviour of dialoguer's
+        // Select/Confirm/Input which all error on non-TTY via interact().
+        dialoguer::MultiSelect::new()
+            .with_prompt(prompt)
+            .items(items)
+            .defaults(defaults)
+            .interact_opt()?
+            .ok_or_else(|| anyhow::anyhow!(
+                "interactive prompts are not supported outside of a terminal; \
+                 rerun with --output=terminal or --output=plain"
+            ))
+    }
+
     /// Ask a yes/no question.
     fn confirm(&self, prompt: &str, default: bool) -> anyhow::Result<bool> {
         Ok(dialoguer::Confirm::new()
@@ -247,7 +273,9 @@ pub(crate) mod tests {
         pub detail_marks: RefCell<Vec<String>>,
 
         /// (prompt, items, default) for each select() call
-        pub select_prompts: RefCell<Vec<(String, Vec<String>, usize)>>,
+        pub select_prompts: RefCell<Vec<SelectEntry>>,
+        /// (prompt, items, defaults) for each multi_select() call
+        pub multi_select_prompts: RefCell<Vec<MultiSelectEntry>>,
         /// (prompt, default) for each confirm() call
         pub confirm_prompts: RefCell<Vec<(String, bool)>>,
         /// (prompt, default) for each text() call
@@ -257,6 +285,8 @@ pub(crate) mod tests {
 
         /// Canned answers consumed in order by select(); falls back to `default` when empty.
         pub select_answers: RefCell<VecDeque<usize>>,
+        /// Canned answers consumed in order by multi_select(); falls back to `vec![]` when empty.
+        pub multi_select_answers: RefCell<VecDeque<Vec<usize>>>,
         /// Canned answers consumed in order by confirm(); falls back to `default` when empty.
         pub confirm_answers: RefCell<VecDeque<bool>>,
         /// Canned answers consumed in order by text(); falls back to `default` when empty.
@@ -377,6 +407,24 @@ pub(crate) mod tests {
                 .borrow_mut()
                 .pop_front()
                 .unwrap_or(default))
+        }
+
+        fn multi_select(
+            &self,
+            prompt: &str,
+            items: &[String],
+            defaults: &[bool],
+        ) -> anyhow::Result<Vec<usize>> {
+            self.multi_select_prompts.borrow_mut().push((
+                prompt.to_string(),
+                items.to_vec(),
+                defaults.to_vec(),
+            ));
+            Ok(self
+                .multi_select_answers
+                .borrow_mut()
+                .pop_front()
+                .unwrap_or_default())
         }
 
         fn confirm(&self, prompt: &str, default: bool) -> anyhow::Result<bool> {


### PR DESCRIPTION
## Description

This PR closes the loop on actually binding Capabilities to launchers with the concrete binding of the `AgentModelCapability` to `ClaudeLauncher`.

## Changes

- Remove the `models` argument from `Capability.bind`. For capabilities that need a specific model, they should store it at construct time so they can use it at bind time without needing to look it back up by ID
- Add multi-select to Ui abstraction for capability selection
- Construct `AgentModelCapability` with the actual `model` to be used in `bind`
  - **NOTE**: The current implementation of this is a bit hacky using `with_config` to extract the config for the global model config and construct it. We need some structural fixes here around the relationships between resource instances and the registries. We'll tackle doing this better in #51 
- Add a path to have a per-provider/variant name alias so that a given model can determine the correct ID string to use in the configured provider
- Bind the real model env overrides into `ClaudeLauncher` for end-to-end launch

## Testing

- Rigorous unit testing
- Spot testing of individual code paths

## Related Issue(s)

Closes #49 

Deferring factory refactors to #52 

## AI Usage

AI was used extensively for this PR. I used a large combination of agents and models. All commits were made by me after reviewing agent output and editing if needed.

<details>
<summary>git-ai-stats</summary>

```sh
╔══════════════════════════════════════════════════════════╗
║           GIT AI USAGE ANALYSIS                          ║
╚══════════════════════════════════════════════════════════╝

📊 COMMITS BY AGENT

--- Aggregate ---
Commits                        |      Count
---------------------------------------------
none                           |         23
OpenCode + Qwen3.6-35b         |         14
Claude + Sonnet 5              |         12
IBM Bob                        |          8
OpenCode + GraniteXX           |          3
OpenCode + Qwen3.6-35b, OpenCode + Granite |          1
---------------------------------------------
TOTAL                          |         61

📊 COMMITS BY USAGE TYPE

--- Aggregate ---
Commits                        |      Count
---------------------------------------------
none                           |         23
draft                          |          5
full                           |         33
---------------------------------------------
TOTAL                          |         61

📈 LINES OF CODE BY AGENT

--- Aggregate ---
Agent                     |    Commits |  Additions |  Deletions
------------------------------------------------------------
none                      |         23 |        279 |         96
OpenCode + Qwen3.6-35b    |         14 |        536 |        357
Claude + Sonnet 5         |         12 |       2575 |        573
IBM Bob                   |          8 |       1362 |         75
OpenCode + GraniteXX      |          3 |        229 |         17
OpenCode + Qwen3.6-35b, OpenCode + Granite |          1 |         11 |         19
------------------------------------------------------------
TOTAL                     |         61 |       4992 |       1137

📈 LINES OF CODE BY USAGE TYPE

--- Aggregate ---
Usage Type           |    Commits |  Additions |  Deletions
-------------------------------------------------------
none                 |         23 |        279 |         96
draft                |          5 |        162 |         38
full                 |         33 |       4551 |       1003
-------------------------------------------------------
TOTAL                |         61 |       4992 |       1137
```

</details>