### PR TITLE
fix: No extra newline in terminal tables between rows

### DIFF
--- a/src/utils/ui/backends/terminal.rs
+++ b/src/utils/ui/backends/terminal.rs
@@ -623,9 +623,6 @@ fn render_rows_with_wrapping(rows: &[Vec<String>], widths: &[usize]) {
             let line = line_parts.join("  ");
             println!("{line}");
         }
-
-        // Blank line between rows for readability
-        println!();
     }
 }
 /*-- tests --*/


### PR DESCRIPTION
Branch: TerminalTableNewlines
AI-usage: draft (OpenCode + GraniteXXX)
Signed-off-by: Gabe Goodhart <ghart@us.ibm.com>

## Description

This PR fixes the extra newline that was being injected between rows in pretty-printed terminal tables

## Changes

- Remove the extra newline after every row

## Testing

manual testing

## AI Usage

Cause of newline found with AI, fix was manual