### PR TITLE
Worktree pi launcher

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -56,10 +56,11 @@ fn generate_model_struct(model: &YamlModel) -> String {
     let struct_name = model_id_to_struct_name(&model.id);
     let mut s = String::new();
 
-    // Struct carrying the resolved provider config it was constructed with
-    // (see `ModelSource::from_config`), if any.
+    // Struct carrying the configured name it was constructed under and the
+    // resolved provider config it was constructed with (see
+    // `ModelSource::from_config`), if any.
     s.push_str(&format!(
-        "pub struct {struct_name} {{ provider_config: Option<crate::config::ProviderConfig> }}\n\n"
+        "pub struct {struct_name} {{ instance_id: String, provider_config: Option<crate::config::ProviderConfig> }}\n\n"
     ));
 
     // ConfigConstructable implementation
@@ -68,11 +69,18 @@ fn generate_model_struct(model: &YamlModel) -> String {
     ));
     s.push_str("    type Config = crate::registry::NoConfig;\n\n");
     s.push_str(
-        "    fn new(cfg: &serde_json::Value, _global_config: &crate::config::Config) -> Self {\n",
+        "    fn new(instance_id: &str, cfg: &serde_json::Value, _global_config: &crate::config::Config) -> Self {\n",
     );
     s.push_str("        let provider_config = cfg.get(\"provider_config\").and_then(|v| serde_json::from_value(v.clone()).map_err(|e| alog_channel!(MessageLevel::Warning, \"WARNING: Failed to deserialize provider_config: {}\", e)).ok());\n");
-    s.push_str("        Self { provider_config }\n");
+    s.push_str("        Self { instance_id: instance_id.to_string(), provider_config }\n");
     s.push_str("    }\n");
+    s.push_str("}\n\n");
+
+    // Named implementation
+    s.push_str(&format!(
+        "impl crate::registry::Named for {struct_name} {{\n"
+    ));
+    s.push_str("    fn instance_id(&self) -> &str { &self.instance_id }\n");
     s.push_str("}\n\n");
 
     // Model trait implementation

--- a/src/capabilities/agent_model.rs
+++ b/src/capabilities/agent_model.rs
@@ -27,6 +27,7 @@ pub struct AgentModelCapabilityConfig {
 /*-- AgentModelCapability ---------------------------------------------------------*/
 
 pub struct AgentModelCapability {
+    instance_id: String,
     config: AgentModelCapabilityConfig,
     model: Arc<dyn Model>,
     /// The raw `"format/precision"` string from `ModelConfig.variant`, if the
@@ -44,8 +45,13 @@ impl ConfigConstructable for AgentModelCapability {
     /// transparently wraps the model in a local tracking proxy.
     ///
     /// `cfg` contains the capability's instance config (e.g. `{"model_id": "my-model"}`)
-    /// where `model_id` is the key into `global_config.models`.
-    fn new(cfg: &serde_json::Value, global_config: &crate::config::Config) -> Self {
+    /// where `model_id` is the key into `global_config.models`. The resolved
+    /// `ModelConfig` supplies the catalog model ID and the provider ID.
+    fn new(
+        instance_id: &str,
+        cfg: &serde_json::Value,
+        global_config: &crate::config::Config,
+    ) -> Self {
         let config: AgentModelCapabilityConfig =
             serde_json::from_value(cfg.clone()).unwrap_or_default();
         let mut source = crate::models::ModelSource::from_config(global_config);
@@ -60,10 +66,17 @@ impl ConfigConstructable for AgentModelCapability {
             .get(&config.model_id)
             .and_then(|mc| mc.variant.clone());
         Self {
+            instance_id: instance_id.to_string(),
             config,
             model,
             configured_variant,
         }
+    }
+}
+
+impl crate::registry::Named for AgentModelCapability {
+    fn instance_id(&self) -> &str {
+        &self.instance_id
     }
 }
 
@@ -160,6 +173,7 @@ impl Capability for AgentModelCapability {
 
         Ok(Binding::AgentModel(AgentModelBinding {
             api_type,
+            provider_name: provider.instance_id().to_string(),
             base_url: provider.base_url().to_string(),
             model_name,
             endpoint_path: endpoint.path().to_string(),
@@ -205,6 +219,7 @@ mod tests {
 
     #[derive(Clone, Default)]
     pub(crate) struct FakeProvider {
+        pub(crate) instance_id: String,
         pub(crate) base_url: String,
         pub(crate) api_key: Option<Secret>,
         pub(crate) verify_ssl: bool,
@@ -217,8 +232,18 @@ mod tests {
     impl ConfigConstructable for FakeProvider {
         type Config = crate::registry::NoConfig;
 
-        fn new(_cfg: &serde_json::Value, _global_config: &crate::config::Config) -> Self {
+        fn new(
+            _instance_id: &str,
+            _cfg: &serde_json::Value,
+            _global_config: &crate::config::Config,
+        ) -> Self {
             unimplemented!("not used in tests")
+        }
+    }
+
+    impl crate::registry::Named for FakeProvider {
+        fn instance_id(&self) -> &str {
+            &self.instance_id
         }
     }
 
@@ -261,6 +286,7 @@ mod tests {
         let mut endpoints = HashMap::new();
         endpoints.insert(function, vec![endpoint]);
         FakeProvider {
+            instance_id: "my-ollama".to_string(),
             base_url: "http://localhost:11434".to_string(),
             api_key: None,
             verify_ssl: true,
@@ -300,12 +326,14 @@ mod tests {
             },
         );
         let cap = AgentModelCapability::new(
+            "my-agent",
             &serde_json::json!({ "model_id": "granite-3.1-8b-instruct" }),
             &config,
         );
         // Replace the real model with our test double that has a custom provider
         // and the specified variants list.
         AgentModelCapability {
+            instance_id: cap.instance_id,
             config: cap.config,
             configured_variant: variant_str,
             model: Arc::new(TestModelWithVariants {
@@ -325,8 +353,18 @@ mod tests {
 
     impl ConfigConstructable for TestModelWithVariants {
         type Config = crate::registry::NoConfig;
-        fn new(_cfg: &serde_json::Value, _global_config: &crate::config::Config) -> Self {
+        fn new(
+            _instance_id: &str,
+            _cfg: &serde_json::Value,
+            _global_config: &crate::config::Config,
+        ) -> Self {
             unimplemented!("not used in tests")
+        }
+    }
+
+    impl crate::registry::Named for TestModelWithVariants {
+        fn instance_id(&self) -> &str {
+            "granite-3.1-8b-instruct"
         }
     }
 
@@ -403,6 +441,7 @@ mod tests {
         let cap = capability_with_test_model(
             vec![ModelFunction::Chat],
             FakeProvider {
+                instance_id: "my-ollama".to_string(),
                 base_url: "http://localhost:11434".to_string(),
                 api_key: None,
                 verify_ssl: true,
@@ -493,6 +532,7 @@ mod tests {
             },
         );
         let cap = AgentModelCapability::new(
+            "my-agent",
             &serde_json::json!({ "model_id": "granite-3.1-8b-instruct" }),
             &config,
         );
@@ -514,6 +554,7 @@ mod tests {
             },
         );
         let cap = AgentModelCapability::new(
+            "my-agent",
             &serde_json::json!({ "model_id": "granite-3.1-8b-instruct" }),
             &config,
         );

--- a/src/capabilities/base.rs
+++ b/src/capabilities/base.rs
@@ -86,6 +86,10 @@ pub struct AgentModelBindingRequest {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct AgentModelBinding {
     pub api_type: ApiType,
+    /// Configured name of the provider instance serving this model (e.g.
+    /// `my-ollama`). Launchers that must name the endpoint in the wrapped tool's
+    /// own config use this rather than inventing a name of their own.
+    pub provider_name: String,
     pub base_url: String,
     pub model_name: String,
     pub endpoint_path: String,

--- a/src/capabilities/base.rs
+++ b/src/capabilities/base.rs
@@ -107,7 +107,7 @@ define_bindings! {
 /// Core trait for capability implementations.
 /// All capabilities must implement this trait along with ConfigConstructable.
 #[async_trait]
-pub trait Capability: Send + Sync {
+pub trait Capability: crate::registry::Named + Send + Sync {
     fn name(&self) -> &str;
     fn description(&self) -> &str;
     fn dependencies(&self) -> Vec<Dependency>;

--- a/src/capabilities/mod.rs
+++ b/src/capabilities/mod.rs
@@ -31,6 +31,7 @@ impl CapabilitySource {
             .filter_map(|capability_config| {
                 let result = CAPABILITY_REGISTRY.construct(
                     &capability_config.capability_type,
+                    &capability_config.capability_id,
                     &capability_config.config,
                     config,
                 );

--- a/src/commands/launcher.rs
+++ b/src/commands/launcher.rs
@@ -187,7 +187,7 @@ impl LauncherCommands {
         // Validate the binary now so the user gets immediate feedback.
         // validate_command respects command_path when set; falls back to PATH.
         let launcher = LAUNCHER_REGISTRY
-            .construct(launcher_type, &config, &ctx.config)
+            .construct(launcher_type, &instance_id, &config, &ctx.config)
             .map_err(|e| anyhow::anyhow!("Failed to construct launcher: {e}"))?;
 
         match launcher.validate_command() {

--- a/src/commands/launcher.rs
+++ b/src/commands/launcher.rs
@@ -428,13 +428,14 @@ mod tests {
     }
 
     #[test]
-    fn catalog_contains_claude_and_bob() {
+    fn catalog_contains_claude_bob_and_pi() {
         let ctx = test_ctx();
         LauncherCommands::catalog(&ctx).unwrap();
         let tables = tables!(ctx);
         let (_, _, rows) = &tables[0];
         assert!(rows.iter().any(|r| r[0] == "claude"));
         assert!(rows.iter().any(|r| r[0] == "bob"));
+        assert!(rows.iter().any(|r| r[0] == "pi"));
     }
 
     // -- list ------------------------------------------------------------------

--- a/src/commands/model.rs
+++ b/src/commands/model.rs
@@ -1108,6 +1108,7 @@ mod tests {
             precision: "bfloat16".to_string(),
         };
         let provider = crate::providers::OpenAIProvider::new(
+            "my-openai",
             &serde_json::json!({ "base_url": "http://localhost:8080" }),
             &crate::config::Config::default(),
         );

--- a/src/commands/provider.rs
+++ b/src/commands/provider.rs
@@ -236,6 +236,7 @@ impl ProviderCommands {
         let provider = PROVIDER_REGISTRY
             .construct(
                 &provider_config.provider_type,
+                &provider_config.provider_id,
                 &provider_config.config,
                 &ctx.config,
             )

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -129,6 +129,16 @@ impl Config {
         Ok(Self::config_dir()?.join("launchers"))
     }
 
+    /// Directory a launcher may materialize generated state into -- config files
+    /// it must put on disk for the tool it wraps. Kept under `GRANITE_CLI_HOME`
+    /// so wrapping a tool never means editing that tool's own global config.
+    ///
+    /// The path is returned without being created; callers create it when they
+    /// actually write, so a dry run leaves no trace.
+    pub fn launcher_state_dir(launcher_id: &str) -> Result<PathBuf> {
+        Ok(Self::config_dir()?.join("launcher-state").join(launcher_id))
+    }
+
     fn ensure_directories() -> Result<()> {
         let config_dir = Self::config_dir()?;
         if !config_dir.exists() {

--- a/src/launchers/base.rs
+++ b/src/launchers/base.rs
@@ -20,7 +20,7 @@ use_channel!("LNCHR");
 /// Core trait for launcher implementations.
 /// All launchers must implement this trait along with ConfigConstructable.
 #[async_trait]
-pub trait Launcher: Send + Sync {
+pub trait Launcher: crate::registry::Named + Send + Sync {
     fn name(&self) -> &str;
 
     /// The binary/command this instance will exec.
@@ -189,15 +189,26 @@ pub(crate) mod tests {
 
     /// Minimal Launcher implementation used only in tests.
     pub(crate) struct FakeLauncher {
+        instance_id: String,
         /// When `Some`, `validate_command` resolves to this path directly.
         command_path: Option<PathBuf>,
         command_name: String,
     }
 
+    impl crate::registry::Named for FakeLauncher {
+        fn instance_id(&self) -> &str {
+            &self.instance_id
+        }
+    }
+
     impl ConfigConstructable for FakeLauncher {
         type Config = crate::registry::NoConfig;
 
-        fn new(cfg: &serde_json::Value, _global_config: &crate::config::Config) -> Self {
+        fn new(
+            instance_id: &str,
+            cfg: &serde_json::Value,
+            _global_config: &crate::config::Config,
+        ) -> Self {
             let command_name = cfg
                 .get("command_name")
                 .and_then(|v| v.as_str())
@@ -208,6 +219,7 @@ pub(crate) mod tests {
                 .and_then(|v| v.as_str())
                 .map(PathBuf::from);
             Self {
+                instance_id: instance_id.to_string(),
                 command_name,
                 command_path,
             }
@@ -257,6 +269,7 @@ pub(crate) mod tests {
     #[test]
     fn validate_command_returns_err_for_unknown_binary() {
         let launcher = FakeLauncher::new(
+            "my-fake",
             &serde_json::json!({
                 "command_name": "this-binary-absolutely-does-not-exist-9x7z"
             }),
@@ -268,6 +281,7 @@ pub(crate) mod tests {
     #[test]
     fn validate_command_returns_err_for_nonexistent_explicit_path() {
         let launcher = FakeLauncher::new(
+            "my-fake",
             &serde_json::json!({
                 "command_name": "fake",
                 "command_path": "/this/path/does/not/exist/fake"
@@ -280,6 +294,7 @@ pub(crate) mod tests {
     #[test]
     fn validate_command_falls_back_to_path_for_bare_command_name() {
         let launcher = FakeLauncher::new(
+            "my-fake",
             &serde_json::json!({
                 "command_path": "ls"
             }),
@@ -290,7 +305,11 @@ pub(crate) mod tests {
 
     #[tokio::test]
     async fn env_overlay_default_is_empty() {
-        let launcher = FakeLauncher::new(&serde_json::json!({}), &crate::config::Config::default());
+        let launcher = FakeLauncher::new(
+            "my-fake",
+            &serde_json::json!({}),
+            &crate::config::Config::default(),
+        );
         let ctx = LaunchContext {
             launcher_id: "test".to_string(),
             working_dir: PathBuf::from("/tmp"),
@@ -315,6 +334,7 @@ pub(crate) mod tests {
         factory.register::<FakeLauncher>("fake");
         let result = factory.construct(
             "fake",
+            "my-fake",
             &serde_json::json!({}),
             &crate::config::Config::default(),
         );

--- a/src/launchers/bob.rs
+++ b/src/launchers/bob.rs
@@ -18,15 +18,29 @@ pub struct BobLauncherConfig {
 }
 
 pub struct BobLauncher {
+    instance_id: String,
     config: BobLauncherConfig,
 }
 
 impl ConfigConstructable for BobLauncher {
     type Config = BobLauncherConfig;
 
-    fn new(cfg: &serde_json::Value, _global_config: &crate::config::Config) -> Self {
+    fn new(
+        instance_id: &str,
+        cfg: &serde_json::Value,
+        _global_config: &crate::config::Config,
+    ) -> Self {
         let config: BobLauncherConfig = serde_json::from_value(cfg.clone()).unwrap_or_default();
-        Self { config }
+        Self {
+            instance_id: instance_id.to_string(),
+            config,
+        }
+    }
+}
+
+impl crate::registry::Named for BobLauncher {
+    fn instance_id(&self) -> &str {
+        &self.instance_id
     }
 }
 
@@ -77,13 +91,18 @@ mod tests {
 
     #[test]
     fn command_defaults_to_bob() {
-        let l = BobLauncher::new(&serde_json::json!({}), &crate::config::Config::default());
+        let l = BobLauncher::new(
+            "my-bob",
+            &serde_json::json!({}),
+            &crate::config::Config::default(),
+        );
         assert_eq!(l.command(), "bob");
     }
 
     #[test]
     fn command_uses_explicit_path_when_set() {
         let l = BobLauncher::new(
+            "my-bob",
             &serde_json::json!({
                 "command_path": "/opt/bin/bob"
             }),
@@ -95,6 +114,7 @@ mod tests {
     #[test]
     fn validate_command_err_for_nonexistent_explicit_path() {
         let l = BobLauncher::new(
+            "my-bob",
             &serde_json::json!({
                 "command_path": "/no/such/path/bob"
             }),
@@ -106,6 +126,7 @@ mod tests {
     #[test]
     fn validate_command_falls_back_to_path_for_bare_command_name() {
         let l = BobLauncher::new(
+            "my-bob",
             &serde_json::json!({
                 "command_path": "ls"
             }),

--- a/src/launchers/claude.rs
+++ b/src/launchers/claude.rs
@@ -18,6 +18,7 @@ pub struct ClaudeLauncherConfig {
 }
 
 pub struct ClaudeLauncher {
+    instance_id: String,
     config: ClaudeLauncherConfig,
     bound_binding: Option<crate::capabilities::AgentModelBinding>,
 }
@@ -25,12 +26,23 @@ pub struct ClaudeLauncher {
 impl ConfigConstructable for ClaudeLauncher {
     type Config = ClaudeLauncherConfig;
 
-    fn new(cfg: &serde_json::Value, _global_config: &crate::config::Config) -> Self {
+    fn new(
+        instance_id: &str,
+        cfg: &serde_json::Value,
+        _global_config: &crate::config::Config,
+    ) -> Self {
         let config: ClaudeLauncherConfig = serde_json::from_value(cfg.clone()).unwrap_or_default();
         Self {
+            instance_id: instance_id.to_string(),
             config,
             bound_binding: None,
         }
+    }
+}
+
+impl crate::registry::Named for ClaudeLauncher {
+    fn instance_id(&self) -> &str {
+        &self.instance_id
     }
 }
 
@@ -134,13 +146,18 @@ mod tests {
 
     #[test]
     fn command_defaults_to_claude() {
-        let l = ClaudeLauncher::new(&serde_json::json!({}), &crate::config::Config::default());
+        let l = ClaudeLauncher::new(
+            "my-claude",
+            &serde_json::json!({}),
+            &crate::config::Config::default(),
+        );
         assert_eq!(l.command(), "claude");
     }
 
     #[test]
     fn command_uses_explicit_path_when_set() {
         let l = ClaudeLauncher::new(
+            "my-claude",
             &serde_json::json!({
                 "command_path": "/opt/bin/claude"
             }),
@@ -152,6 +169,7 @@ mod tests {
     #[test]
     fn validate_command_err_for_nonexistent_explicit_path() {
         let l = ClaudeLauncher::new(
+            "my-claude",
             &serde_json::json!({
                 "command_path": "/no/such/path/claude"
             }),
@@ -163,6 +181,7 @@ mod tests {
     #[test]
     fn validate_command_falls_back_to_path_for_bare_command_name() {
         let l = ClaudeLauncher::new(
+            "my-claude",
             &serde_json::json!({
                 "command_path": "ls"
             }),

--- a/src/launchers/mod.rs
+++ b/src/launchers/mod.rs
@@ -33,7 +33,12 @@ impl LauncherSource {
             .launchers
             .values()
             .filter_map(|lc| {
-                let result = LAUNCHER_REGISTRY.construct(&lc.launcher_type, &lc.config, config);
+                let result = LAUNCHER_REGISTRY.construct(
+                    &lc.launcher_type,
+                    &lc.launcher_id,
+                    &lc.config,
+                    config,
+                );
                 if result.is_err() {
                     alog_channel!(
                         MessageLevel::Warning,

--- a/src/launchers/mod.rs
+++ b/src/launchers/mod.rs
@@ -13,6 +13,7 @@ pub static LAUNCHER_REGISTRY: LazyLock<base::LauncherFactory> = LazyLock::new(||
     let mut factory = base::LauncherFactory::new();
     factory.register::<claude::ClaudeLauncher>("claude");
     factory.register::<bob::BobLauncher>("bob");
+    factory.register::<pi::PiLauncher>("pi");
     factory
 });
 
@@ -77,10 +78,12 @@ impl crate::dependency::Configured<dyn Launcher> for LauncherSource {
 mod base;
 pub mod bob;
 pub mod claude;
+pub mod pi;
 
 pub use base::{EnvBinding, LaunchContext, Launcher, LauncherMetadata};
 pub use bob::{BobLauncher, BobLauncherConfig};
 pub use claude::{ClaudeLauncher, ClaudeLauncherConfig};
+pub use pi::{PiLauncher, PiLauncherConfig};
 
 /*-- tests -------------------------------------------------------------------*/
 
@@ -104,9 +107,10 @@ mod tests {
     }
 
     #[test]
-    fn registry_contains_claude_and_bob() {
+    fn registry_contains_claude_bob_and_pi() {
         assert!(LAUNCHER_REGISTRY.get("claude").is_some());
         assert!(LAUNCHER_REGISTRY.get("bob").is_some());
+        assert!(LAUNCHER_REGISTRY.get("pi").is_some());
         assert!(LAUNCHER_REGISTRY.get("nonexistent").is_none());
     }
 
@@ -149,6 +153,7 @@ mod tests {
         let catalog = source.catalog();
         assert!(catalog.contains_key("claude"));
         assert!(catalog.contains_key("bob"));
+        assert!(catalog.contains_key("pi"));
     }
 
     #[test]
@@ -157,6 +162,7 @@ mod tests {
         let source = LauncherSource::from_config(&config);
         assert!(source.config_schema("claude").is_some());
         assert!(source.config_schema("bob").is_some());
+        assert!(source.config_schema("pi").is_some());
         assert!(source.config_schema("nonexistent").is_none());
     }
 }

--- a/src/launchers/pi.rs
+++ b/src/launchers/pi.rs
@@ -1,0 +1,982 @@
+//! Launcher for the `pi` coding agent harness (<https://pi.dev>).
+//!
+//! Unlike `claude`, Pi has no environment variable for the model endpoint: a
+//! non-built-in provider must be declared in Pi's `models.json`, then selected
+//! with `--provider`/`--model`. Rather than edit the user's real Pi config, this
+//! launcher builds its own Pi config directory under `GRANITE_CLI_HOME` --
+//! `models.json` written fresh from the bound model, everything else linked
+//! through from the user's directory -- and points the child process at it with
+//! `PI_CODING_AGENT_DIR`.
+
+use crate::capabilities::{AgentModelBinding, BindingType, Capability};
+use crate::launchers::base::{EnvBinding, LaunchContext, Launcher, LauncherMetadata, run_command};
+use crate::providers::ApiType;
+use crate::registry::ConfigConstructable;
+use crate::utils::resolve_shell_command;
+use crate::utils::ui::Ui;
+use alog::{MessageLevel, alog_channel, use_channel};
+use anyhow::Context;
+use async_trait::async_trait;
+use serde::{Deserialize, Serialize};
+use std::collections::HashSet;
+use std::path::{Path, PathBuf};
+
+use_channel!("LNCHR");
+
+/*-- public --*/
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default, schemars::JsonSchema)]
+pub struct PiLauncherConfig {
+    /// Override path to the `pi` binary for non-PATH installs.
+    /// Leave unset to use PATH lookup.
+    #[serde(default)]
+    pub command_path: Option<String>,
+
+    /// Extra keys merged (shallow, last-write-wins) into the generated Pi
+    /// provider entry -- e.g. `compat` flags or `headers` a particular server
+    /// needs. Necessary because the entry is regenerated on every launch.
+    #[serde(default)]
+    pub provider_overrides: Option<serde_json::Value>,
+}
+
+pub struct PiLauncher {
+    instance_id: String,
+    config: PiLauncherConfig,
+    bound_binding: Option<AgentModelBinding>,
+}
+
+impl ConfigConstructable for PiLauncher {
+    type Config = PiLauncherConfig;
+
+    fn new(
+        instance_id: &str,
+        cfg: &serde_json::Value,
+        _global_config: &crate::config::Config,
+    ) -> Self {
+        let config: PiLauncherConfig = serde_json::from_value(cfg.clone()).unwrap_or_default();
+        Self {
+            instance_id: instance_id.to_string(),
+            config,
+            bound_binding: None,
+        }
+    }
+}
+
+impl crate::registry::Named for PiLauncher {
+    fn instance_id(&self) -> &str {
+        &self.instance_id
+    }
+}
+
+#[async_trait]
+impl Launcher for PiLauncher {
+    fn name(&self) -> &str {
+        "Pi CLI"
+    }
+
+    fn command(&self) -> &str {
+        self.config.command_path.as_deref().unwrap_or("pi")
+    }
+
+    async fn bind_capability(&mut self, capability: &dyn Capability) -> anyhow::Result<()> {
+        let supported = Self::metadata().supported_capabilities;
+        let capability_types = capability.binding_types();
+        if !capability_types.is_subset(&supported) {
+            anyhow::bail!(
+                "capability supports {:?} which this launcher does not support",
+                capability_types.difference(&supported).collect::<Vec<_>>()
+            );
+        }
+
+        // Pi speaks several API dialects, but `openai-completions` is the one
+        // every granite-cli provider can serve and the one Pi documents as most
+        // compatible, so that is what we ask the capability for.
+        let request = crate::capabilities::BindingRequest::AgentModel(
+            crate::capabilities::AgentModelBindingRequest {
+                api_type: ApiType::OpenAI,
+            },
+        );
+
+        let binding = capability.bind(request).await?;
+        match binding {
+            crate::capabilities::Binding::AgentModel(binding) => {
+                self.bound_binding = Some(binding);
+            }
+        }
+        Ok(())
+    }
+
+    fn validate_command(&self) -> anyhow::Result<PathBuf> {
+        resolve_shell_command(&self.config.command_path, "pi")
+    }
+
+    /// Redirects Pi at the granite-cli-owned config directory and supplies the
+    /// credential the generated `models.json` interpolates.
+    ///
+    /// The provider entry's `apiKey` is written as an environment reference
+    /// (`$GRANITE_CLI_PI_API_KEY`) rather than a literal, so the secret stays out
+    /// of the generated file and off Pi's command line. Pi only treats a model as
+    /// selectable once *some* credential resolves, so providers with no key get a
+    /// placeholder -- local servers ignore it.
+    async fn env_overlay(&self, ctx: &LaunchContext) -> anyhow::Result<Vec<EnvBinding>> {
+        let Some(binding) = &self.bound_binding else {
+            return Ok(vec![]);
+        };
+        let api_key_val = binding
+            .api_key
+            .as_ref()
+            .map(|api_key| api_key.0.clone())
+            .filter(|key| !key.is_empty())
+            .unwrap_or_else(|| PLACEHOLDER_API_KEY.to_string());
+        Ok(vec![
+            EnvBinding {
+                key: CONFIG_DIR_ENV.to_string(),
+                value: pi_state_dir(ctx)?.to_string_lossy().to_string(),
+            },
+            EnvBinding {
+                key: API_KEY_ENV.to_string(),
+                value: api_key_val,
+            },
+        ])
+    }
+
+    /// Materializes the granite-cli Pi config directory, then execs `pi` with the
+    /// selection flags in front of the caller's arguments (Pi's own positional
+    /// `@files`/messages must stay last).
+    async fn launch(
+        &self,
+        args: &[String],
+        ctx: &LaunchContext,
+        ui: &dyn Ui,
+    ) -> anyhow::Result<std::process::ExitStatus> {
+        let binary = self.validate_command()?;
+        let overlay = self.env_overlay(ctx).await?;
+        alog_channel!(MessageLevel::Debug2, "Env Overlay: {:#?}", overlay);
+
+        let mut pi_args: Vec<String> = vec![];
+        if let Some(binding) = &self.bound_binding {
+            let provider_name = &binding.provider_name;
+            let entry = self.provider_entry(binding)?;
+            let state_dir = pi_state_dir(ctx)?;
+            let source_dir = pi_source_dir()?;
+
+            if ctx.dry_run {
+                ui.info(&format!(
+                    "Would write Pi provider '{provider_name}' into {}:",
+                    state_dir.join(MODELS_JSON).display()
+                ));
+                ui.info(&serde_json::to_string_pretty(&entry)?);
+                ui.info(&format!(
+                    "  (merged over {}, which is left unmodified)",
+                    source_dir.join(MODELS_JSON).display()
+                ));
+            } else {
+                materialize_pi_config(&state_dir, &source_dir, provider_name, entry, ui)?;
+                ui.info(&format!(
+                    "Wrote Pi provider '{provider_name}' to {}",
+                    state_dir.join(MODELS_JSON).display()
+                ));
+            }
+            pi_args.extend([
+                "--provider".to_string(),
+                provider_name.clone(),
+                "--model".to_string(),
+                binding.model_name.clone(),
+            ]);
+        }
+        pi_args.extend_from_slice(args);
+
+        run_command(binary, &overlay, &pi_args, ctx, ui).await
+    }
+}
+
+impl HasPiLauncherMetadata for PiLauncher {
+    fn metadata() -> LauncherMetadata {
+        LauncherMetadata {
+            name: "Pi CLI".to_string(),
+            description: "Pi terminal coding agent harness".to_string(),
+            default_command: "pi".to_string(),
+            supported_capabilities: HashSet::from([BindingType::AgentModel]),
+            tags: vec!["pi".to_string(), "coding-agent".to_string()],
+        }
+    }
+}
+
+/*-- private --*/
+
+// HasPiLauncherMetadata is the macro-generated trait; re-exported via mod.rs.
+use crate::launchers::base::HasLauncherMetadata as HasPiLauncherMetadata;
+
+/// Env var pointing Pi at a config directory other than `~/.pi/agent`.
+const CONFIG_DIR_ENV: &str = "PI_CODING_AGENT_DIR";
+
+/// Env var the generated provider entry interpolates its `apiKey` from.
+const API_KEY_ENV: &str = "GRANITE_CLI_PI_API_KEY";
+
+/// Stand-in credential for providers that need no auth. Pi hides models whose
+/// provider has no resolvable key, so the value must be non-empty.
+const PLACEHOLDER_API_KEY: &str = "granite-cli";
+
+/// Pi's custom-model file, relative to its config directory.
+const MODELS_JSON: &str = "models.json";
+
+/// Pi's session store. Deliberately *not* linked through to the user's
+/// directory: granite-cli launches keep their own history rather than writing
+/// into the user's Pi state.
+const SESSIONS_DIR: &str = "sessions";
+
+impl PiLauncher {
+    /// Builds the `models.json` provider entry describing the bound model.
+    fn provider_entry(&self, binding: &AgentModelBinding) -> anyhow::Result<serde_json::Value> {
+        let mut entry = serde_json::json!({
+            "baseUrl": pi_base_url(binding),
+            "api": pi_api_name(&binding.api_type)?,
+            "apiKey": format!("${API_KEY_ENV}"),
+            "models": [{
+                "id": binding.model_name,
+                "contextWindow": binding.context_length,
+            }],
+        });
+
+        // Shallow merge so a user override of e.g. `compat` doesn't clobber the
+        // generated `baseUrl`/`models`, and vice versa.
+        if let (Some(overrides), Some(target)) = (
+            self.config
+                .provider_overrides
+                .as_ref()
+                .and_then(serde_json::Value::as_object),
+            entry.as_object_mut(),
+        ) {
+            for (key, value) in overrides {
+                target.insert(key.clone(), value.clone());
+            }
+        }
+        Ok(entry)
+    }
+}
+
+/// Maps a granite-cli `ApiType` onto Pi's `api` discriminator.
+fn pi_api_name(api_type: &ApiType) -> anyhow::Result<&'static str> {
+    match api_type {
+        ApiType::OpenAI => Ok("openai-completions"),
+        ApiType::Anthropic => Ok("anthropic-messages"),
+        ApiType::Ollama => anyhow::bail!(
+            "Pi has no Ollama-native API client; bind an OpenAI-compatible endpoint instead"
+        ),
+    }
+}
+
+/// Pi's `baseUrl` is the API root it appends the operation path to (e.g.
+/// `/chat/completions`), so drop that trailing operation from the binding's
+/// full endpoint path and keep the version prefix.
+fn pi_base_url(binding: &AgentModelBinding) -> String {
+    let root = binding.base_url.trim_end_matches('/');
+    let prefix = match binding.api_type {
+        ApiType::OpenAI => binding.endpoint_path.strip_suffix("/chat/completions"),
+        ApiType::Anthropic => binding.endpoint_path.strip_suffix("/messages"),
+        ApiType::Ollama => None,
+    }
+    .unwrap_or("");
+    format!("{root}{prefix}")
+}
+
+/// The granite-cli-owned Pi config directory for this launcher instance.
+fn pi_state_dir(ctx: &LaunchContext) -> anyhow::Result<PathBuf> {
+    crate::config::Config::launcher_state_dir(&ctx.launcher_id)
+}
+
+/// The user's own Pi config directory, which we only ever read from:
+/// `$PI_CODING_AGENT_DIR` when set, else `~/.pi/agent`.
+fn pi_source_dir() -> anyhow::Result<PathBuf> {
+    if let Ok(val) = std::env::var(CONFIG_DIR_ENV)
+        && !val.is_empty()
+    {
+        return Ok(PathBuf::from(val));
+    }
+    let home = dirs::home_dir()
+        .ok_or_else(|| anyhow::anyhow!("Could not determine home directory for Pi's config"))?;
+    Ok(home.join(".pi").join("agent"))
+}
+
+/// Builds `state_dir` into a usable Pi config directory: a generated
+/// `models.json` carrying `provider_name`, plus pass-through links to the rest of
+/// the user's Pi resources. Nothing under `source_dir` is written.
+fn materialize_pi_config(
+    state_dir: &Path,
+    source_dir: &Path,
+    provider_name: &str,
+    entry: serde_json::Value,
+    ui: &dyn Ui,
+) -> anyhow::Result<()> {
+    std::fs::create_dir_all(state_dir)
+        .with_context(|| format!("Failed to create {}", state_dir.display()))?;
+
+    // A nested launch can land here with source == state (the parent already
+    // redirected PI_CODING_AGENT_DIR at us); linking a directory into itself is
+    // meaningless, and models.json is already ours.
+    let nested = same_dir(state_dir, source_dir);
+    if !nested {
+        link_pass_through_resources(state_dir, source_dir, ui);
+    }
+
+    let mut root = read_json_object(&source_dir.join(MODELS_JSON))?;
+    let malformed = |what: &str| {
+        anyhow::anyhow!(
+            "{} in {} is not a JSON object",
+            what,
+            source_dir.join(MODELS_JSON).display()
+        )
+    };
+    root.as_object_mut()
+        .ok_or_else(|| malformed("the top-level value"))?
+        .entry("providers")
+        .or_insert_with(|| serde_json::json!({}))
+        .as_object_mut()
+        .ok_or_else(|| malformed("`providers`"))?
+        .insert(provider_name.to_string(), entry);
+
+    write_owned_json(&state_dir.join(MODELS_JSON), &root)
+}
+
+/// Reads a JSON object from `path`, treating a missing or blank file as `{}`.
+/// A file that exists but does not parse is an error rather than something to
+/// silently discard -- it is the user's own config.
+fn read_json_object(path: &Path) -> anyhow::Result<serde_json::Value> {
+    match std::fs::read_to_string(path) {
+        Ok(content) if content.trim().is_empty() => Ok(serde_json::json!({})),
+        Ok(content) => serde_json::from_str(&content)
+            .with_context(|| format!("{} is not valid JSON", path.display())),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(serde_json::json!({})),
+        Err(e) => Err(e).with_context(|| format!("Failed to read {}", path.display())),
+    }
+}
+
+/// Writes a file granite-cli owns outright. Any symlink already at `path` is
+/// removed first -- writing through one would land in whatever it points at,
+/// which is exactly the user's file we are trying not to touch.
+fn write_owned_json(path: &Path, value: &serde_json::Value) -> anyhow::Result<()> {
+    if std::fs::symlink_metadata(path).is_ok_and(|md| md.file_type().is_symlink()) {
+        std::fs::remove_file(path)
+            .with_context(|| format!("Failed to replace symlink at {}", path.display()))?;
+    }
+    let mut content = serde_json::to_string_pretty(value)?;
+    content.push('\n');
+    std::fs::write(path, content).with_context(|| format!("Failed to write {}", path.display()))
+}
+
+/// Links every top-level entry of the user's Pi directory into `state_dir`, so
+/// their settings, credentials, packages, extensions, skills and themes still
+/// apply. `models.json` is skipped (granite-cli generates its own) and so is
+/// the session store (see [`SESSIONS_DIR`]).
+///
+/// Best-effort: a platform or permission that refuses symlinks costs the user
+/// those resources for granite-cli launches, not the launch itself.
+fn link_pass_through_resources(state_dir: &Path, source_dir: &Path, ui: &dyn Ui) {
+    let entries = match std::fs::read_dir(source_dir) {
+        Ok(entries) => entries,
+        // No Pi config of their own yet -- nothing to pass through.
+        Err(_) => return,
+    };
+
+    let mut failed = 0usize;
+    for entry in entries.flatten() {
+        let name = entry.file_name();
+        if name == MODELS_JSON || name == SESSIONS_DIR {
+            continue;
+        }
+        // The link target must be absolute: a relative one resolves against the
+        // *link's* directory, not ours, and would dangle.
+        let Ok(target) = entry.path().canonicalize() else {
+            failed += 1;
+            continue;
+        };
+        let link = state_dir.join(&name);
+        match std::fs::symlink_metadata(&link) {
+            // Refresh our own link in case the target moved.
+            Ok(md) if md.file_type().is_symlink() => {
+                if std::fs::remove_file(&link).is_err() {
+                    failed += 1;
+                    continue;
+                }
+            }
+            // Something real is sitting there; leave it be.
+            Ok(_) => continue,
+            Err(_) => {}
+        }
+        if symlink(&target, &link).is_err() {
+            failed += 1;
+        }
+    }
+
+    if failed > 0 {
+        ui.warn(&format!(
+            "Could not link {failed} Pi resource(s) from {} into {}; \
+             settings, logins and extensions from there will not apply to this launch.",
+            source_dir.display(),
+            state_dir.display()
+        ));
+    }
+}
+
+#[cfg(unix)]
+fn symlink(target: &Path, link: &Path) -> std::io::Result<()> {
+    std::os::unix::fs::symlink(target, link)
+}
+
+#[cfg(windows)]
+fn symlink(target: &Path, link: &Path) -> std::io::Result<()> {
+    if target.is_dir() {
+        std::os::windows::fs::symlink_dir(target, link)
+    } else {
+        std::os::windows::fs::symlink_file(target, link)
+    }
+}
+
+/// Whether two paths denote the same directory, comparing canonical forms when
+/// both exist and falling back to a literal comparison when they don't.
+fn same_dir(a: &Path, b: &Path) -> bool {
+    match (a.canonicalize(), b.canonicalize()) {
+        (Ok(a), Ok(b)) => a == b,
+        _ => a == b,
+    }
+}
+
+/*-- tests --*/
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::registry::{Named, Secret};
+    use crate::utils::ui::base::tests::CaptureUi;
+
+    fn launcher(cfg: serde_json::Value) -> PiLauncher {
+        PiLauncher::new("pi", &cfg, &crate::config::Config::default())
+    }
+
+    fn binding() -> AgentModelBinding {
+        AgentModelBinding {
+            api_type: ApiType::OpenAI,
+            provider_name: "my-ollama".to_string(),
+            base_url: "http://localhost:11434".to_string(),
+            model_name: "granite4.1:8b".to_string(),
+            endpoint_path: "/v1/chat/completions".to_string(),
+            api_key: None,
+            verify_ssl: true,
+            context_length: 131072,
+        }
+    }
+
+    fn bound(cfg: serde_json::Value, binding: AgentModelBinding) -> PiLauncher {
+        let mut l = launcher(cfg);
+        l.bound_binding = Some(binding);
+        l
+    }
+
+    fn ctx(dry_run: bool) -> LaunchContext {
+        LaunchContext {
+            launcher_id: "pi".to_string(),
+            working_dir: PathBuf::from("/tmp"),
+            base_env: std::collections::HashMap::new(),
+            dry_run,
+        }
+    }
+
+    // -- command resolution ----------------------------------------------------
+
+    #[test]
+    fn command_defaults_to_pi() {
+        assert_eq!(launcher(serde_json::json!({})).command(), "pi");
+    }
+
+    #[test]
+    fn command_uses_explicit_path_when_set() {
+        let l = launcher(serde_json::json!({ "command_path": "/opt/bin/pi" }));
+        assert_eq!(l.command(), "/opt/bin/pi");
+    }
+
+    #[test]
+    fn validate_command_err_for_nonexistent_explicit_path() {
+        let l = launcher(serde_json::json!({ "command_path": "/no/such/path/pi" }));
+        assert!(l.validate_command().is_err());
+    }
+
+    #[test]
+    fn validate_command_falls_back_to_path_for_bare_command_name() {
+        let l = launcher(serde_json::json!({ "command_path": "ls" }));
+        assert!(l.validate_command().is_ok());
+    }
+
+    // -- metadata / schema -----------------------------------------------------
+
+    #[test]
+    fn metadata_name_is_pi_cli() {
+        let meta = PiLauncher::metadata();
+        assert_eq!(meta.name, "Pi CLI");
+        assert_eq!(meta.default_command, "pi");
+        assert!(
+            meta.supported_capabilities
+                .contains(&BindingType::AgentModel)
+        );
+    }
+
+    #[test]
+    fn instance_id_round_trips_from_construction() {
+        let l = PiLauncher::new(
+            "pi-local",
+            &serde_json::json!({}),
+            &crate::config::Config::default(),
+        );
+        assert_eq!(l.instance_id(), "pi-local");
+    }
+
+    #[test]
+    fn config_schema_exposes_only_command_path_and_overrides() {
+        use crate::launchers::base::LauncherFactory;
+        let mut factory = LauncherFactory::new();
+        factory.register::<PiLauncher>("pi");
+        let schema = factory.config_schema("pi").unwrap();
+        let props = schema
+            .get("properties")
+            .and_then(|p| p.as_object())
+            .unwrap();
+        assert!(props.contains_key("command_path"));
+        assert!(props.contains_key("provider_overrides"));
+        // The Pi provider name comes from the binding, never from launcher config.
+        assert!(!props.contains_key("provider_name"));
+    }
+
+    // -- provider entry --------------------------------------------------------
+
+    #[test]
+    fn provider_entry_describes_bound_model() {
+        let entry = launcher(serde_json::json!({}))
+            .provider_entry(&binding())
+            .unwrap();
+        assert_eq!(entry["baseUrl"], "http://localhost:11434/v1");
+        assert_eq!(entry["api"], "openai-completions");
+        assert_eq!(entry["apiKey"], "$GRANITE_CLI_PI_API_KEY");
+        assert_eq!(entry["models"][0]["id"], "granite4.1:8b");
+        assert_eq!(entry["models"][0]["contextWindow"], 131072);
+    }
+
+    #[test]
+    fn provider_entry_merges_overrides() {
+        let l = launcher(serde_json::json!({
+            "provider_overrides": { "compat": { "supportsDeveloperRole": false } }
+        }));
+        let entry = l.provider_entry(&binding()).unwrap();
+        assert_eq!(entry["compat"]["supportsDeveloperRole"], false);
+        // Generated keys survive the merge.
+        assert_eq!(entry["baseUrl"], "http://localhost:11434/v1");
+    }
+
+    #[test]
+    fn provider_entry_overrides_win_on_conflict() {
+        let l = launcher(serde_json::json!({
+            "provider_overrides": { "baseUrl": "http://proxy:8080/v1" }
+        }));
+        let entry = l.provider_entry(&binding()).unwrap();
+        assert_eq!(entry["baseUrl"], "http://proxy:8080/v1");
+    }
+
+    // -- base url / api mapping ------------------------------------------------
+
+    #[test]
+    fn base_url_keeps_version_prefix_and_drops_operation() {
+        assert_eq!(pi_base_url(&binding()), "http://localhost:11434/v1");
+    }
+
+    #[test]
+    fn base_url_trims_trailing_slash_from_provider_url() {
+        let b = AgentModelBinding {
+            base_url: "http://localhost:1234/".to_string(),
+            ..binding()
+        };
+        assert_eq!(pi_base_url(&b), "http://localhost:1234/v1");
+    }
+
+    #[test]
+    fn base_url_for_anthropic_endpoint_drops_messages() {
+        let b = AgentModelBinding {
+            api_type: ApiType::Anthropic,
+            endpoint_path: "/v1/messages".to_string(),
+            ..binding()
+        };
+        assert_eq!(pi_base_url(&b), "http://localhost:11434/v1");
+    }
+
+    #[test]
+    fn api_name_maps_supported_dialects_and_rejects_ollama() {
+        assert_eq!(pi_api_name(&ApiType::OpenAI).unwrap(), "openai-completions");
+        assert_eq!(
+            pi_api_name(&ApiType::Anthropic).unwrap(),
+            "anthropic-messages"
+        );
+        assert!(pi_api_name(&ApiType::Ollama).is_err());
+    }
+
+    // -- env overlay -----------------------------------------------------------
+
+    #[tokio::test]
+    async fn env_overlay_is_empty_without_a_binding() {
+        let overlay = launcher(serde_json::json!({}))
+            .env_overlay(&ctx(false))
+            .await
+            .unwrap();
+        assert!(overlay.is_empty());
+    }
+
+    #[tokio::test]
+    async fn env_overlay_redirects_config_dir_and_exports_api_key() {
+        let b = AgentModelBinding {
+            api_key: Some(Secret::from("sk-test")),
+            ..binding()
+        };
+        let overlay = bound(serde_json::json!({}), b)
+            .env_overlay(&ctx(false))
+            .await
+            .unwrap();
+
+        let dir = overlay
+            .iter()
+            .find(|b| b.key == "PI_CODING_AGENT_DIR")
+            .expect("config dir redirect");
+        assert!(dir.value.ends_with("launcher-state/pi"), "{}", dir.value);
+
+        let key = overlay
+            .iter()
+            .find(|b| b.key == "GRANITE_CLI_PI_API_KEY")
+            .expect("api key");
+        assert_eq!(key.value, "sk-test");
+    }
+
+    #[tokio::test]
+    async fn env_overlay_uses_placeholder_when_provider_has_no_key() {
+        let overlay = bound(serde_json::json!({}), binding())
+            .env_overlay(&ctx(false))
+            .await
+            .unwrap();
+        let key = overlay
+            .iter()
+            .find(|b| b.key == "GRANITE_CLI_PI_API_KEY")
+            .unwrap();
+        assert_eq!(key.value, "granite-cli");
+    }
+
+    #[tokio::test]
+    async fn env_overlay_uses_placeholder_for_empty_key() {
+        let b = AgentModelBinding {
+            api_key: Some(Secret::from("")),
+            ..binding()
+        };
+        let overlay = bound(serde_json::json!({}), b)
+            .env_overlay(&ctx(false))
+            .await
+            .unwrap();
+        let key = overlay
+            .iter()
+            .find(|b| b.key == "GRANITE_CLI_PI_API_KEY")
+            .unwrap();
+        assert_eq!(key.value, "granite-cli");
+    }
+
+    // -- materialized config ---------------------------------------------------
+
+    /// A (state_dir, source_dir) pair inside one tempdir.
+    fn dirs(tmp: &tempfile::TempDir) -> (PathBuf, PathBuf) {
+        let source = tmp.path().join("user-pi");
+        std::fs::create_dir_all(&source).unwrap();
+        (tmp.path().join("state"), source)
+    }
+
+    fn read_models_json(dir: &Path) -> serde_json::Value {
+        serde_json::from_str(&std::fs::read_to_string(dir.join(MODELS_JSON)).unwrap()).unwrap()
+    }
+
+    #[test]
+    fn materialize_writes_provider_under_the_binding_name() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let (state, source) = dirs(&tmp);
+        materialize_pi_config(
+            &state,
+            &source,
+            "my-ollama",
+            serde_json::json!({ "api": "openai-completions" }),
+            &CaptureUi::default(),
+        )
+        .unwrap();
+
+        let written = read_models_json(&state);
+        assert_eq!(
+            written["providers"]["my-ollama"]["api"],
+            "openai-completions"
+        );
+    }
+
+    #[test]
+    fn materialize_never_writes_into_the_source_dir() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let (state, source) = dirs(&tmp);
+        let source_models = source.join(MODELS_JSON);
+        let original = r#"{"providers":{"my-vllm":{"api":"openai-completions"}}}"#;
+        std::fs::write(&source_models, original).unwrap();
+
+        materialize_pi_config(
+            &state,
+            &source,
+            "my-ollama",
+            serde_json::json!({ "api": "x" }),
+            &CaptureUi::default(),
+        )
+        .unwrap();
+
+        // The user's file is byte-identical.
+        assert_eq!(std::fs::read_to_string(&source_models).unwrap(), original);
+        // Ours carries both their provider and the generated one.
+        let written = read_models_json(&state);
+        assert_eq!(written["providers"]["my-vllm"]["api"], "openai-completions");
+        assert_eq!(written["providers"]["my-ollama"]["api"], "x");
+    }
+
+    #[test]
+    fn materialize_preserves_unrelated_top_level_keys_from_source() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let (state, source) = dirs(&tmp);
+        std::fs::write(source.join(MODELS_JSON), r#"{"somethingElse":42}"#).unwrap();
+
+        materialize_pi_config(
+            &state,
+            &source,
+            "my-ollama",
+            serde_json::json!({}),
+            &CaptureUi::default(),
+        )
+        .unwrap();
+        assert_eq!(read_models_json(&state)["somethingElse"], 42);
+    }
+
+    #[test]
+    fn materialize_works_with_no_user_pi_config_at_all() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let state = tmp.path().join("state");
+        let source = tmp.path().join("does-not-exist");
+
+        materialize_pi_config(
+            &state,
+            &source,
+            "my-ollama",
+            serde_json::json!({ "api": "x" }),
+            &CaptureUi::default(),
+        )
+        .unwrap();
+        assert_eq!(
+            read_models_json(&state)["providers"]["my-ollama"]["api"],
+            "x"
+        );
+    }
+
+    #[test]
+    fn materialize_is_idempotent_across_launches() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let (state, source) = dirs(&tmp);
+        std::fs::write(source.join("settings.json"), "{}").unwrap();
+
+        for api in ["old", "new"] {
+            materialize_pi_config(
+                &state,
+                &source,
+                "my-ollama",
+                serde_json::json!({ "api": api }),
+                &CaptureUi::default(),
+            )
+            .unwrap();
+        }
+        assert_eq!(
+            read_models_json(&state)["providers"]["my-ollama"]["api"],
+            "new"
+        );
+        assert!(state.join("settings.json").exists());
+    }
+
+    #[test]
+    fn materialize_refuses_malformed_source_json() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let (state, source) = dirs(&tmp);
+        std::fs::write(source.join(MODELS_JSON), "{ not json").unwrap();
+
+        let err = materialize_pi_config(
+            &state,
+            &source,
+            "my-ollama",
+            serde_json::json!({}),
+            &CaptureUi::default(),
+        )
+        .expect_err("must fail");
+        assert!(err.to_string().contains("not valid JSON"));
+        assert!(!state.join(MODELS_JSON).exists());
+    }
+
+    #[test]
+    fn materialize_refuses_non_object_providers_in_source() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let (state, source) = dirs(&tmp);
+        std::fs::write(source.join(MODELS_JSON), r#"{"providers":[]}"#).unwrap();
+
+        let err = materialize_pi_config(
+            &state,
+            &source,
+            "my-ollama",
+            serde_json::json!({}),
+            &CaptureUi::default(),
+        )
+        .expect_err("must fail");
+        assert!(err.to_string().contains("not a JSON object"));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn materialize_links_user_resources_but_not_models_or_sessions() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let (state, source) = dirs(&tmp);
+        std::fs::write(source.join("settings.json"), r#"{"theme":"dark"}"#).unwrap();
+        std::fs::write(source.join("auth.json"), "{}").unwrap();
+        std::fs::create_dir(source.join("packages")).unwrap();
+        std::fs::create_dir(source.join(SESSIONS_DIR)).unwrap();
+        std::fs::write(source.join(MODELS_JSON), "{}").unwrap();
+
+        materialize_pi_config(
+            &state,
+            &source,
+            "my-ollama",
+            serde_json::json!({}),
+            &CaptureUi::default(),
+        )
+        .unwrap();
+
+        for linked in ["settings.json", "auth.json", "packages"] {
+            let path = state.join(linked);
+            let md = std::fs::symlink_metadata(&path)
+                .unwrap_or_else(|_| panic!("{linked} should be linked"));
+            assert!(md.file_type().is_symlink(), "{linked} should be a symlink");
+            // A relative target would resolve against the link's own directory
+            // and dangle, so the link must point at an absolute path.
+            let target = std::fs::read_link(&path).unwrap();
+            assert!(
+                target.is_absolute(),
+                "{linked} -> {} must be absolute",
+                target.display()
+            );
+            assert!(path.exists(), "{linked} link must resolve");
+        }
+        // Reading through the link sees the user's content.
+        assert_eq!(
+            std::fs::read_to_string(state.join("settings.json")).unwrap(),
+            r#"{"theme":"dark"}"#
+        );
+        // Sessions stay local; models.json is ours, not a link.
+        assert!(!state.join(SESSIONS_DIR).exists());
+        assert!(
+            !std::fs::symlink_metadata(state.join(MODELS_JSON))
+                .unwrap()
+                .file_type()
+                .is_symlink()
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn write_owned_json_replaces_a_symlink_instead_of_writing_through_it() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let victim = tmp.path().join("users-real-file.json");
+        std::fs::write(&victim, "SACRED").unwrap();
+        let link = tmp.path().join(MODELS_JSON);
+        std::os::unix::fs::symlink(&victim, &link).unwrap();
+
+        write_owned_json(&link, &serde_json::json!({ "ours": true })).unwrap();
+
+        assert_eq!(std::fs::read_to_string(&victim).unwrap(), "SACRED");
+        assert_eq!(
+            serde_json::from_str::<serde_json::Value>(&std::fs::read_to_string(&link).unwrap())
+                .unwrap()["ours"],
+            true
+        );
+    }
+
+    #[test]
+    fn materialize_tolerates_source_equal_to_state() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let dir = tmp.path().join("both");
+        std::fs::create_dir_all(&dir).unwrap();
+        std::fs::write(dir.join(MODELS_JSON), r#"{"providers":{"keep":{}}}"#).unwrap();
+
+        materialize_pi_config(
+            &dir,
+            &dir,
+            "my-ollama",
+            serde_json::json!({ "api": "x" }),
+            &CaptureUi::default(),
+        )
+        .unwrap();
+
+        let written = read_models_json(&dir);
+        assert!(written["providers"]["keep"].is_object());
+        assert_eq!(written["providers"]["my-ollama"]["api"], "x");
+    }
+
+    // -- launch ----------------------------------------------------------------
+
+    // Deliberately reads whatever `GRANITE_CLI_HOME` is ambient rather than
+    // setting it: env mutation would race the other tests in this binary that
+    // point that var at their own tempdirs.
+    #[tokio::test]
+    async fn dry_run_launch_reports_without_writing_anything() {
+        let state_dir = crate::config::Config::launcher_state_dir("pi").unwrap();
+        let existed_before = state_dir.exists();
+
+        let l = bound(serde_json::json!({ "command_path": "ls" }), binding());
+        let ui = CaptureUi::default();
+        let status = l
+            .launch(&["--help".to_string()], &ctx(true), &ui)
+            .await
+            .unwrap();
+        assert!(status.success());
+
+        let infos = ui.infos.borrow();
+        assert!(
+            infos.iter().any(|m| m.contains("Would write Pi provider")),
+            "expected a dry-run notice, got {infos:?}"
+        );
+        assert!(
+            infos.iter().any(|m| m.contains("left unmodified")),
+            "expected the source file to be called out as untouched, got {infos:?}"
+        );
+        assert!(
+            infos
+                .iter()
+                .any(|m| m.contains("--provider my-ollama --model granite4.1:8b --help")),
+            "expected the selection flags ahead of caller args, got {infos:?}"
+        );
+        assert_eq!(
+            state_dir.exists(),
+            existed_before,
+            "dry run must not create {}",
+            state_dir.display()
+        );
+    }
+
+    #[tokio::test]
+    async fn launch_without_binding_passes_args_through_unchanged() {
+        let l = launcher(serde_json::json!({ "command_path": "ls" }));
+        let ui = CaptureUi::default();
+        l.launch(&["--version".to_string()], &ctx(true), &ui)
+            .await
+            .unwrap();
+
+        let infos = ui.infos.borrow();
+        assert!(infos.iter().any(|m| m.contains("args: --version")));
+        assert!(!infos.iter().any(|m| m.contains("--provider")));
+        // Without a binding there is no generated config, so Pi keeps using the
+        // user's own directory.
+        assert!(!infos.iter().any(|m| m.contains(CONFIG_DIR_ENV)));
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -310,6 +310,7 @@ fn construct_ui(output: &str) -> Box<dyn Ui> {
     UI_REGISTRY
         .construct(
             output,
+            output,
             &serde_json::json!({}),
             &crate::config::Config::default(),
         )
@@ -687,7 +688,7 @@ async fn run_launch(
     }
 
     let mut launcher = LAUNCHER_REGISTRY
-        .construct(&lc.launcher_type, &lc.config, &config)
+        .construct(&lc.launcher_type, &lc.launcher_id, &lc.config, &config)
         .map_err(|e| anyhow::anyhow!("Failed to construct launcher: {e}"))?;
 
     // Bind each enabled capability to the launcher before launching.
@@ -699,7 +700,12 @@ async fn run_launch(
             )
         })?;
         let capability = CAPABILITY_REGISTRY
-            .construct(&cap_cfg.capability_type, &cap_cfg.config, &config)
+            .construct(
+                &cap_cfg.capability_type,
+                &cap_cfg.capability_id,
+                &cap_cfg.config,
+                &config,
+            )
             .map_err(|e| anyhow::anyhow!("Failed to construct capability '{cap_id}': {e}"))?;
         launcher.bind_capability(capability.as_ref()).await?;
     }

--- a/src/models/base.rs
+++ b/src/models/base.rs
@@ -103,7 +103,7 @@ pub struct ModelArchitecture {
 
 /// Core trait for model implementations.
 /// All models must implement this trait along with ConfigConstructable.
-pub trait Model: Send + Sync {
+pub trait Model: crate::registry::Named + Send + Sync {
     /// Get the model family name
     fn family(&self) -> &str;
 
@@ -175,6 +175,7 @@ pub trait Model: Send + Sync {
         crate::providers::PROVIDER_REGISTRY
             .construct(
                 &pc.provider_type,
+                &pc.provider_id,
                 &pc.config,
                 &crate::config::Config::default(),
             )

--- a/src/models/mod.rs
+++ b/src/models/mod.rs
@@ -45,7 +45,12 @@ impl ModelSource {
                     }
                     None => serde_json::json!({}),
                 };
-                let result = MODEL_REGISTRY.construct(&model_config.model_id, &cfg, config);
+                let result = MODEL_REGISTRY.construct(
+                    &model_config.model_id,
+                    &model_config.model_id,
+                    &cfg,
+                    config,
+                );
                 if result.is_err() {
                     alog_channel!(
                         MessageLevel::Warning,

--- a/src/providers/base.rs
+++ b/src/providers/base.rs
@@ -121,7 +121,7 @@ impl std::fmt::Display for ApiEndpoint {
 /// Core trait for provider implementations.
 /// All providers must implement this trait along with ConfigConstructable.
 #[async_trait]
-pub trait Provider: Send + Sync {
+pub trait Provider: crate::registry::Named + Send + Sync {
     fn name(&self) -> &str;
 
     /// Returns the mapping of model functions to API endpoints this provider instance supports.

--- a/src/providers/llamacpp.rs
+++ b/src/providers/llamacpp.rs
@@ -101,6 +101,7 @@ impl Default for LlamaCppProviderConfig {
 /*-- llama.cpp Provider Implementation ---------------------------------------*/
 
 pub struct LlamaCppProvider {
+    instance_id: String,
     config: LlamaCppProviderConfig,
     client: reqwest::Client,
     /// Same TLS settings as `client` but with no request timeout, used for
@@ -283,7 +284,11 @@ impl LlamaCppProvider {
 impl ConfigConstructable for LlamaCppProvider {
     type Config = LlamaCppProviderConfig;
 
-    fn new(cfg: &serde_json::Value, _global_config: &crate::config::Config) -> Self {
+    fn new(
+        instance_id: &str,
+        cfg: &serde_json::Value,
+        _global_config: &crate::config::Config,
+    ) -> Self {
         let config: LlamaCppProviderConfig =
             serde_json::from_value(cfg.clone()).unwrap_or_default();
 
@@ -299,10 +304,17 @@ impl ConfigConstructable for LlamaCppProvider {
             .expect("Failed to create HTTP client");
 
         Self {
+            instance_id: instance_id.to_string(),
             config,
             client,
             stream_client,
         }
+    }
+}
+
+impl crate::registry::Named for LlamaCppProvider {
+    fn instance_id(&self) -> &str {
+        &self.instance_id
     }
 }
 
@@ -464,31 +476,41 @@ mod tests {
             "base_url": "http://example.com:9000",
             "timeout_secs": 30
         });
-        let provider = LlamaCppProvider::new(&cfg, &crate::config::Config::default());
+        let provider =
+            LlamaCppProvider::new("my-llamacpp", &cfg, &crate::config::Config::default());
         assert_eq!(provider.config.base_url, "http://example.com:9000");
         assert_eq!(provider.config.timeout_secs, 30);
     }
 
     #[test]
     fn test_can_run_model_accepts_gguf() {
-        let provider =
-            LlamaCppProvider::new(&serde_json::json!({}), &crate::config::Config::default());
+        let provider = LlamaCppProvider::new(
+            "my-llamacpp",
+            &serde_json::json!({}),
+            &crate::config::Config::default(),
+        );
         assert!(provider.can_run_model("gguf", "Q4_K_M"));
         assert!(provider.can_run_model("GGUF", "fp16"));
     }
 
     #[test]
     fn test_can_run_model_rejects_non_gguf() {
-        let provider =
-            LlamaCppProvider::new(&serde_json::json!({}), &crate::config::Config::default());
+        let provider = LlamaCppProvider::new(
+            "my-llamacpp",
+            &serde_json::json!({}),
+            &crate::config::Config::default(),
+        );
         assert!(!provider.can_run_model("safetensors", "fp16"));
         assert!(!provider.can_run_model("onnx", "fp32"));
     }
 
     #[test]
     fn test_model_alias_returns_hf_ref_for_gguf_variant() {
-        let provider =
-            LlamaCppProvider::new(&serde_json::json!({}), &crate::config::Config::default());
+        let provider = LlamaCppProvider::new(
+            "my-llamacpp",
+            &serde_json::json!({}),
+            &crate::config::Config::default(),
+        );
         let variant = ModelVariant {
             format: "GGUF".to_string(),
             precision: "Q4_K_M".to_string(),
@@ -503,8 +525,11 @@ mod tests {
 
     #[test]
     fn test_model_alias_returns_none_for_ollama_url() {
-        let provider =
-            LlamaCppProvider::new(&serde_json::json!({}), &crate::config::Config::default());
+        let provider = LlamaCppProvider::new(
+            "my-llamacpp",
+            &serde_json::json!({}),
+            &crate::config::Config::default(),
+        );
         let variant = ModelVariant {
             format: "Ollama".to_string(),
             precision: "Q4_K_M".to_string(),
@@ -516,8 +541,11 @@ mod tests {
 
     #[test]
     fn test_model_alias_returns_none_when_no_variant() {
-        let provider =
-            LlamaCppProvider::new(&serde_json::json!({}), &crate::config::Config::default());
+        let provider = LlamaCppProvider::new(
+            "my-llamacpp",
+            &serde_json::json!({}),
+            &crate::config::Config::default(),
+        );
         assert_eq!(provider.model_alias(None), None);
     }
 

--- a/src/providers/lmstudio.rs
+++ b/src/providers/lmstudio.rs
@@ -98,6 +98,7 @@ impl Default for LMStudioProviderConfig {
 /*-- LM Studio Provider Implementation ---------------------------------------*/
 
 pub struct LMStudioProvider {
+    instance_id: String,
     config: LMStudioProviderConfig,
     client: reqwest::Client,
 }
@@ -148,7 +149,11 @@ impl LMStudioProvider {
 impl ConfigConstructable for LMStudioProvider {
     type Config = LMStudioProviderConfig;
 
-    fn new(cfg: &serde_json::Value, _global_config: &crate::config::Config) -> Self {
+    fn new(
+        instance_id: &str,
+        cfg: &serde_json::Value,
+        _global_config: &crate::config::Config,
+    ) -> Self {
         let config: LMStudioProviderConfig =
             serde_json::from_value(cfg.clone()).unwrap_or_default();
 
@@ -158,7 +163,17 @@ impl ConfigConstructable for LMStudioProvider {
             .build()
             .expect("Failed to create HTTP client");
 
-        Self { config, client }
+        Self {
+            instance_id: instance_id.to_string(),
+            config,
+            client,
+        }
+    }
+}
+
+impl crate::registry::Named for LMStudioProvider {
+    fn instance_id(&self) -> &str {
+        &self.instance_id
     }
 }
 
@@ -371,31 +386,41 @@ mod tests {
             "base_url": "http://example.com:5678",
             "timeout_secs": 30
         });
-        let provider = LMStudioProvider::new(&cfg, &crate::config::Config::default());
+        let provider =
+            LMStudioProvider::new("my-lmstudio", &cfg, &crate::config::Config::default());
         assert_eq!(provider.config.base_url, "http://example.com:5678");
         assert_eq!(provider.config.timeout_secs, 30);
     }
 
     #[test]
     fn test_can_run_model_accepts_gguf() {
-        let provider =
-            LMStudioProvider::new(&serde_json::json!({}), &crate::config::Config::default());
+        let provider = LMStudioProvider::new(
+            "my-lmstudio",
+            &serde_json::json!({}),
+            &crate::config::Config::default(),
+        );
         assert!(provider.can_run_model("gguf", "Q4_K_M"));
         assert!(provider.can_run_model("GGUF", "fp16"));
     }
 
     #[test]
     fn test_can_run_model_rejects_non_supported() {
-        let provider =
-            LMStudioProvider::new(&serde_json::json!({}), &crate::config::Config::default());
+        let provider = LMStudioProvider::new(
+            "my-lmstudio",
+            &serde_json::json!({}),
+            &crate::config::Config::default(),
+        );
         assert!(!provider.can_run_model("safetensors", "fp16"));
         assert!(!provider.can_run_model("onnx", "fp32"));
     }
 
     #[test]
     fn test_mlx_formats_on_macos() {
-        let provider =
-            LMStudioProvider::new(&serde_json::json!({}), &crate::config::Config::default());
+        let provider = LMStudioProvider::new(
+            "my-lmstudio",
+            &serde_json::json!({}),
+            &crate::config::Config::default(),
+        );
         let formats = provider.supported_formats();
 
         #[cfg(target_os = "macos")]
@@ -407,8 +432,11 @@ mod tests {
 
     #[test]
     fn test_can_run_mlx_model() {
-        let provider =
-            LMStudioProvider::new(&serde_json::json!({}), &crate::config::Config::default());
+        let provider = LMStudioProvider::new(
+            "my-lmstudio",
+            &serde_json::json!({}),
+            &crate::config::Config::default(),
+        );
 
         #[cfg(target_os = "macos")]
         assert!(provider.can_run_model("mlx", "fp16"));

--- a/src/providers/mod.rs
+++ b/src/providers/mod.rs
@@ -37,6 +37,7 @@ impl ProviderSource {
             .filter_map(|provider_config| {
                 let result = PROVIDER_REGISTRY.construct(
                     &provider_config.provider_type,
+                    &provider_config.provider_id,
                     &provider_config.config,
                     config,
                 );

--- a/src/providers/ollama.rs
+++ b/src/providers/ollama.rs
@@ -67,6 +67,7 @@ impl Default for OllamaProviderConfig {
 /*-- Ollama Provider Implementation ------------------------------------------*/
 
 pub struct OllamaProvider {
+    instance_id: String,
     config: OllamaProviderConfig,
     client: reqwest::Client,
     /// Same TLS settings as `client` but with no request timeout, used for
@@ -173,7 +174,11 @@ impl OllamaProvider {
 impl ConfigConstructable for OllamaProvider {
     type Config = OllamaProviderConfig;
 
-    fn new(cfg: &serde_json::Value, _global_config: &crate::config::Config) -> Self {
+    fn new(
+        instance_id: &str,
+        cfg: &serde_json::Value,
+        _global_config: &crate::config::Config,
+    ) -> Self {
         let config: OllamaProviderConfig = serde_json::from_value(cfg.clone()).unwrap_or_default();
 
         let client = reqwest::Client::builder()
@@ -188,10 +193,17 @@ impl ConfigConstructable for OllamaProvider {
             .expect("Failed to create HTTP client");
 
         Self {
+            instance_id: instance_id.to_string(),
             config,
             client,
             stream_client,
         }
+    }
+}
+
+impl crate::registry::Named for OllamaProvider {
+    fn instance_id(&self) -> &str {
+        &self.instance_id
     }
 }
 
@@ -423,23 +435,29 @@ mod tests {
             "base_url": "http://example.com:8080",
             "timeout_secs": 30
         });
-        let provider = OllamaProvider::new(&cfg, &crate::config::Config::default());
+        let provider = OllamaProvider::new("my-ollama", &cfg, &crate::config::Config::default());
         assert_eq!(provider.config.base_url, "http://example.com:8080");
         assert_eq!(provider.config.timeout_secs, 30);
     }
 
     #[test]
     fn test_can_run_model_accepts_gguf() {
-        let provider =
-            OllamaProvider::new(&serde_json::json!({}), &crate::config::Config::default());
+        let provider = OllamaProvider::new(
+            "my-ollama",
+            &serde_json::json!({}),
+            &crate::config::Config::default(),
+        );
         assert!(provider.can_run_model("gguf", "Q4_K_M"));
         assert!(provider.can_run_model("GGUF", "fp16"));
     }
 
     #[test]
     fn test_can_run_model_rejects_non_gguf() {
-        let provider =
-            OllamaProvider::new(&serde_json::json!({}), &crate::config::Config::default());
+        let provider = OllamaProvider::new(
+            "my-ollama",
+            &serde_json::json!({}),
+            &crate::config::Config::default(),
+        );
         assert!(!provider.can_run_model("safetensors", "fp16"));
         assert!(!provider.can_run_model("onnx", "fp32"));
     }
@@ -583,8 +601,11 @@ mod tests {
 
     #[test]
     fn test_model_alias_returns_library_ref_for_ollama_variant() {
-        let provider =
-            OllamaProvider::new(&serde_json::json!({}), &crate::config::Config::default());
+        let provider = OllamaProvider::new(
+            "my-ollama",
+            &serde_json::json!({}),
+            &crate::config::Config::default(),
+        );
         let variant = ModelVariant {
             format: "Ollama".to_string(),
             precision: "Q4_K_M".to_string(),
@@ -599,8 +620,11 @@ mod tests {
 
     #[test]
     fn test_model_alias_returns_org_scoped_ref_for_org_url() {
-        let provider =
-            OllamaProvider::new(&serde_json::json!({}), &crate::config::Config::default());
+        let provider = OllamaProvider::new(
+            "my-ollama",
+            &serde_json::json!({}),
+            &crate::config::Config::default(),
+        );
         let variant = ModelVariant {
             format: "Ollama".to_string(),
             precision: "Q4_K_M".to_string(),
@@ -615,8 +639,11 @@ mod tests {
 
     #[test]
     fn test_model_alias_returns_none_for_non_ollama_variant() {
-        let provider =
-            OllamaProvider::new(&serde_json::json!({}), &crate::config::Config::default());
+        let provider = OllamaProvider::new(
+            "my-ollama",
+            &serde_json::json!({}),
+            &crate::config::Config::default(),
+        );
         let variant = ModelVariant {
             format: "GGUF".to_string(),
             precision: "Q4_K_M".to_string(),
@@ -628,8 +655,11 @@ mod tests {
 
     #[test]
     fn test_model_alias_returns_none_when_no_variant() {
-        let provider =
-            OllamaProvider::new(&serde_json::json!({}), &crate::config::Config::default());
+        let provider = OllamaProvider::new(
+            "my-ollama",
+            &serde_json::json!({}),
+            &crate::config::Config::default(),
+        );
         assert_eq!(provider.model_alias(None), None);
     }
 

--- a/src/providers/openai.rs
+++ b/src/providers/openai.rs
@@ -64,6 +64,7 @@ impl Default for OpenAIProviderConfig {
 /*-- OpenAI Provider Implementation ------------------------------------------*/
 
 pub struct OpenAIProvider {
+    instance_id: String,
     config: OpenAIProviderConfig,
     client: reqwest::Client,
     function_endpoints: HashMap<ModelFunction, Vec<ApiEndpoint>>,
@@ -91,7 +92,11 @@ impl OpenAIProvider {
 impl ConfigConstructable for OpenAIProvider {
     type Config = OpenAIProviderConfig;
 
-    fn new(cfg: &serde_json::Value, _global_config: &crate::config::Config) -> Self {
+    fn new(
+        instance_id: &str,
+        cfg: &serde_json::Value,
+        _global_config: &crate::config::Config,
+    ) -> Self {
         let config: OpenAIProviderConfig = serde_json::from_value(cfg.clone()).unwrap_or_default();
 
         let client = reqwest::Client::builder()
@@ -106,10 +111,17 @@ impl ConfigConstructable for OpenAIProvider {
             .unwrap_or_else(Self::default_function_endpoints);
 
         Self {
+            instance_id: instance_id.to_string(),
             config,
             client,
             function_endpoints,
         }
+    }
+}
+
+impl crate::registry::Named for OpenAIProvider {
+    fn instance_id(&self) -> &str {
+        &self.instance_id
     }
 }
 
@@ -306,7 +318,7 @@ mod tests {
             "api_key": "test-key",
             "timeout_secs": 30
         });
-        let provider = OpenAIProvider::new(&cfg, &crate::config::Config::default());
+        let provider = OpenAIProvider::new("my-openai", &cfg, &crate::config::Config::default());
         assert_eq!(provider.config.base_url, "http://example.com:8080");
         assert_eq!(
             provider.config.api_key,
@@ -318,7 +330,7 @@ mod tests {
     #[test]
     fn test_provider_function_endpoints() {
         let cfg = serde_json::json!({});
-        let provider = OpenAIProvider::new(&cfg, &crate::config::Config::default());
+        let provider = OpenAIProvider::new("my-openai", &cfg, &crate::config::Config::default());
         let endpoints = provider.function_endpoints();
         assert!(endpoints.contains_key(&ModelFunction::Chat));
         assert!(endpoints.contains_key(&ModelFunction::Embeddings));
@@ -331,7 +343,7 @@ mod tests {
         let cfg = serde_json::json!({
             "base_url": "http://example.com:8080"
         });
-        let provider = OpenAIProvider::new(&cfg, &crate::config::Config::default());
+        let provider = OpenAIProvider::new("my-openai", &cfg, &crate::config::Config::default());
         let endpoints = provider.function_endpoints();
         // Default config has all three functions
         assert!(endpoints.contains_key(&ModelFunction::Chat));

--- a/src/proxy/model_wrapper.rs
+++ b/src/proxy/model_wrapper.rs
@@ -70,6 +70,12 @@ impl UsageTrackingModel {
     }
 }
 
+impl crate::registry::Named for UsageTrackingModel {
+    fn instance_id(&self) -> &str {
+        self.inner.instance_id()
+    }
+}
+
 impl Model for UsageTrackingModel {
     fn family(&self) -> &str {
         self.inner.family()
@@ -124,6 +130,12 @@ impl Model for UsageTrackingModel {
 struct UsageTrackingProvider {
     inner: Box<dyn Provider>,
     local_base_url: String,
+}
+
+impl crate::registry::Named for UsageTrackingProvider {
+    fn instance_id(&self) -> &str {
+        self.inner.instance_id()
+    }
 }
 
 #[async_trait]
@@ -183,6 +195,12 @@ mod tests {
         api_key: Option<Secret>,
     }
 
+    impl crate::registry::Named for FakeProvider {
+        fn instance_id(&self) -> &str {
+            "so fake!"
+        }
+    }
+
     #[async_trait]
     impl Provider for FakeProvider {
         fn name(&self) -> &str {
@@ -213,6 +231,12 @@ mod tests {
 
     struct FakeModel {
         provider: FakeProvider,
+    }
+
+    impl crate::registry::Named for FakeModel {
+        fn instance_id(&self) -> &str {
+            "Mr. McFake"
+        }
     }
 
     impl Model for FakeModel {

--- a/src/registry/mod.rs
+++ b/src/registry/mod.rs
@@ -19,12 +19,36 @@ pub trait ConfigConstructable {
     /// Must implement `JsonSchema + Serialize + Default`.
     type Config: schemars::JsonSchema + serde::Serialize + Default;
 
-    /// Construct with a config instance and the global application config.
+    /// Construct with the instance's configured name, a config instance, and
+    /// the global application config.
+    ///
+    /// `instance_id` is the key this instance is configured under (e.g. the
+    /// provider nickname `my-ollama`), *not* the registry type name. Implementations
+    /// that need to identify themselves downstream store it and surface it via
+    /// [`Named`]. For instances constructed outside any configured set (bare
+    /// catalog lookups, `--output` backends), callers pass the type name.
+    ///
     /// Most implementations ignore `global_config`; types that need cross-registry
     /// resolution (e.g. resolving a model's provider) use it.
-    fn new(cfg: &serde_json::Value, global_config: &crate::config::Config) -> Self
+    fn new(
+        instance_id: &str,
+        cfg: &serde_json::Value,
+        global_config: &crate::config::Config,
+    ) -> Self
     where
         Self: Sized;
+}
+
+/// Lets a factory-constructed instance report the configured name it was built
+/// for. Object-safe on purpose: the domain traits (`Provider`, `Model`,
+/// `Capability`, `Launcher`) require it, so a `&dyn Provider` can answer "which
+/// configured provider are you?" without downcasting.
+///
+/// The value is whatever `instance_id` was passed to
+/// [`ConfigConstructable::new`], so it round-trips the config key that produced
+/// the instance.
+pub trait Named {
+    fn instance_id(&self) -> &str;
 }
 
 /// Macro to define a complete factory infrastructure for a trait hierarchy.
@@ -84,9 +108,9 @@ macro_rules! define_factory {
                 /// Get metadata describing this implementation
                 fn describe(&self) -> $metadata;
 
-                /// Construct an instance with the given config and global application config
+                /// Construct an instance with its configured name, config, and global application config
                 #[allow(unused)]
-                fn construct(&self, cfg: &serde_json::Value, global_config: &$crate::config::Config) -> Box<dyn $trait>;
+                fn construct(&self, instance_id: &str, cfg: &serde_json::Value, global_config: &$crate::config::Config) -> Box<dyn $trait>;
 
                 /// JSON schema of the config this implementation expects
                 #[allow(unused)]
@@ -119,8 +143,8 @@ macro_rules! define_factory {
                     T::metadata()
                 }
 
-                fn construct(&self, cfg: &serde_json::Value, global_config: &$crate::config::Config) -> Box<dyn $trait> {
-                    Box::new(T::new(cfg, global_config))
+                fn construct(&self, instance_id: &str, cfg: &serde_json::Value, global_config: &$crate::config::Config) -> Box<dyn $trait> {
+                    Box::new(T::new(instance_id, cfg, global_config))
                 }
 
                 fn config_schema(&self) -> schemars::Schema {
@@ -181,6 +205,9 @@ macro_rules! define_factory {
                 /// # Arguments
                 ///
                 /// * `name` - The name of the implementation to construct
+                /// * `instance_id` - The configured name of this instance (the config
+                ///   key it came from). Pass `name` for instances that aren't drawn
+                ///   from a configured set.
                 /// * `cfg` - Configuration to pass to the constructor
                 ///
                 /// # Returns
@@ -191,12 +218,13 @@ macro_rules! define_factory {
                 pub(crate) fn construct(
                     &self,
                     name: &str,
+                    instance_id: &str,
                     cfg: &serde_json::Value,
                     global_config: &$crate::config::Config,
                 ) -> Result<Box<dyn $trait>, String> {
                     self.registry
                         .get(name)
-                        .map(|x| x.construct(cfg, global_config))
+                        .map(|x| x.construct(instance_id, cfg, global_config))
                         .ok_or_else(|| format!("Unknown instance type: {}", name))
                 }
 
@@ -282,7 +310,7 @@ mod tests {
     extern crate paste;
 
     // Test trait and types
-    pub(crate) trait TestTrait {
+    pub(crate) trait TestTrait: Named {
         fn get_value(&self) -> i32;
     }
 
@@ -291,21 +319,35 @@ mod tests {
 
     // Test implementation 1
     struct TestImpl1 {
+        instance_id: String,
         value: i32,
     }
 
     impl ConfigConstructable for TestImpl1 {
         type Config = NoConfig;
 
-        fn new(cfg: &serde_json::Value, _global_config: &crate::config::Config) -> Self {
+        fn new(
+            instance_id: &str,
+            cfg: &serde_json::Value,
+            _global_config: &crate::config::Config,
+        ) -> Self {
             let value = cfg.get("value").and_then(|v| v.as_i64()).unwrap_or(0) as i32;
-            Self { value }
+            Self {
+                instance_id: instance_id.to_string(),
+                value,
+            }
         }
     }
 
     impl TestTrait for TestImpl1 {
         fn get_value(&self) -> i32 {
             self.value
+        }
+    }
+
+    impl Named for TestImpl1 {
+        fn instance_id(&self) -> &str {
+            &self.instance_id
         }
     }
 
@@ -317,21 +359,35 @@ mod tests {
 
     // Test implementation 2
     struct TestImpl2 {
+        instance_id: String,
         value: i32,
     }
 
     impl ConfigConstructable for TestImpl2 {
         type Config = TestImpl2Config;
 
-        fn new(cfg: &serde_json::Value, _global_config: &crate::config::Config) -> Self {
+        fn new(
+            instance_id: &str,
+            cfg: &serde_json::Value,
+            _global_config: &crate::config::Config,
+        ) -> Self {
             let value = cfg.get("value").and_then(|v| v.as_i64()).unwrap_or(0) as i32;
-            Self { value: value * 2 }
+            Self {
+                instance_id: instance_id.to_string(),
+                value: value * 2,
+            }
         }
     }
 
     impl TestTrait for TestImpl2 {
         fn get_value(&self) -> i32 {
             self.value
+        }
+    }
+
+    impl Named for TestImpl2 {
+        fn instance_id(&self) -> &str {
+            &self.instance_id
         }
     }
 
@@ -380,10 +436,14 @@ mod tests {
         let cfg = serde_json::json!({ "value": 42 });
         let global_config = crate::config::Config::default();
 
-        let inst1 = factory.construct("impl1", &cfg, &global_config).unwrap();
+        let inst1 = factory
+            .construct("impl1", "my-impl1", &cfg, &global_config)
+            .unwrap();
         assert_eq!(inst1.get_value(), 42);
 
-        let inst2 = factory.construct("impl2", &cfg, &global_config).unwrap();
+        let inst2 = factory
+            .construct("impl2", "my-impl2", &cfg, &global_config)
+            .unwrap();
         assert_eq!(inst2.get_value(), 84); // TestImpl2 doubles the value
     }
 
@@ -393,7 +453,7 @@ mod tests {
         let cfg = serde_json::json!({ "value": 42 });
         let global_config = crate::config::Config::default();
 
-        let result = factory.construct("unknown", &cfg, &global_config);
+        let result = factory.construct("unknown", "unknown", &cfg, &global_config);
         assert!(result.is_err());
         assert!(result.err().unwrap().contains("Unknown instance type"));
     }

--- a/src/utils/ui/backends/json.rs
+++ b/src/utils/ui/backends/json.rs
@@ -68,7 +68,11 @@ impl Write for SharedWriter {
 impl ConfigConstructable for JsonOutput {
     type Config = NoConfig;
 
-    fn new(_cfg: &serde_json::Value, _global_config: &crate::config::Config) -> Self {
+    fn new(
+        _instance_id: &str,
+        _cfg: &serde_json::Value,
+        _global_config: &crate::config::Config,
+    ) -> Self {
         Self {
             writer: Mutex::new(Box::new(std::io::stdout())),
             buf: None,

--- a/src/utils/ui/backends/markdown.rs
+++ b/src/utils/ui/backends/markdown.rs
@@ -10,7 +10,11 @@ pub struct MarkdownOutput;
 impl ConfigConstructable for MarkdownOutput {
     type Config = NoConfig;
 
-    fn new(_cfg: &serde_json::Value, _global_config: &crate::config::Config) -> Self {
+    fn new(
+        _instance_id: &str,
+        _cfg: &serde_json::Value,
+        _global_config: &crate::config::Config,
+    ) -> Self {
         Self
     }
 }
@@ -124,6 +128,7 @@ mod tests {
     use crate::utils::ui::base::tests::CaptureUi;
 
     crate::output_contract_tests!(MarkdownOutput::new(
+        "markdown",
         &serde_json::json!({}),
         &crate::config::Config::default()
     ));
@@ -144,7 +149,11 @@ mod tests {
     #[test]
     fn markdown_table_has_header_separator() {
         // Invoke the real MarkdownOutput (print-only) — just verifies no panic
-        let md = MarkdownOutput::new(&serde_json::json!({}), &crate::config::Config::default());
+        let md = MarkdownOutput::new(
+            "markdown",
+            &serde_json::json!({}),
+            &crate::config::Config::default(),
+        );
         md.table(
             "T",
             &["ID", "NAME"],
@@ -154,13 +163,21 @@ mod tests {
 
     #[test]
     fn markdown_detail_is_two_column_table() {
-        let md = MarkdownOutput::new(&serde_json::json!({}), &crate::config::Config::default());
+        let md = MarkdownOutput::new(
+            "markdown",
+            &serde_json::json!({}),
+            &crate::config::Config::default(),
+        );
         md.detail("My Item", &[("Family", "Granite 3.1".to_string())]);
     }
 
     #[test]
     fn markdown_status_ok_contains_checkmark() {
-        let md = MarkdownOutput::new(&serde_json::json!({}), &crate::config::Config::default());
+        let md = MarkdownOutput::new(
+            "markdown",
+            &serde_json::json!({}),
+            &crate::config::Config::default(),
+        );
         md.status("my-service", true, "");
         md.status("my-service", false, "timeout");
     }

--- a/src/utils/ui/backends/plain.rs
+++ b/src/utils/ui/backends/plain.rs
@@ -10,7 +10,11 @@ pub struct PlainOutput;
 impl ConfigConstructable for PlainOutput {
     type Config = NoConfig;
 
-    fn new(_cfg: &serde_json::Value, _global_config: &crate::config::Config) -> Self {
+    fn new(
+        _instance_id: &str,
+        _cfg: &serde_json::Value,
+        _global_config: &crate::config::Config,
+    ) -> Self {
         Self
     }
 }
@@ -135,6 +139,7 @@ mod tests {
     use super::*;
 
     crate::output_contract_tests!(PlainOutput::new(
+        "plain",
         &serde_json::json!({}),
         &crate::config::Config::default()
     ));

--- a/src/utils/ui/backends/terminal.rs
+++ b/src/utils/ui/backends/terminal.rs
@@ -29,7 +29,11 @@ pub struct TerminalOutput {
 impl ConfigConstructable for TerminalOutput {
     type Config = NoConfig;
 
-    fn new(_cfg: &serde_json::Value, _global_config: &crate::config::Config) -> Self {
+    fn new(
+        _instance_id: &str,
+        _cfg: &serde_json::Value,
+        _global_config: &crate::config::Config,
+    ) -> Self {
         let (is_tty, width) = match crossterm::terminal::size() {
             Ok((cols, _rows)) => (true, Some(cols.max(20))),
             Err(_) => (false, None),

--- a/src/utils/ui/base.rs
+++ b/src/utils/ui/base.rs
@@ -51,7 +51,7 @@ pub(crate) fn non_interactive<T>() -> anyhow::Result<T> {
 /// Invoke with the constructor expression as argument:
 ///
 /// ```ignore
-/// output_contract_tests!(PlainOutput::new(&serde_json::json!({})));
+/// output_contract_tests!(PlainOutput::new("plain", &serde_json::json!({})));
 /// ```
 #[macro_export]
 macro_rules! output_contract_tests {
@@ -309,7 +309,11 @@ pub(crate) mod tests {
     impl ConfigConstructable for CaptureUi {
         type Config = crate::registry::NoConfig;
 
-        fn new(_cfg: &serde_json::Value, _global_config: &crate::config::Config) -> Self {
+        fn new(
+            _instance_id: &str,
+            _cfg: &serde_json::Value,
+            _global_config: &crate::config::Config,
+        ) -> Self {
             Self::default()
         }
     }
@@ -481,6 +485,7 @@ pub(crate) mod tests {
     #[test]
     fn ui_registry_construct_unknown_returns_err() {
         let result = UI_REGISTRY.construct(
+            "nonexistent",
             "nonexistent",
             &serde_json::json!({}),
             &crate::config::Config::default(),


### PR DESCRIPTION
## Description

This PR adds a new `launcher` for `Pi`

## Changes

- Add `instance_id` as a new first arg to all factory construction so instances can track their own names
- Add `provider_name` to `AgentModelBinding`
- Add `Config.launcher_state_dir` for ephemeral launcher state
- Add new `launcher` for `pi` that wires up Pi's config

## Testing

- Unit tests
- Manual testing

## AI Usage

```sh
╔══════════════════════════════════════════════════════════╗
║           GIT AI USAGE ANALYSIS                          ║
╚══════════════════════════════════════════════════════════╝

📊 COMMITS BY AGENT

--- Aggregate ---
Commits                        |      Count
---------------------------------------------
Claude + Sonnet 5              |         10
none                           |          2
---------------------------------------------
TOTAL                          |         12

📊 COMMITS BY USAGE TYPE

--- Aggregate ---
Commits                        |      Count
---------------------------------------------
none                           |          2
draft                          |          0
full                           |         10
---------------------------------------------
TOTAL                          |         12

📈 LINES OF CODE BY AGENT

--- Aggregate ---
Agent                     |    Commits |  Additions |  Deletions
------------------------------------------------------------
Claude + Sonnet 5         |         10 |       3499 |        526
none                      |          2 |         24 |          0
------------------------------------------------------------
TOTAL                     |         12 |       3523 |        526

📈 LINES OF CODE BY USAGE TYPE

--- Aggregate ---
Usage Type           |    Commits |  Additions |  Deletions
-------------------------------------------------------
none                 |          2 |         24 |          0
draft                |          0 |          0 |          0
full                 |         10 |       3499 |        526
-------------------------------------------------------
TOTAL                |         12 |       3523 |        526
```