### PR TITLE
New launchers

### DIFF
--- a/scripts/launcher-testing/Dockerfile
+++ b/scripts/launcher-testing/Dockerfile
@@ -18,3 +18,13 @@ RUN curl -fsSL https://claude.ai/install.sh | bash && \
     chmod -R ugo+rx /root && \
     mv /root/.local/bin/claude /usr/local/bin/claude && \
     chmod ugo+rx /usr/local/bin/claude
+
+# Install bobshell
+RUN curl -fsSL https://bob.ibm.com/download/bobshell.sh | bash
+
+# Install opencode
+RUN curl -fsSL https://opencode.ai/install | bash -s -- --no-modify-path && \
+    mv /root/.opencode/bin/opencode /usr/local/bin/opencode
+
+# Install pi
+RUN npm install -g --ignore-scripts --min-release-age=0 @earendil-works/pi-coding-agent

--- a/scripts/launcher-testing/Dockerfile
+++ b/scripts/launcher-testing/Dockerfile
@@ -12,3 +12,9 @@ RUN curl -fsSL https://hermes-agent.nousresearch.com/install.sh | bash -s -- --n
 
 # Install goose
 RUN curl -fsSL https://github.com/aaif-goose/goose/releases/download/stable/download_cli.sh | CONFIGURE=false GOOSE_BIN_DIR=/usr/local/bin bash
+
+# Install claude
+RUN curl -fsSL https://claude.ai/install.sh | bash && \
+    chmod -R ugo+rx /root && \
+    mv /root/.local/bin/claude /usr/local/bin/claude && \
+    chmod ugo+rx /usr/local/bin/claude

--- a/scripts/launcher-testing/Dockerfile
+++ b/scripts/launcher-testing/Dockerfile
@@ -9,3 +9,6 @@ RUN export OPENCLAW_NO_ONBOARD=1 && \
 
 # Install hermes
 RUN curl -fsSL https://hermes-agent.nousresearch.com/install.sh | bash -s -- --non-interactive --skip-browser --skip-setup
+
+# Install goose
+RUN curl -fsSL https://github.com/aaif-goose/goose/releases/download/stable/download_cli.sh | CONFIGURE=false GOOSE_BIN_DIR=/usr/local/bin bash

--- a/scripts/launcher-testing/Dockerfile
+++ b/scripts/launcher-testing/Dockerfile
@@ -1,0 +1,11 @@
+FROM ubuntu
+
+RUN apt-get update -y && apt-get install -y curl wget vim rustup
+
+# Install openclaw
+RUN export OPENCLAW_NO_ONBOARD=1 && \
+    export OPENCLAW_NO_PROMPT=1 && \
+    curl -fsSL https://openclaw.ai/install.sh | bash
+
+# Install hermes
+RUN curl -fsSL https://hermes-agent.nousresearch.com/install.sh | bash -s -- --non-interactive --skip-browser --skip-setup

--- a/scripts/launcher-testing/build.sh
+++ b/scripts/launcher-testing/build.sh
@@ -1,0 +1,2 @@
+#!/usr/bin/env bash
+docker buildx build -t agent-test .

--- a/scripts/launcher-testing/build.sh
+++ b/scripts/launcher-testing/build.sh
@@ -1,2 +1,2 @@
 #!/usr/bin/env bash
-docker buildx build -t agent-test .
+docker buildx build -t agents-test .

--- a/scripts/launcher-testing/run.sh
+++ b/scripts/launcher-testing/run.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+# Run from the project root
+cd $(dirname ${BASH_SOURCE[0]})/../..
+
+docker run --rm -it \
+    --network=host \
+    -v $PWD:/src \
+    -u $(id -u):$(id -g) \
+    -w /src \
+    -e HOME=/src/tmp/mounted-home \
+    --name agents-test \
+    agents-test

--- a/src/capabilities/agent_model.rs
+++ b/src/capabilities/agent_model.rs
@@ -180,7 +180,6 @@ impl Capability for AgentModelCapability {
             api_key: provider.api_key().cloned(),
             verify_ssl: provider.verify_ssl(),
             context_length: Some(self.model.context_length()),
-            temperature: None,
         }))
     }
 }

--- a/src/capabilities/agent_model.rs
+++ b/src/capabilities/agent_model.rs
@@ -179,7 +179,8 @@ impl Capability for AgentModelCapability {
             endpoint_path: endpoint.path().to_string(),
             api_key: provider.api_key().cloned(),
             verify_ssl: provider.verify_ssl(),
-            context_length: self.model.context_length(),
+            context_length: Some(self.model.context_length()),
+            temperature: None,
         }))
     }
 }

--- a/src/capabilities/base.rs
+++ b/src/capabilities/base.rs
@@ -95,7 +95,8 @@ pub struct AgentModelBinding {
     pub endpoint_path: String,
     pub api_key: Option<Secret>,
     pub verify_ssl: bool,
-    pub context_length: u64,
+    pub context_length: Option<u64>,
+    pub temperature: Option<f64>,
 }
 
 /// Which wire transport an MCP server binding uses. Payload-free and

--- a/src/capabilities/base.rs
+++ b/src/capabilities/base.rs
@@ -96,7 +96,6 @@ pub struct AgentModelBinding {
     pub api_key: Option<Secret>,
     pub verify_ssl: bool,
     pub context_length: Option<u64>,
-    pub temperature: Option<f64>,
 }
 
 /// Which wire transport an MCP server binding uses. Payload-free and

--- a/src/capabilities/mod.rs
+++ b/src/capabilities/mod.rs
@@ -77,6 +77,7 @@ pub use base::{
     CapabilityMetadata, Dependency, EnvBinding, LaunchContext, McpBinding, McpBindingRequest,
     McpTransportKind,
 };
+pub use crate::providers::ApiType;
 
 mod requirement;
 pub use requirement::{ModelRequirement, ProviderRequirement, ShellCommandRequirement};

--- a/src/capabilities/mod.rs
+++ b/src/capabilities/mod.rs
@@ -72,12 +72,12 @@ impl crate::dependency::Configured<dyn Capability> for CapabilitySource {
 /*-- Module Declarations -----------------------------------------------------*/
 
 mod base;
+pub use crate::providers::ApiType;
 pub use base::{
     AgentModelBinding, AgentModelBindingRequest, Binding, BindingRequest, BindingType, Capability,
     CapabilityMetadata, Dependency, EnvBinding, LaunchContext, McpBinding, McpBindingRequest,
     McpTransportKind,
 };
-pub use crate::providers::ApiType;
 
 mod requirement;
 pub use requirement::{ModelRequirement, ProviderRequirement, ShellCommandRequirement};

--- a/src/launchers/claude.rs
+++ b/src/launchers/claude.rs
@@ -136,7 +136,9 @@ impl Launcher for ClaudeLauncher {
                 },
                 EnvBinding {
                     key: "CLAUDE_CODE_MAX_CONTEXT_TOKENS".to_string(),
-                    value: binding.context_length.map_or(String::new(), |v| v.to_string()),
+                    value: binding
+                        .context_length
+                        .map_or(String::new(), |v| v.to_string()),
                 },
                 EnvBinding {
                     key: "ANTHROPIC_AUTH_TOKEN".to_string(),

--- a/src/launchers/claude.rs
+++ b/src/launchers/claude.rs
@@ -136,7 +136,7 @@ impl Launcher for ClaudeLauncher {
                 },
                 EnvBinding {
                     key: "CLAUDE_CODE_MAX_CONTEXT_TOKENS".to_string(),
-                    value: binding.context_length.to_string(),
+                    value: binding.context_length.map_or(String::new(), |v| v.to_string()),
                 },
                 EnvBinding {
                     key: "ANTHROPIC_AUTH_TOKEN".to_string(),

--- a/src/launchers/goose.rs
+++ b/src/launchers/goose.rs
@@ -7,7 +7,9 @@
 //! session-scoped `--with-extension`/`--with-streamable-http-extension` CLI
 //! flags for MCP servers (goose calls them "extensions").
 
-use crate::capabilities::{AgentModelBinding, ApiType, Binding, BindingType, Capability, McpBinding};
+use crate::capabilities::{
+    AgentModelBinding, ApiType, Binding, BindingType, Capability, McpBinding,
+};
 use crate::launchers::base::{EnvBinding, LaunchContext, Launcher, LauncherMetadata, run_command};
 use crate::launchers::shared::mcp_cli::mcp_binding_request;
 use crate::registry::ConfigConstructable;
@@ -401,7 +403,10 @@ mod tests {
         let meta = GooseLauncher::metadata();
         assert_eq!(meta.name, "Goose CLI");
         assert_eq!(meta.default_command, "goose");
-        assert!(meta.supported_capabilities.contains(&BindingType::AgentModel));
+        assert!(
+            meta.supported_capabilities
+                .contains(&BindingType::AgentModel)
+        );
         assert!(meta.supported_capabilities.contains(&BindingType::Mcp));
     }
 
@@ -534,10 +539,7 @@ mod tests {
             .env_overlay(&ctx(false))
             .await
             .unwrap();
-        let key = overlay
-            .iter()
-            .find(|b| b.key == "OPENAI_API_KEY")
-            .unwrap();
+        let key = overlay.iter().find(|b| b.key == "OPENAI_API_KEY").unwrap();
         assert_eq!(key.value, "sk-test");
     }
 
@@ -657,17 +659,17 @@ mod tests {
             vec!["--with-extension".to_string(), "foo".to_string()],
             &CaptureUi::default(),
         );
-        assert_eq!(
-            out,
-            vec!["session", "--with-extension", "foo", "--resume"]
-        );
+        assert_eq!(out, vec!["session", "--with-extension", "foo", "--resume"]);
     }
 
     #[test]
     fn insert_extension_flags_inserts_after_explicit_run_subcommand() {
         let out = insert_extension_flags(
             &["run".to_string(), "-t".to_string(), "hi".to_string()],
-            vec!["--with-streamable-http-extension".to_string(), "url".to_string()],
+            vec![
+                "--with-streamable-http-extension".to_string(),
+                "url".to_string(),
+            ],
             &CaptureUi::default(),
         );
         assert_eq!(

--- a/src/launchers/goose.rs
+++ b/src/launchers/goose.rs
@@ -1,7 +1,18 @@
-use crate::capabilities::{AgentModelBinding, ApiType, Capability};
-use crate::launchers::base::{EnvBinding, LaunchContext, Launcher, LauncherMetadata};
+//! Launcher for the `goose` coding agent (<https://block.github.io/goose/>).
+//!
+//! Goose has no persistent-config mechanism for injecting a one-off model or
+//! MCP server without touching the user's own `config.yaml`, so both are done
+//! through the surfaces goose documents for exactly that: env vars for the
+//! model (`GOOSE_PROVIDER`/`GOOSE_MODEL`/`OPENAI_HOST`/...), and the
+//! session-scoped `--with-extension`/`--with-streamable-http-extension` CLI
+//! flags for MCP servers (goose calls them "extensions").
+
+use crate::capabilities::{AgentModelBinding, ApiType, Binding, BindingType, Capability, McpBinding};
+use crate::launchers::base::{EnvBinding, LaunchContext, Launcher, LauncherMetadata, run_command};
+use crate::launchers::shared::mcp_cli::mcp_binding_request;
 use crate::registry::ConfigConstructable;
 use crate::utils::resolve_shell_command;
+use crate::utils::ui::Ui;
 use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
 use std::collections::HashSet;
@@ -20,6 +31,10 @@ pub struct GooseLauncher {
     instance_id: String,
     config: GooseLauncherConfig,
     bound_binding: Option<AgentModelBinding>,
+    /// `(server_name, binding)` for every MCP-capable capability bound to
+    /// this launcher, turned into `--with-extension`/
+    /// `--with-streamable-http-extension` flags in `launch()`.
+    bound_mcp_bindings: Vec<(String, McpBinding)>,
 }
 
 impl ConfigConstructable for GooseLauncher {
@@ -35,6 +50,7 @@ impl ConfigConstructable for GooseLauncher {
             instance_id: instance_id.to_string(),
             config,
             bound_binding: None,
+            bound_mcp_bindings: vec![],
         }
     }
 }
@@ -55,10 +71,7 @@ impl Launcher for GooseLauncher {
         self.config.command_path.as_deref().unwrap_or("goose")
     }
 
-    async fn bind_capability(
-        &mut self,
-        capability: &dyn Capability,
-    ) -> anyhow::Result<()> {
+    async fn bind_capability(&mut self, capability: &dyn Capability) -> anyhow::Result<()> {
         let supported = Self::metadata().supported_capabilities;
         let capability_types = capability.binding_types();
         if !capability_types.is_subset(&supported) {
@@ -68,15 +81,38 @@ impl Launcher for GooseLauncher {
             );
         }
 
-        let binding = capability.bind(crate::capabilities::BindingRequest::AgentModel(
-            crate::capabilities::AgentModelBindingRequest {
-                api_type: ApiType::OpenAI,
-            },
-        )).await?;
+        if capability_types.contains(&BindingType::Mcp) {
+            let binding = capability.bind(mcp_binding_request()).await?;
+            match binding {
+                Binding::Mcp(binding) => {
+                    self.bound_mcp_bindings
+                        .push((capability.instance_id().to_string(), binding));
+                }
+                other => anyhow::bail!("expected an Mcp binding, got {:?}", other.binding_type()),
+            }
+            return Ok(());
+        }
+
+        // Goose only recognizes a fixed set of built-in provider ids (see
+        // `env_overlay`, which always sends `GOOSE_PROVIDER=openai`), and the
+        // "openai" provider is the one that honors `OPENAI_HOST` for
+        // OpenAI-compatible endpoints -- so that's what every granite-cli
+        // provider is asked to speak here.
+        let binding = capability
+            .bind(crate::capabilities::BindingRequest::AgentModel(
+                crate::capabilities::AgentModelBindingRequest {
+                    api_type: ApiType::OpenAI,
+                },
+            ))
+            .await?;
         match binding {
-            crate::capabilities::Binding::AgentModel(binding) => {
+            Binding::AgentModel(binding) => {
                 self.bound_binding = Some(binding);
             }
+            other => anyhow::bail!(
+                "expected an AgentModel binding, got {:?}",
+                other.binding_type()
+            ),
         }
         Ok(())
     }
@@ -85,14 +121,22 @@ impl Launcher for GooseLauncher {
         resolve_shell_command(&self.config.command_path, "goose")
     }
 
+    /// Env vars goose documents for overriding its OpenAI-compatible
+    /// provider without touching `config.yaml`.
+    ///
+    /// `GOOSE_PROVIDER` is always the literal `"openai"` -- goose has no
+    /// notion of an arbitrary custom provider id, only its fixed built-in
+    /// providers, and `"openai"` is the one that reads `OPENAI_HOST`.
+    /// `OPENAI_API_KEY` is required even for a local server that ignores it:
+    /// goose panics with "No provider configured" if it's unset entirely
+    /// (see block/goose#5138).
     async fn env_overlay(&self, _ctx: &LaunchContext) -> anyhow::Result<Vec<EnvBinding>> {
         let mut overlay = Vec::new();
 
         if let Some(binding) = &self.bound_binding {
-            // GOOSE_PROVIDER and GOOSE_MODEL override config.yaml
             overlay.push(EnvBinding {
                 key: "GOOSE_PROVIDER".to_string(),
-                value: binding.provider_name.clone(),
+                value: "openai".to_string(),
             });
             overlay.push(EnvBinding {
                 key: "GOOSE_MODEL".to_string(),
@@ -100,34 +144,88 @@ impl Launcher for GooseLauncher {
             });
 
             if !binding.base_url.is_empty() {
-                // For OpenAI-compatible providers, set OPENAI_HOST to override base URL
-                // Goose's env var precedence: env vars > config.yaml > defaults
+                // OPENAI_HOST is scheme+host only; goose appends its own
+                // default operation path unless OPENAI_BASE_PATH overrides it.
                 overlay.push(EnvBinding {
                     key: "OPENAI_HOST".to_string(),
                     value: binding.base_url.clone(),
                 });
             }
 
+            let path = binding.endpoint_path.trim_start_matches('/');
+            if !path.is_empty() && path != DEFAULT_OPENAI_BASE_PATH {
+                overlay.push(EnvBinding {
+                    key: "OPENAI_BASE_PATH".to_string(),
+                    value: path.to_string(),
+                });
+            }
+
             if let Some(context_length) = binding.context_length {
-                // Goose respects GOOSE_CONTEXT_LIMIT env var (see issue #7839)
                 overlay.push(EnvBinding {
                     key: "GOOSE_CONTEXT_LIMIT".to_string(),
                     value: context_length.to_string(),
                 });
             }
+
+            let api_key_val = binding
+                .api_key
+                .as_ref()
+                .map(|api_key| api_key.0.clone())
+                .filter(|key| !key.is_empty())
+                .unwrap_or_else(|| PLACEHOLDER_API_KEY.to_string());
+            overlay.push(EnvBinding {
+                key: "OPENAI_API_KEY".to_string(),
+                value: api_key_val,
+            });
         }
 
         Ok(overlay)
     }
 
+    /// Registers each bound MCP server as a session-scoped goose "extension"
+    /// via `--with-extension`/`--with-streamable-http-extension`, prepended
+    /// ahead of the caller's own args -- goose has no way to register an
+    /// extension without these flags on the invocation itself, so unlike
+    /// `claude`/`bob` there is nothing to register before spawning and clean
+    /// up after: the registration *is* the invocation.
     async fn launch(
         &self,
         args: &[String],
         ctx: &LaunchContext,
-        ui: &dyn crate::utils::ui::Ui,
+        ui: &dyn Ui,
     ) -> anyhow::Result<std::process::ExitStatus> {
         let binary = self.validate_command()?;
-        crate::launchers::base::run_command(binary, &self.env_overlay(ctx).await?, args, ctx, ui).await
+        let overlay = self.env_overlay(ctx).await?;
+
+        let mut goose_args: Vec<String> = vec![];
+        for (_, binding) in &self.bound_mcp_bindings {
+            match binding {
+                McpBinding::Stdio { command, args, env } => {
+                    // Goose's `--with-extension` takes a single shell-style
+                    // command string; env vars are inlined as `KEY=value`
+                    // prefixes ahead of the command per goose's own docs.
+                    let mut parts: Vec<String> =
+                        env.iter().map(|(k, v)| format!("{k}={v}")).collect();
+                    parts.push(command.clone());
+                    parts.extend(args.iter().cloned());
+                    goose_args.push("--with-extension".to_string());
+                    goose_args.push(parts.join(" "));
+                }
+                McpBinding::Http { url, headers } | McpBinding::Sse { url, headers } => {
+                    if !headers.is_empty() {
+                        ui.warn(
+                            "goose's --with-streamable-http-extension does not support \
+                             custom headers; they will be dropped for this launch",
+                        );
+                    }
+                    goose_args.push("--with-streamable-http-extension".to_string());
+                    goose_args.push(url.clone());
+                }
+            }
+        }
+        goose_args.extend_from_slice(args);
+
+        run_command(binary, &overlay, &goose_args, ctx, ui).await
     }
 }
 
@@ -137,7 +235,7 @@ impl HasGooseLauncherMetadata for GooseLauncher {
             name: "Goose CLI".to_string(),
             description: "Goose Agent CLI launcher".to_string(),
             default_command: "goose".to_string(),
-            supported_capabilities: HashSet::from([crate::capabilities::BindingType::AgentModel]),
+            supported_capabilities: HashSet::from([BindingType::AgentModel, BindingType::Mcp]),
             tags: vec!["goose".to_string(), "agent".to_string()],
         }
     }
@@ -147,8 +245,14 @@ impl HasGooseLauncherMetadata for GooseLauncher {
 
 use crate::launchers::base::HasLauncherMetadata as HasGooseLauncherMetadata;
 
-impl GooseLauncher {
-}
+/// Goose's default OpenAI operation path, appended automatically unless
+/// `OPENAI_BASE_PATH` overrides it.
+const DEFAULT_OPENAI_BASE_PATH: &str = "v1/chat/completions";
+
+/// Stand-in credential for providers that need no auth. Goose panics with
+/// "No provider configured" if `OPENAI_API_KEY` is unset entirely, even for a
+/// local server that never checks it.
+const PLACEHOLDER_API_KEY: &str = "granite-cli";
 
 /*-- tests --*/
 
@@ -162,12 +266,12 @@ mod tests {
         GooseLauncher::new("goose", &cfg, &crate::config::Config::default())
     }
 
-    fn binding() -> crate::capabilities::AgentModelBinding {
-        crate::capabilities::AgentModelBinding {
-            api_type: crate::capabilities::ApiType::OpenAI,
-            provider_name: "ollama".to_string(),
+    fn binding() -> AgentModelBinding {
+        AgentModelBinding {
+            api_type: ApiType::OpenAI,
+            provider_name: "my-ollama".to_string(),
             base_url: "http://localhost:11434".to_string(),
-            model_name: "mistral/mistral-large-v0.2".to_string(),
+            model_name: "granite4.1:8b".to_string(),
             endpoint_path: "/v1/chat/completions".to_string(),
             api_key: None,
             verify_ssl: true,
@@ -176,16 +280,22 @@ mod tests {
         }
     }
 
-    fn bound(cfg: serde_json::Value, binding: crate::capabilities::AgentModelBinding) -> GooseLauncher {
+    fn bound(cfg: serde_json::Value, binding: AgentModelBinding) -> GooseLauncher {
         let mut l = launcher(cfg);
         l.bound_binding = Some(binding);
         l
     }
 
-    fn ctx(dry_run: bool) -> crate::launchers::base::LaunchContext {
-        crate::launchers::base::LaunchContext {
+    fn with_mcp(cfg: serde_json::Value, name: &str, binding: McpBinding) -> GooseLauncher {
+        let mut l = launcher(cfg);
+        l.bound_mcp_bindings.push((name.to_string(), binding));
+        l
+    }
+
+    fn ctx(dry_run: bool) -> LaunchContext {
+        LaunchContext {
             launcher_id: "goose".to_string(),
-            working_dir: std::path::PathBuf::from("/tmp"),
+            working_dir: PathBuf::from("/tmp"),
             base_env: std::collections::HashMap::new(),
             dry_run,
         }
@@ -217,10 +327,8 @@ mod tests {
         let meta = GooseLauncher::metadata();
         assert_eq!(meta.name, "Goose CLI");
         assert_eq!(meta.default_command, "goose");
-        assert!(
-            meta.supported_capabilities
-                .contains(&crate::capabilities::BindingType::AgentModel)
-        );
+        assert!(meta.supported_capabilities.contains(&BindingType::AgentModel));
+        assert!(meta.supported_capabilities.contains(&BindingType::Mcp));
     }
 
     #[test]
@@ -258,7 +366,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn env_overlay_sets_goose_provider_and_model() {
+    async fn env_overlay_always_uses_openai_as_goose_provider() {
         let overlay = bound(serde_json::json!({}), binding())
             .env_overlay(&ctx(false))
             .await
@@ -267,12 +375,14 @@ mod tests {
             .iter()
             .find(|b| b.key == "GOOSE_PROVIDER")
             .expect("GOOSE_PROVIDER env");
-        assert_eq!(provider.value, "ollama");
+        // Not the granite-cli provider name ("my-ollama") -- goose only
+        // knows its own fixed built-in provider ids.
+        assert_eq!(provider.value, "openai");
         let model = overlay
             .iter()
             .find(|b| b.key == "GOOSE_MODEL")
             .expect("GOOSE_MODEL env");
-        assert_eq!(model.value, "mistral/mistral-large-v0.2");
+        assert_eq!(model.value, "granite4.1:8b");
     }
 
     #[tokio::test]
@@ -289,6 +399,32 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn env_overlay_omits_base_path_for_default_operation_path() {
+        let overlay = bound(serde_json::json!({}), binding())
+            .env_overlay(&ctx(false))
+            .await
+            .unwrap();
+        assert!(!overlay.iter().any(|b| b.key == "OPENAI_BASE_PATH"));
+    }
+
+    #[tokio::test]
+    async fn env_overlay_sets_base_path_for_nonstandard_operation_path() {
+        let b = AgentModelBinding {
+            endpoint_path: "/v1/responses".to_string(),
+            ..binding()
+        };
+        let overlay = bound(serde_json::json!({}), b)
+            .env_overlay(&ctx(false))
+            .await
+            .unwrap();
+        let path = overlay
+            .iter()
+            .find(|b| b.key == "OPENAI_BASE_PATH")
+            .expect("OPENAI_BASE_PATH env");
+        assert_eq!(path.value, "v1/responses");
+    }
+
+    #[tokio::test]
     async fn env_overlay_sets_goose_context_limit() {
         let overlay = bound(serde_json::json!({}), binding())
             .env_overlay(&ctx(false))
@@ -299,6 +435,112 @@ mod tests {
             .find(|b| b.key == "GOOSE_CONTEXT_LIMIT")
             .expect("GOOSE_CONTEXT_LIMIT env");
         assert_eq!(limit.value, "131072");
+    }
+
+    #[tokio::test]
+    async fn env_overlay_uses_placeholder_api_key_when_none_configured() {
+        let overlay = bound(serde_json::json!({}), binding())
+            .env_overlay(&ctx(false))
+            .await
+            .unwrap();
+        let key = overlay
+            .iter()
+            .find(|b| b.key == "OPENAI_API_KEY")
+            .expect("OPENAI_API_KEY env is required by goose even for local servers");
+        assert_eq!(key.value, "granite-cli");
+    }
+
+    #[tokio::test]
+    async fn env_overlay_uses_real_api_key_when_configured() {
+        let b = AgentModelBinding {
+            api_key: Some(crate::registry::Secret::from("sk-test")),
+            ..binding()
+        };
+        let overlay = bound(serde_json::json!({}), b)
+            .env_overlay(&ctx(false))
+            .await
+            .unwrap();
+        let key = overlay
+            .iter()
+            .find(|b| b.key == "OPENAI_API_KEY")
+            .unwrap();
+        assert_eq!(key.value, "sk-test");
+    }
+
+    // -- MCP bindings ------------------------------------------------------------
+
+    #[tokio::test]
+    async fn launch_prepends_with_extension_for_stdio_mcp_binding() {
+        let l = with_mcp(
+            serde_json::json!({ "command_path": "ls" }),
+            "vision",
+            McpBinding::Stdio {
+                command: "granite-cli".to_string(),
+                args: vec!["__mcp-serve".to_string(), "vision".to_string()],
+                env: std::collections::HashMap::from([("FOO".to_string(), "bar".to_string())]),
+            },
+        );
+        let ui = CaptureUi::default();
+        l.launch(&["--version".to_string()], &ctx(true), &ui)
+            .await
+            .unwrap();
+
+        let infos = ui.infos.borrow();
+        assert!(
+            infos.iter().any(|m| {
+                m.contains("--with-extension")
+                    && m.contains("FOO=bar granite-cli __mcp-serve vision")
+            }),
+            "expected the stdio extension flag, got {infos:?}"
+        );
+        // Caller args still land after the extension flags.
+        assert!(infos.iter().any(|m| m.trim_end().ends_with("--version")));
+    }
+
+    #[tokio::test]
+    async fn launch_uses_streamable_http_flag_for_http_mcp_binding() {
+        let l = with_mcp(
+            serde_json::json!({ "command_path": "ls" }),
+            "vision",
+            McpBinding::Http {
+                url: "http://127.0.0.1:54321/mcp".to_string(),
+                headers: Default::default(),
+            },
+        );
+        let ui = CaptureUi::default();
+        l.launch(&[], &ctx(true), &ui).await.unwrap();
+
+        let infos = ui.infos.borrow();
+        assert!(
+            infos.iter().any(|m| {
+                m.contains("--with-streamable-http-extension")
+                    && m.contains("http://127.0.0.1:54321/mcp")
+            }),
+            "expected the streamable-http extension flag, got {infos:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn launch_warns_and_drops_headers_for_http_mcp_binding() {
+        let l = with_mcp(
+            serde_json::json!({ "command_path": "ls" }),
+            "vision",
+            McpBinding::Http {
+                url: "http://127.0.0.1:54321/mcp".to_string(),
+                headers: std::collections::HashMap::from([(
+                    "Authorization".to_string(),
+                    "Bearer x".to_string(),
+                )]),
+            },
+        );
+        let ui = CaptureUi::default();
+        l.launch(&[], &ctx(true), &ui).await.unwrap();
+
+        let warns = ui.warns.borrow();
+        assert!(
+            warns.iter().any(|m| m.contains("headers")),
+            "expected a warning about dropped headers, got {warns:?}"
+        );
     }
 
     // -- launch ---------------------------------------------------------------

--- a/src/launchers/goose.rs
+++ b/src/launchers/goose.rs
@@ -351,7 +351,6 @@ mod tests {
             api_key: None,
             verify_ssl: true,
             context_length: Some(131072),
-            temperature: None,
         }
     }
 

--- a/src/launchers/goose.rs
+++ b/src/launchers/goose.rs
@@ -183,8 +183,9 @@ impl Launcher for GooseLauncher {
     }
 
     /// Registers each bound MCP server as a session-scoped goose "extension"
-    /// via `--with-extension`/`--with-streamable-http-extension`, prepended
-    /// ahead of the caller's own args -- goose has no way to register an
+    /// via `--with-extension`/`--with-streamable-http-extension`, inserted at
+    /// whichever position in the caller's own args actually parses (see
+    /// `insert_extension_flags`) -- goose has no way to register an
     /// extension without these flags on the invocation itself, so unlike
     /// `claude`/`bob` there is nothing to register before spawning and clean
     /// up after: the registration *is* the invocation.
@@ -197,7 +198,7 @@ impl Launcher for GooseLauncher {
         let binary = self.validate_command()?;
         let overlay = self.env_overlay(ctx).await?;
 
-        let mut goose_args: Vec<String> = vec![];
+        let mut extension_flags: Vec<String> = vec![];
         for (_, binding) in &self.bound_mcp_bindings {
             match binding {
                 McpBinding::Stdio { command, args, env } => {
@@ -208,8 +209,8 @@ impl Launcher for GooseLauncher {
                         env.iter().map(|(k, v)| format!("{k}={v}")).collect();
                     parts.push(command.clone());
                     parts.extend(args.iter().cloned());
-                    goose_args.push("--with-extension".to_string());
-                    goose_args.push(parts.join(" "));
+                    extension_flags.push("--with-extension".to_string());
+                    extension_flags.push(parts.join(" "));
                 }
                 McpBinding::Http { url, headers } | McpBinding::Sse { url, headers } => {
                     if !headers.is_empty() {
@@ -218,12 +219,12 @@ impl Launcher for GooseLauncher {
                              custom headers; they will be dropped for this launch",
                         );
                     }
-                    goose_args.push("--with-streamable-http-extension".to_string());
-                    goose_args.push(url.clone());
+                    extension_flags.push("--with-streamable-http-extension".to_string());
+                    extension_flags.push(url.clone());
                 }
             }
         }
-        goose_args.extend_from_slice(args);
+        let goose_args = insert_extension_flags(args, extension_flags, ui);
 
         run_command(binary, &overlay, &goose_args, ctx, ui).await
     }
@@ -253,6 +254,80 @@ const DEFAULT_OPENAI_BASE_PATH: &str = "v1/chat/completions";
 /// "No provider configured" if `OPENAI_API_KEY` is unset entirely, even for a
 /// local server that never checks it.
 const PLACEHOLDER_API_KEY: &str = "granite-cli";
+
+/// Subcommands whose clap parser actually accepts
+/// `--with-extension`/`--with-streamable-http-extension`, per `goose <sub>
+/// --help`. Their short aliases are included since either form is a valid
+/// first token.
+const EXTENSION_CAPABLE_SUBCOMMANDS: &[&str] = &["session", "s", "run"];
+
+/// Every other goose subcommand goose ships today (from `goose --help`,
+/// aliases included). None of these accept the extension flags, so if the
+/// caller explicitly named one of these, injecting the flags would just
+/// produce a parse error identical to bare `goose --with-extension ...`.
+const OTHER_KNOWN_SUBCOMMANDS: &[&str] = &[
+    "configure",
+    "info",
+    "doctor",
+    "mcp",
+    "acp",
+    "serve",
+    "recipe",
+    "skills",
+    "plugin",
+    "schedule",
+    "sched",
+    "gateway",
+    "gw",
+    "update",
+    "term",
+    "tui",
+    "local-models",
+    "lm",
+    "completion",
+    "review",
+    "help",
+];
+
+/// Splices MCP extension flags into `args` at a position goose's clap parser
+/// will actually accept.
+///
+/// `--with-extension`/`--with-streamable-http-extension` only parse under
+/// goose's `session` and `run` subcommands -- bare `goose` (which otherwise
+/// behaves like `session` for a plain interactive launch, per goose's own
+/// default) rejects *any* flag at all unless a subcommand is named first.
+/// So: if the caller already named `session`/`run`, the flags are inserted
+/// right after it; if the caller named some other subcommand that goose
+/// documents as not accepting these flags, the extensions are dropped with a
+/// warning rather than corrupting the invocation; otherwise (no subcommand,
+/// or the first token isn't a recognized one -- e.g. free-form prompt text)
+/// `session` is inserted explicitly so the flags have somewhere to attach.
+fn insert_extension_flags(args: &[String], flags: Vec<String>, ui: &dyn Ui) -> Vec<String> {
+    if flags.is_empty() {
+        return args.to_vec();
+    }
+    match args.first().map(String::as_str) {
+        Some(sub) if EXTENSION_CAPABLE_SUBCOMMANDS.contains(&sub) => {
+            let mut out = vec![args[0].clone()];
+            out.extend(flags);
+            out.extend_from_slice(&args[1..]);
+            out
+        }
+        Some(sub) if OTHER_KNOWN_SUBCOMMANDS.contains(&sub) => {
+            ui.warn(&format!(
+                "goose subcommand '{sub}' does not accept MCP extension flags; \
+                 bound MCP servers will not be attached for this launch"
+            ));
+            args.to_vec()
+        }
+        _ => {
+            let mut out = vec!["session".to_string()];
+            out.extend(flags);
+            out.extend_from_slice(args);
+            out
+        }
+    }
+}
 
 /*-- tests --*/
 
@@ -540,6 +615,81 @@ mod tests {
         assert!(
             warns.iter().any(|m| m.contains("headers")),
             "expected a warning about dropped headers, got {warns:?}"
+        );
+    }
+
+    // -- extension flag insertion -----------------------------------------------
+
+    #[test]
+    fn insert_extension_flags_returns_args_unchanged_when_no_flags() {
+        let args = vec!["session".to_string(), "--resume".to_string()];
+        let out = insert_extension_flags(&args, vec![], &CaptureUi::default());
+        assert_eq!(out, args);
+    }
+
+    #[test]
+    fn insert_extension_flags_inserts_session_when_args_are_empty() {
+        let out = insert_extension_flags(
+            &[],
+            vec!["--with-extension".to_string(), "foo".to_string()],
+            &CaptureUi::default(),
+        );
+        assert_eq!(out, vec!["session", "--with-extension", "foo"]);
+    }
+
+    #[test]
+    fn insert_extension_flags_inserts_session_ahead_of_non_subcommand_args() {
+        // Mirrors the bug this fixes: bare `goose --version` (no subcommand)
+        // used to get `--with-extension`/`--with-streamable-http-extension`
+        // spliced in ahead of it with no subcommand at all, which goose's
+        // clap parser rejects outright ("unexpected argument").
+        let out = insert_extension_flags(
+            &["--version".to_string()],
+            vec!["--with-extension".to_string(), "foo".to_string()],
+            &CaptureUi::default(),
+        );
+        assert_eq!(out, vec!["session", "--with-extension", "foo", "--version"]);
+    }
+
+    #[test]
+    fn insert_extension_flags_inserts_after_explicit_session_subcommand() {
+        let out = insert_extension_flags(
+            &["session".to_string(), "--resume".to_string()],
+            vec!["--with-extension".to_string(), "foo".to_string()],
+            &CaptureUi::default(),
+        );
+        assert_eq!(
+            out,
+            vec!["session", "--with-extension", "foo", "--resume"]
+        );
+    }
+
+    #[test]
+    fn insert_extension_flags_inserts_after_explicit_run_subcommand() {
+        let out = insert_extension_flags(
+            &["run".to_string(), "-t".to_string(), "hi".to_string()],
+            vec!["--with-streamable-http-extension".to_string(), "url".to_string()],
+            &CaptureUi::default(),
+        );
+        assert_eq!(
+            out,
+            vec!["run", "--with-streamable-http-extension", "url", "-t", "hi"]
+        );
+    }
+
+    #[test]
+    fn insert_extension_flags_warns_and_drops_for_non_extension_capable_subcommand() {
+        let ui = CaptureUi::default();
+        let out = insert_extension_flags(
+            &["configure".to_string()],
+            vec!["--with-extension".to_string(), "foo".to_string()],
+            &ui,
+        );
+        assert_eq!(out, vec!["configure"]);
+        let warns = ui.warns.borrow();
+        assert!(
+            warns.iter().any(|m| m.contains("configure")),
+            "expected a warning naming the incompatible subcommand, got {warns:?}"
         );
     }
 

--- a/src/launchers/goose.rs
+++ b/src/launchers/goose.rs
@@ -1,0 +1,319 @@
+use crate::capabilities::{AgentModelBinding, ApiType, Capability};
+use crate::launchers::base::{EnvBinding, LaunchContext, Launcher, LauncherMetadata};
+use crate::registry::ConfigConstructable;
+use crate::utils::resolve_shell_command;
+use async_trait::async_trait;
+use serde::{Deserialize, Serialize};
+use std::collections::HashSet;
+use std::path::PathBuf;
+
+/*-- public --*/
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default, schemars::JsonSchema)]
+pub struct GooseLauncherConfig {
+    /// Override path to the `goose` binary for non-PATH installs.
+    #[serde(default)]
+    pub command_path: Option<String>,
+}
+
+pub struct GooseLauncher {
+    instance_id: String,
+    config: GooseLauncherConfig,
+    bound_binding: Option<AgentModelBinding>,
+}
+
+impl ConfigConstructable for GooseLauncher {
+    type Config = GooseLauncherConfig;
+
+    fn new(
+        instance_id: &str,
+        cfg: &serde_json::Value,
+        _global_config: &crate::config::Config,
+    ) -> Self {
+        let config: GooseLauncherConfig = serde_json::from_value(cfg.clone()).unwrap_or_default();
+        Self {
+            instance_id: instance_id.to_string(),
+            config,
+            bound_binding: None,
+        }
+    }
+}
+
+impl crate::registry::Named for GooseLauncher {
+    fn instance_id(&self) -> &str {
+        &self.instance_id
+    }
+}
+
+#[async_trait]
+impl Launcher for GooseLauncher {
+    fn name(&self) -> &str {
+        "Goose CLI"
+    }
+
+    fn command(&self) -> &str {
+        self.config.command_path.as_deref().unwrap_or("goose")
+    }
+
+    async fn bind_capability(
+        &mut self,
+        capability: &dyn Capability,
+    ) -> anyhow::Result<()> {
+        let supported = Self::metadata().supported_capabilities;
+        let capability_types = capability.binding_types();
+        if !capability_types.is_subset(&supported) {
+            anyhow::bail!(
+                "capability supports {:?} which this launcher does not support",
+                capability_types.difference(&supported).collect::<Vec<_>>()
+            );
+        }
+
+        let binding = capability.bind(crate::capabilities::BindingRequest::AgentModel(
+            crate::capabilities::AgentModelBindingRequest {
+                api_type: ApiType::OpenAI,
+            },
+        )).await?;
+        match binding {
+            crate::capabilities::Binding::AgentModel(binding) => {
+                self.bound_binding = Some(binding);
+            }
+        }
+        Ok(())
+    }
+
+    fn validate_command(&self) -> anyhow::Result<PathBuf> {
+        resolve_shell_command(&self.config.command_path, "goose")
+    }
+
+    async fn env_overlay(&self, _ctx: &LaunchContext) -> anyhow::Result<Vec<EnvBinding>> {
+        let mut overlay = Vec::new();
+
+        if let Some(binding) = &self.bound_binding {
+            // GOOSE_PROVIDER and GOOSE_MODEL override config.yaml
+            overlay.push(EnvBinding {
+                key: "GOOSE_PROVIDER".to_string(),
+                value: binding.provider_name.clone(),
+            });
+            overlay.push(EnvBinding {
+                key: "GOOSE_MODEL".to_string(),
+                value: binding.model_name.clone(),
+            });
+
+            if !binding.base_url.is_empty() {
+                // For OpenAI-compatible providers, set OPENAI_HOST to override base URL
+                // Goose's env var precedence: env vars > config.yaml > defaults
+                overlay.push(EnvBinding {
+                    key: "OPENAI_HOST".to_string(),
+                    value: binding.base_url.clone(),
+                });
+            }
+
+            if let Some(context_length) = binding.context_length {
+                // Goose respects GOOSE_CONTEXT_LIMIT env var (see issue #7839)
+                overlay.push(EnvBinding {
+                    key: "GOOSE_CONTEXT_LIMIT".to_string(),
+                    value: context_length.to_string(),
+                });
+            }
+        }
+
+        Ok(overlay)
+    }
+
+    async fn launch(
+        &self,
+        args: &[String],
+        ctx: &LaunchContext,
+        ui: &dyn crate::utils::ui::Ui,
+    ) -> anyhow::Result<std::process::ExitStatus> {
+        let binary = self.validate_command()?;
+        crate::launchers::base::run_command(binary, &self.env_overlay(ctx).await?, args, ctx, ui).await
+    }
+}
+
+impl HasGooseLauncherMetadata for GooseLauncher {
+    fn metadata() -> LauncherMetadata {
+        LauncherMetadata {
+            name: "Goose CLI".to_string(),
+            description: "Goose Agent CLI launcher".to_string(),
+            default_command: "goose".to_string(),
+            supported_capabilities: HashSet::from([crate::capabilities::BindingType::AgentModel]),
+            tags: vec!["goose".to_string(), "agent".to_string()],
+        }
+    }
+}
+
+/*-- private --*/
+
+use crate::launchers::base::HasLauncherMetadata as HasGooseLauncherMetadata;
+
+impl GooseLauncher {
+}
+
+/*-- tests --*/
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::registry::Named;
+    use crate::utils::ui::base::tests::CaptureUi;
+
+    fn launcher(cfg: serde_json::Value) -> GooseLauncher {
+        GooseLauncher::new("goose", &cfg, &crate::config::Config::default())
+    }
+
+    fn binding() -> crate::capabilities::AgentModelBinding {
+        crate::capabilities::AgentModelBinding {
+            api_type: crate::capabilities::ApiType::OpenAI,
+            provider_name: "ollama".to_string(),
+            base_url: "http://localhost:11434".to_string(),
+            model_name: "mistral/mistral-large-v0.2".to_string(),
+            endpoint_path: "/v1/chat/completions".to_string(),
+            api_key: None,
+            verify_ssl: true,
+            context_length: Some(131072),
+            temperature: None,
+        }
+    }
+
+    fn bound(cfg: serde_json::Value, binding: crate::capabilities::AgentModelBinding) -> GooseLauncher {
+        let mut l = launcher(cfg);
+        l.bound_binding = Some(binding);
+        l
+    }
+
+    fn ctx(dry_run: bool) -> crate::launchers::base::LaunchContext {
+        crate::launchers::base::LaunchContext {
+            launcher_id: "goose".to_string(),
+            working_dir: std::path::PathBuf::from("/tmp"),
+            base_env: std::collections::HashMap::new(),
+            dry_run,
+        }
+    }
+
+    // -- command resolution ----------------------------------------------------
+
+    #[test]
+    fn command_defaults_to_goose() {
+        assert_eq!(launcher(serde_json::json!({})).command(), "goose");
+    }
+
+    #[test]
+    fn command_uses_explicit_path_when_set() {
+        let l = launcher(serde_json::json!({ "command_path": "/opt/bin/goose" }));
+        assert_eq!(l.command(), "/opt/bin/goose");
+    }
+
+    #[test]
+    fn validate_command_falls_back_to_path_for_bare_command_name() {
+        let l = launcher(serde_json::json!({ "command_path": "ls" }));
+        assert!(l.validate_command().is_ok());
+    }
+
+    // -- metadata / schema -----------------------------------------------------
+
+    #[test]
+    fn metadata_name_is_goose_cli() {
+        let meta = GooseLauncher::metadata();
+        assert_eq!(meta.name, "Goose CLI");
+        assert_eq!(meta.default_command, "goose");
+        assert!(
+            meta.supported_capabilities
+                .contains(&crate::capabilities::BindingType::AgentModel)
+        );
+    }
+
+    #[test]
+    fn instance_id_round_trips_from_construction() {
+        let l = GooseLauncher::new(
+            "goose-local",
+            &serde_json::json!({}),
+            &crate::config::Config::default(),
+        );
+        assert_eq!(l.instance_id(), "goose-local");
+    }
+
+    #[test]
+    fn config_schema_exposes_command_path() {
+        use crate::launchers::base::LauncherFactory;
+        let mut factory = LauncherFactory::new();
+        factory.register::<GooseLauncher>("goose");
+        let schema = factory.config_schema("goose").unwrap();
+        let props = schema
+            .get("properties")
+            .and_then(|p| p.as_object())
+            .unwrap();
+        assert!(props.contains_key("command_path"));
+    }
+
+    // -- env overlay -----------------------------------------------------------
+
+    #[tokio::test]
+    async fn env_overlay_is_empty_without_a_binding() {
+        let overlay = launcher(serde_json::json!({}))
+            .env_overlay(&ctx(false))
+            .await
+            .unwrap();
+        assert!(overlay.is_empty());
+    }
+
+    #[tokio::test]
+    async fn env_overlay_sets_goose_provider_and_model() {
+        let overlay = bound(serde_json::json!({}), binding())
+            .env_overlay(&ctx(false))
+            .await
+            .unwrap();
+        let provider = overlay
+            .iter()
+            .find(|b| b.key == "GOOSE_PROVIDER")
+            .expect("GOOSE_PROVIDER env");
+        assert_eq!(provider.value, "ollama");
+        let model = overlay
+            .iter()
+            .find(|b| b.key == "GOOSE_MODEL")
+            .expect("GOOSE_MODEL env");
+        assert_eq!(model.value, "mistral/mistral-large-v0.2");
+    }
+
+    #[tokio::test]
+    async fn env_overlay_sets_openai_host_for_base_url() {
+        let overlay = bound(serde_json::json!({}), binding())
+            .env_overlay(&ctx(false))
+            .await
+            .unwrap();
+        let host = overlay
+            .iter()
+            .find(|b| b.key == "OPENAI_HOST")
+            .expect("OPENAI_HOST env");
+        assert_eq!(host.value, "http://localhost:11434");
+    }
+
+    #[tokio::test]
+    async fn env_overlay_sets_goose_context_limit() {
+        let overlay = bound(serde_json::json!({}), binding())
+            .env_overlay(&ctx(false))
+            .await
+            .unwrap();
+        let limit = overlay
+            .iter()
+            .find(|b| b.key == "GOOSE_CONTEXT_LIMIT")
+            .expect("GOOSE_CONTEXT_LIMIT env");
+        assert_eq!(limit.value, "131072");
+    }
+
+    // -- launch ---------------------------------------------------------------
+
+    #[tokio::test]
+    async fn launch_without_binding_passes_args_through_unchanged() {
+        let l = launcher(serde_json::json!({ "command_path": "ls" }));
+        let ui = CaptureUi::default();
+        l.launch(&["--version".to_string()], &ctx(true), &ui)
+            .await
+            .unwrap();
+
+        let infos = ui.infos.borrow();
+        assert!(infos.iter().any(|m| m.contains("--version")));
+        // Without a binding there is no GOOSE_* env override.
+        assert!(!infos.iter().any(|m| m.contains("GOOSE_PROVIDER")));
+    }
+}

--- a/src/launchers/hermes.rs
+++ b/src/launchers/hermes.rs
@@ -468,7 +468,6 @@ mod tests {
             api_key: None,
             verify_ssl: true,
             context_length: Some(131072),
-            temperature: None,
         }
     }
 

--- a/src/launchers/hermes.rs
+++ b/src/launchers/hermes.rs
@@ -1,0 +1,456 @@
+use crate::capabilities::{AgentModelBinding, ApiType, Capability};
+use crate::launchers::base::{EnvBinding, LaunchContext, Launcher, LauncherMetadata};
+use crate::registry::ConfigConstructable;
+use crate::utils::resolve_shell_command;
+use anyhow::Context;
+use async_trait::async_trait;
+use serde::{Deserialize, Serialize};
+use std::collections::HashSet;
+use std::path::{Path, PathBuf};
+
+/*-- public --*/
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default, schemars::JsonSchema)]
+pub struct HermesLauncherConfig {
+    /// Override path to the `hermes` binary for non-PATH installs.
+    /// Leave unset to use PATH lookup.
+    #[serde(default)]
+    pub command_path: Option<String>,
+
+    /// Extra keys merged (shallow, last-write-wins) into the generated
+    /// hermes config file -- e.g. `model.context_length` or provider-specific
+    /// overrides. Necessary because the entry is regenerated on every launch.
+    #[serde(default)]
+    pub model_overrides: Option<serde_json::Value>,
+}
+
+pub struct HermesLauncher {
+    instance_id: String,
+    config: HermesLauncherConfig,
+    bound_binding: Option<AgentModelBinding>,
+}
+
+impl ConfigConstructable for HermesLauncher {
+    type Config = HermesLauncherConfig;
+
+    fn new(
+        instance_id: &str,
+        cfg: &serde_json::Value,
+        _global_config: &crate::config::Config,
+    ) -> Self {
+        let config: HermesLauncherConfig = serde_json::from_value(cfg.clone()).unwrap_or_default();
+        Self {
+            instance_id: instance_id.to_string(),
+            config,
+            bound_binding: None,
+        }
+    }
+}
+
+impl crate::registry::Named for HermesLauncher {
+    fn instance_id(&self) -> &str {
+        &self.instance_id
+    }
+}
+
+#[async_trait]
+impl Launcher for HermesLauncher {
+    fn name(&self) -> &str {
+        "Hermes CLI"
+    }
+
+    fn command(&self) -> &str {
+        self.config.command_path.as_deref().unwrap_or("hermes")
+    }
+
+    async fn bind_capability(&mut self, capability: &dyn Capability) -> anyhow::Result<()> {
+        let supported = Self::metadata().supported_capabilities;
+        let capability_types = capability.binding_types();
+        if !capability_types.is_subset(&supported) {
+            anyhow::bail!(
+                "capability supports {:?} which this launcher does not support",
+                capability_types.difference(&supported).collect::<Vec<_>>()
+            );
+        }
+
+        let binding = capability.bind(crate::capabilities::BindingRequest::AgentModel(
+            crate::capabilities::AgentModelBindingRequest {
+                api_type: ApiType::OpenAI,
+            },
+        )).await?;
+        match binding {
+            crate::capabilities::Binding::AgentModel(binding) => {
+                self.bound_binding = Some(binding);
+            }
+        }
+        Ok(())
+    }
+
+    fn validate_command(&self) -> anyhow::Result<PathBuf> {
+        resolve_shell_command(&self.config.command_path, "hermes")
+    }
+
+    async fn env_overlay(&self, ctx: &LaunchContext) -> anyhow::Result<Vec<EnvBinding>> {
+        let Some(_binding) = &self.bound_binding else {
+            return Ok(vec![]);
+        };
+        let overlay = vec![EnvBinding {
+            key: "HERMES_HOME".to_string(),
+            value: hermes_config_path(ctx)?.to_string_lossy().to_string(),
+        }];
+        Ok(overlay)
+    }
+
+    async fn launch(
+        &self,
+        args: &[String],
+        ctx: &LaunchContext,
+        ui: &dyn crate::utils::ui::Ui,
+    ) -> anyhow::Result<std::process::ExitStatus> {
+        let binary = self.validate_command()?;
+
+        if let Some(binding) = &self.bound_binding {
+            let config = self.generate_config(binding)?;
+            let config_path = hermes_config_path(ctx)?;
+
+            if ctx.dry_run {
+                ui.info(&format!(
+                    "Would write Hermes config to {}:",
+                    config_path.display()
+                ));
+                ui.info(&serde_json::to_string_pretty(&config)?);
+            } else {
+                write_hermes_config(&config_path, &config)?;
+                ui.info(&format!(
+                    "Wrote Hermes config to {}",
+                    config_path.display()
+                ));
+            }
+        }
+
+        crate::launchers::base::run_command(binary, &self.env_overlay(ctx).await?, args, ctx, ui).await
+    }
+}
+
+impl HasHermesLauncherMetadata for HermesLauncher {
+    fn metadata() -> LauncherMetadata {
+        LauncherMetadata {
+            name: "Hermes CLI".to_string(),
+            description: "Hermes Agent local CLI launcher".to_string(),
+            default_command: "hermes".to_string(),
+            supported_capabilities: HashSet::from([crate::capabilities::BindingType::AgentModel]),
+            tags: vec!["hermes".to_string(), "agent".to_string()],
+        }
+    }
+}
+
+/*-- private --*/
+
+use crate::launchers::base::HasLauncherMetadata as HasHermesLauncherMetadata;
+
+/// Env var Hermes reads to locate its config directory.
+const HERMES_HOME_ENV: &str = "HERMES_HOME";
+
+/// The generated Hermes config file's name, relative to the launcher state dir.
+const HERMES_CONFIG_FILE: &str = "config.yaml";
+
+impl HermesLauncher {
+    /// Builds the Hermes config describing the bound model.
+    fn generate_config(&self, binding: &AgentModelBinding) -> anyhow::Result<serde_json::Value> {
+        let mut config = serde_json::json!({
+            "model": {
+                "provider": binding.provider_name,
+                "model": binding.model_name,
+            }
+        });
+
+        if !binding.base_url.is_empty() {
+            config["model"]["base_url"] = serde_json::Value::String(binding.base_url.clone());
+        }
+        if let Some(context_length) = binding.context_length {
+            config["model"]["context_length"] = serde_json::json!(context_length);
+        }
+
+        // Merge user-provided overrides on top so they win on conflict.
+        // Special case: if the override key is "model", merge the inner object
+        // into config["model"] rather than replacing it entirely.
+        if let Some(overrides) = self.config
+            .model_overrides
+            .as_ref()
+            .and_then(serde_json::Value::as_object)
+        {
+            for (key, value) in overrides {
+                if key == "model" {
+                    if let Some(inner) = value.as_object() {
+                        if let Some(target) = config.get_mut("model").and_then(serde_json::Value::as_object_mut) {
+                            for (k, v) in inner {
+                                target.insert(k.clone(), v.clone());
+                            }
+                        }
+                    }
+                } else {
+                    if let Some(target) = config.as_object_mut() {
+                        target.insert(key.clone(), value.clone());
+                    }
+                }
+            }
+        }
+        Ok(config)
+    }
+}
+
+/// The Hermes config file this launcher instance writes and points `HERMES_HOME` at.
+/// Lives under the launcher state dir rather than the user's own Hermes config
+/// directory — it is never read by anything else.
+fn hermes_config_path(ctx: &LaunchContext) -> anyhow::Result<PathBuf> {
+    Ok(crate::config::Config::launcher_state_dir(&ctx.launcher_id)?
+        .join(HERMES_CONFIG_FILE))
+}
+
+/// Wraps the bound model info in the top-level hermes config shape.
+fn write_hermes_config(path: &Path, config: &serde_json::Value) -> anyhow::Result<()> {
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)
+            .with_context(|| format!("Failed to create {}", parent.display()))?;
+    }
+    let mut content = serde_json::to_string_pretty(config)?;
+    content.push('\n');
+    std::fs::write(path, content)
+        .with_context(|| format!("Failed to write {}", path.display()))?;
+    Ok(())
+}
+
+/*-- tests --*/
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::capabilities::BindingType;
+    use crate::registry::Named;
+    use crate::utils::ui::base::tests::CaptureUi;
+
+    fn launcher(cfg: serde_json::Value) -> HermesLauncher {
+        HermesLauncher::new("hermes", &cfg, &crate::config::Config::default())
+    }
+
+    fn binding() -> AgentModelBinding {
+        AgentModelBinding {
+            api_type: ApiType::OpenAI,
+            provider_name: "my-ollama".to_string(),
+            base_url: "http://localhost:11434".to_string(),
+            model_name: "granite4.1:8b".to_string(),
+            endpoint_path: "/v1/chat/completions".to_string(),
+            api_key: None,
+            verify_ssl: true,
+            context_length: Some(131072),
+            temperature: None,
+        }
+    }
+
+    fn bound(cfg: serde_json::Value, binding: AgentModelBinding) -> HermesLauncher {
+        let mut l = launcher(cfg);
+        l.bound_binding = Some(binding);
+        l
+    }
+
+    fn ctx(dry_run: bool) -> LaunchContext {
+        LaunchContext {
+            launcher_id: "hermes".to_string(),
+            working_dir: PathBuf::from("/tmp"),
+            base_env: std::collections::HashMap::new(),
+            dry_run,
+        }
+    }
+
+    // -- command resolution ----------------------------------------------------
+
+    #[test]
+    fn command_defaults_to_hermes() {
+        assert_eq!(launcher(serde_json::json!({})).command(), "hermes");
+    }
+
+    #[test]
+    fn command_uses_explicit_path_when_set() {
+        let l = launcher(serde_json::json!({ "command_path": "/opt/bin/hermes" }));
+        assert_eq!(l.command(), "/opt/bin/hermes");
+    }
+
+    #[test]
+    fn validate_command_err_for_nonexistent_explicit_path() {
+        let l = launcher(serde_json::json!({ "command_path": "/no/such/path/hermes" }));
+        assert!(l.validate_command().is_err());
+    }
+
+    #[test]
+    fn validate_command_falls_back_to_path_for_bare_command_name() {
+        let l = launcher(serde_json::json!({ "command_path": "ls" }));
+        assert!(l.validate_command().is_ok());
+    }
+
+    // -- metadata / schema -----------------------------------------------------
+
+    #[test]
+    fn metadata_name_is_hermes_cli() {
+        let meta = HermesLauncher::metadata();
+        assert_eq!(meta.name, "Hermes CLI");
+        assert_eq!(meta.default_command, "hermes");
+        assert!(
+            meta.supported_capabilities
+                .contains(&BindingType::AgentModel)
+        );
+    }
+
+    #[test]
+    fn instance_id_round_trips_from_construction() {
+        let l = HermesLauncher::new(
+            "hermes-local",
+            &serde_json::json!({}),
+            &crate::config::Config::default(),
+        );
+        assert_eq!(l.instance_id(), "hermes-local");
+    }
+
+    #[test]
+    fn config_schema_exposes_command_path_and_model_overrides() {
+        use crate::launchers::base::LauncherFactory;
+        let mut factory = LauncherFactory::new();
+        factory.register::<HermesLauncher>("hermes");
+        let schema = factory.config_schema("hermes").unwrap();
+        let props = schema
+            .get("properties")
+            .and_then(|p| p.as_object())
+            .unwrap();
+        assert!(props.contains_key("command_path"));
+        assert!(props.contains_key("model_overrides"));
+    }
+
+    // -- generate_config ------------------------------------------------------
+
+    #[test]
+    fn generate_config_sets_provider_and_model() {
+        let l = launcher(serde_json::json!({}));
+        let config = l.generate_config(&binding()).unwrap();
+        assert_eq!(config["model"]["provider"], "my-ollama");
+        assert_eq!(config["model"]["model"], "granite4.1:8b");
+        assert_eq!(config["model"]["base_url"], "http://localhost:11434");
+        assert_eq!(config["model"]["context_length"], serde_json::json!(131072));
+    }
+
+    #[test]
+    fn generate_config_omits_context_length_when_none() {
+        let b = AgentModelBinding {
+            context_length: None,
+            ..binding()
+        };
+        let l = launcher(serde_json::json!({}));
+        let config = l.generate_config(&b).unwrap();
+        assert!(!config["model"].get("context_length").is_some());
+    }
+
+    #[test]
+    fn generate_config_merges_overrides() {
+        let l = launcher(serde_json::json!({
+            "model_overrides": {
+                "model": {
+                    "context_length": 4000
+                }
+            }
+        }));
+        let config = l.generate_config(&binding()).unwrap();
+        // Override wins
+        assert_eq!(config["model"]["context_length"], serde_json::json!(4000));
+        // Generated keys survive the merge
+        assert_eq!(config["model"]["provider"], "my-ollama");
+        assert_eq!(config["model"]["model"], "granite4.1:8b");
+    }
+
+    // -- env overlay -----------------------------------------------------------
+
+    #[tokio::test]
+    async fn env_overlay_is_empty_without_a_binding() {
+        let overlay = launcher(serde_json::json!({}))
+            .env_overlay(&ctx(false))
+            .await
+            .unwrap();
+        assert!(overlay.is_empty());
+    }
+
+    #[tokio::test]
+    async fn env_overlay_sets_hermes_home_when_bound() {
+        let overlay = bound(serde_json::json!({}), binding())
+            .env_overlay(&ctx(false))
+            .await
+            .unwrap();
+        let home = overlay
+            .iter()
+            .find(|b| b.key == "HERMES_HOME")
+            .expect("HERMES_HOME env");
+        assert!(
+            home.value.ends_with("launcher-state/hermes/config.yaml"),
+            "{}",
+            home.value
+        );
+    }
+
+    // -- launch ---------------------------------------------------------------
+
+    // Deliberately reads whatever `GRANITE_CLI_HOME` is ambient rather than
+    // setting it: env mutation would race the other tests in this binary that
+    // point that var at their own tempdirs.
+    #[tokio::test]
+    async fn dry_run_launch_reports_without_writing_anything() {
+        let state_dir = crate::config::Config::launcher_state_dir("hermes").unwrap();
+        let existed_before = state_dir.exists();
+
+        let l = bound(serde_json::json!({ "command_path": "ls" }), binding());
+        let ui = CaptureUi::default();
+        let status = l
+            .launch(&["--help".to_string()], &ctx(true), &ui)
+            .await
+            .unwrap();
+        assert!(status.success());
+
+        let infos = ui.infos.borrow();
+        assert!(
+            infos
+                .iter()
+                .any(|m| m.contains("Would write Hermes config")),
+            "expected a dry-run notice, got {infos:?}"
+        );
+        assert!(
+            infos
+                .iter()
+                .any(|m| m.contains(r#""provider": "my-ollama""#) && m.contains(r#""model": "granite4.1:8b""#)),
+            "expected the generated config to select the model, got {infos:?}"
+        );
+        assert!(
+            infos.iter().any(|m| m.contains("args: --help")),
+            "expected caller args to pass through unmodified, got {infos:?}"
+        );
+        assert_eq!(
+            state_dir.exists(),
+            existed_before,
+            "dry run must not create {}",
+            state_dir.display()
+        );
+    }
+
+    #[tokio::test]
+    async fn launch_without_binding_passes_args_through_unchanged() {
+        let l = launcher(serde_json::json!({ "command_path": "ls" }));
+        let ui = CaptureUi::default();
+        l.launch(&["--version".to_string()], &ctx(true), &ui)
+            .await
+            .unwrap();
+
+        let infos = ui.infos.borrow();
+        assert!(infos.iter().any(|m| m.contains("--version")));
+        assert!(
+            !infos.iter().any(|m| m.contains("Would write Hermes config")),
+            "expected no config write without binding"
+        );
+        // Without a binding there is no generated config, so hermes keeps
+        // using its own config chain.
+        assert!(!infos.iter().any(|m| m.contains(HERMES_HOME_ENV)));
+    }
+}

--- a/src/launchers/hermes.rs
+++ b/src/launchers/hermes.rs
@@ -218,6 +218,22 @@ const API_KEY_ENV: &str = "GRANITE_CLI_HERMES_API_KEY";
 /// The generated Hermes config file's name, relative to the launcher state dir.
 const HERMES_CONFIG_FILE: &str = "config.yaml";
 
+/// Hermes's `base_url` is the API root it appends operation paths to (e.g.
+/// `/chat/completions`), same convention as `opencode.rs`/`pi.rs`/
+/// `openclaw.rs`'s equivalent helpers -- so the trailing operation is
+/// dropped from the binding's full endpoint path here, keeping the version
+/// prefix (e.g. `/v1`). Without this, `base_url` is left as the bare host
+/// root and every request 404s, since Ollama's (and most OpenAI-compatible
+/// servers') actual endpoints live under `/v1`.
+fn hermes_base_url(binding: &AgentModelBinding) -> String {
+    let root = binding.base_url.trim_end_matches('/');
+    let prefix = binding
+        .endpoint_path
+        .strip_suffix("/chat/completions")
+        .unwrap_or("");
+    format!("{root}{prefix}")
+}
+
 impl HermesLauncher {
     /// Builds the Hermes config describing the bound model and MCP servers.
     fn generate_config(&self) -> anyhow::Result<serde_json::Value> {
@@ -232,7 +248,7 @@ impl HermesLauncher {
                 "default": binding.model_name,
             });
             if !binding.base_url.is_empty() {
-                model["base_url"] = serde_json::Value::String(binding.base_url.clone());
+                model["base_url"] = serde_json::Value::String(hermes_base_url(binding));
             }
             if let Some(context_length) = binding.context_length {
                 model["context_length"] = serde_json::json!(context_length);
@@ -541,8 +557,24 @@ mod tests {
         // "custom" discriminator, never the granite-cli provider name.
         assert_eq!(config["model"]["default"], "granite4.1:8b");
         assert_eq!(config["model"]["provider"], "custom");
-        assert_eq!(config["model"]["base_url"], "http://localhost:11434");
+        // Version prefix kept, trailing operation dropped -- not the bare
+        // host root, which would 404 against Ollama's /v1 endpoints.
+        assert_eq!(config["model"]["base_url"], "http://localhost:11434/v1");
         assert_eq!(config["model"]["context_length"], serde_json::json!(131072));
+    }
+
+    #[test]
+    fn base_url_keeps_version_prefix_and_drops_operation() {
+        assert_eq!(hermes_base_url(&binding()), "http://localhost:11434/v1");
+    }
+
+    #[test]
+    fn base_url_trims_trailing_slash_from_provider_url() {
+        let b = AgentModelBinding {
+            base_url: "http://localhost:1234/".to_string(),
+            ..binding()
+        };
+        assert_eq!(hermes_base_url(&b), "http://localhost:1234/v1");
     }
 
     #[test]

--- a/src/launchers/hermes.rs
+++ b/src/launchers/hermes.rs
@@ -1,7 +1,23 @@
-use crate::capabilities::{AgentModelBinding, ApiType, Capability};
-use crate::launchers::base::{EnvBinding, LaunchContext, Launcher, LauncherMetadata};
+//! Launcher for the `hermes` coding agent CLI
+//! (<https://hermes-agent.nousresearch.com>, NousResearch's agent CLI --
+//! not the Hermes model family).
+//!
+//! `HERMES_HOME` is Hermes's "profile boundary": it fully redirects
+//! `config.yaml`, `.env`, `auth.json`, `memories/`, `skills/`, `cron/`,
+//! `sessions/`, and `logs/` all at once. Pointing it straight at an
+//! otherwise-empty generated directory (as this launcher originally did)
+//! would silently discard the user's real auth/memories/skills on every
+//! launch, so -- exactly like `pi.rs` does for `PI_CODING_AGENT_DIR` -- this
+//! launcher symlinks every other top-level entry from the user's real
+//! `$HERMES_HOME`/`~/.hermes` through into its own generated directory and
+//! only ever writes `config.yaml` itself.
+
+use crate::capabilities::{AgentModelBinding, ApiType, Binding, BindingType, Capability, McpBinding};
+use crate::launchers::base::{EnvBinding, LaunchContext, Launcher, LauncherMetadata, run_command};
+use crate::launchers::shared::mcp_cli::mcp_binding_request;
 use crate::registry::ConfigConstructable;
 use crate::utils::resolve_shell_command;
+use crate::utils::ui::Ui;
 use anyhow::Context;
 use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
@@ -28,6 +44,9 @@ pub struct HermesLauncher {
     instance_id: String,
     config: HermesLauncherConfig,
     bound_binding: Option<AgentModelBinding>,
+    /// `(server_name, binding)` for every MCP-capable capability bound to
+    /// this launcher, written into the generated config's `mcp_servers` block.
+    bound_mcp_bindings: Vec<(String, McpBinding)>,
 }
 
 impl ConfigConstructable for HermesLauncher {
@@ -43,6 +62,7 @@ impl ConfigConstructable for HermesLauncher {
             instance_id: instance_id.to_string(),
             config,
             bound_binding: None,
+            bound_mcp_bindings: vec![],
         }
     }
 }
@@ -73,15 +93,33 @@ impl Launcher for HermesLauncher {
             );
         }
 
-        let binding = capability.bind(crate::capabilities::BindingRequest::AgentModel(
-            crate::capabilities::AgentModelBindingRequest {
-                api_type: ApiType::OpenAI,
-            },
-        )).await?;
+        if capability_types.contains(&BindingType::Mcp) {
+            let binding = capability.bind(mcp_binding_request()).await?;
+            match binding {
+                Binding::Mcp(binding) => {
+                    self.bound_mcp_bindings
+                        .push((capability.instance_id().to_string(), binding));
+                }
+                other => anyhow::bail!("expected an Mcp binding, got {:?}", other.binding_type()),
+            }
+            return Ok(());
+        }
+
+        let binding = capability
+            .bind(crate::capabilities::BindingRequest::AgentModel(
+                crate::capabilities::AgentModelBindingRequest {
+                    api_type: ApiType::OpenAI,
+                },
+            ))
+            .await?;
         match binding {
-            crate::capabilities::Binding::AgentModel(binding) => {
+            Binding::AgentModel(binding) => {
                 self.bound_binding = Some(binding);
             }
+            other => anyhow::bail!(
+                "expected an AgentModel binding, got {:?}",
+                other.binding_type()
+            ),
         }
         Ok(())
     }
@@ -90,28 +128,47 @@ impl Launcher for HermesLauncher {
         resolve_shell_command(&self.config.command_path, "hermes")
     }
 
+    /// Redirects Hermes at the granite-cli-owned config directory and
+    /// supplies the credential the generated `config.yaml` interpolates.
     async fn env_overlay(&self, ctx: &LaunchContext) -> anyhow::Result<Vec<EnvBinding>> {
-        let Some(_binding) = &self.bound_binding else {
+        if self.bound_binding.is_none() && self.bound_mcp_bindings.is_empty() {
             return Ok(vec![]);
-        };
-        let overlay = vec![EnvBinding {
+        }
+        let mut overlay = vec![EnvBinding {
             key: HERMES_HOME_ENV.to_string(),
-            value: hermes_config_path(ctx)?.to_string_lossy().to_string(),
+            value: hermes_state_dir(ctx)?.to_string_lossy().to_string(),
         }];
+        if let Some(binding) = &self.bound_binding
+            && let Some(api_key) = binding
+                .api_key
+                .as_ref()
+                .map(|api_key| api_key.0.clone())
+                .filter(|key| !key.is_empty())
+        {
+            overlay.push(EnvBinding {
+                key: API_KEY_ENV.to_string(),
+                value: api_key,
+            });
+        }
         Ok(overlay)
     }
 
+    /// Materializes the granite-cli Hermes config directory (pass-through
+    /// symlinks plus a freshly generated `config.yaml`), then execs `hermes`
+    /// with the caller's arguments untouched.
     async fn launch(
         &self,
         args: &[String],
         ctx: &LaunchContext,
-        ui: &dyn crate::utils::ui::Ui,
+        ui: &dyn Ui,
     ) -> anyhow::Result<std::process::ExitStatus> {
         let binary = self.validate_command()?;
 
-        if let Some(binding) = &self.bound_binding {
-            let config = self.generate_config(binding)?;
-            let config_path = hermes_config_path(ctx)?;
+        if self.bound_binding.is_some() || !self.bound_mcp_bindings.is_empty() {
+            let config = self.generate_config()?;
+            let state_dir = hermes_state_dir(ctx)?;
+            let source_dir = hermes_source_dir()?;
+            let config_path = state_dir.join(HERMES_CONFIG_FILE);
 
             if ctx.dry_run {
                 ui.info(&format!(
@@ -119,16 +176,17 @@ impl Launcher for HermesLauncher {
                     config_path.display()
                 ));
                 ui.info(&serde_json::to_string_pretty(&config)?);
-            } else {
-                write_hermes_config(&config_path, &config)?;
                 ui.info(&format!(
-                    "Wrote Hermes config to {}",
-                    config_path.display()
+                    "  (other Hermes state linked through from {}, which is left unmodified)",
+                    source_dir.display()
                 ));
+            } else {
+                materialize_hermes_config(&state_dir, &source_dir, &config, ui)?;
+                ui.info(&format!("Wrote Hermes config to {}", config_path.display()));
             }
         }
 
-        crate::launchers::base::run_command(binary, &self.env_overlay(ctx).await?, args, ctx, ui).await
+        run_command(binary, &self.env_overlay(ctx).await?, args, ctx, ui).await
     }
 }
 
@@ -138,7 +196,7 @@ impl HasHermesLauncherMetadata for HermesLauncher {
             name: "Hermes CLI".to_string(),
             description: "Hermes Agent local CLI launcher".to_string(),
             default_command: "hermes".to_string(),
-            supported_capabilities: HashSet::from([crate::capabilities::BindingType::AgentModel]),
+            supported_capabilities: HashSet::from([BindingType::AgentModel, BindingType::Mcp]),
             tags: vec!["hermes".to_string(), "agent".to_string()],
         }
     }
@@ -148,76 +206,227 @@ impl HasHermesLauncherMetadata for HermesLauncher {
 
 use crate::launchers::base::HasLauncherMetadata as HasHermesLauncherMetadata;
 
-/// Env var Hermes reads to locate its config directory.
+/// Env var Hermes reads to locate its config directory -- and, per its own
+/// docs, the boundary of an entire "profile" (config, secrets, auth,
+/// memories, skills, sessions, logs), not just the one config file.
 const HERMES_HOME_ENV: &str = "HERMES_HOME";
+
+/// Env var the generated config's `model.api_key` field interpolates via
+/// Hermes's `${VAR_NAME}` substitution syntax.
+const API_KEY_ENV: &str = "GRANITE_CLI_HERMES_API_KEY";
 
 /// The generated Hermes config file's name, relative to the launcher state dir.
 const HERMES_CONFIG_FILE: &str = "config.yaml";
 
 impl HermesLauncher {
-    /// Builds the Hermes config describing the bound model.
-    fn generate_config(&self, binding: &AgentModelBinding) -> anyhow::Result<serde_json::Value> {
-        let mut config = serde_json::json!({
-            "model": {
-                "provider": binding.provider_name,
-                "model": binding.model_name,
+    /// Builds the Hermes config describing the bound model and MCP servers.
+    fn generate_config(&self) -> anyhow::Result<serde_json::Value> {
+        let mut config = serde_json::json!({});
+
+        if let Some(binding) = &self.bound_binding {
+            let mut model = serde_json::json!({
+                // `provider` is a discriminator Hermes recognizes (a
+                // built-in id, or "custom") -- not a free-form label, so the
+                // granite-cli provider name never goes here.
+                "provider": "custom",
+                "default": binding.model_name,
+            });
+            if !binding.base_url.is_empty() {
+                model["base_url"] = serde_json::Value::String(binding.base_url.clone());
             }
-        });
+            if let Some(context_length) = binding.context_length {
+                model["context_length"] = serde_json::json!(context_length);
+            }
+            if binding
+                .api_key
+                .as_ref()
+                .is_some_and(|key| !key.0.is_empty())
+            {
+                model["api_key"] = serde_json::Value::String(format!("${{{API_KEY_ENV}}}"));
+            }
 
-        if !binding.base_url.is_empty() {
-            config["model"]["base_url"] = serde_json::Value::String(binding.base_url.clone());
-        }
-        if let Some(context_length) = binding.context_length {
-            config["model"]["context_length"] = serde_json::json!(context_length);
-        }
-
-        // Merge user-provided overrides on top so they win on conflict.
-        // Special case: if the override key is "model", merge the inner object
-        // into config["model"] rather than replacing it entirely.
-        if let Some(overrides) = self.config
-            .model_overrides
-            .as_ref()
-            .and_then(serde_json::Value::as_object)
-        {
-            for (key, value) in overrides {
-                if key == "model" {
-                    if let Some(inner) = value.as_object() {
-                        if let Some(target) = config.get_mut("model").and_then(serde_json::Value::as_object_mut) {
+            // Merge user-provided overrides on top so they win on conflict.
+            // Special case: if the override key is "model", merge the inner
+            // object into config["model"] rather than replacing it entirely.
+            if let Some(overrides) = self
+                .config
+                .model_overrides
+                .as_ref()
+                .and_then(serde_json::Value::as_object)
+            {
+                for (key, value) in overrides {
+                    if key == "model" {
+                        if let Some(inner) = value.as_object()
+                            && let Some(target) = model.as_object_mut()
+                        {
                             for (k, v) in inner {
                                 target.insert(k.clone(), v.clone());
                             }
                         }
-                    }
-                } else {
-                    if let Some(target) = config.as_object_mut() {
+                    } else if let Some(target) = config.as_object_mut() {
                         target.insert(key.clone(), value.clone());
                     }
                 }
             }
+            config["model"] = model;
         }
+
+        if !self.bound_mcp_bindings.is_empty() {
+            let mut mcp_servers = serde_json::Map::new();
+            for (name, binding) in &self.bound_mcp_bindings {
+                mcp_servers.insert(name.clone(), {
+                    match binding {
+                        McpBinding::Stdio { command, args, env } => serde_json::json!({
+                            "command": command,
+                            "args": args,
+                            "env": env,
+                        }),
+                        McpBinding::Http { url, headers } | McpBinding::Sse { url, headers } => {
+                            serde_json::json!({
+                                "url": url,
+                                "headers": headers,
+                            })
+                        }
+                    }
+                });
+            }
+            config["mcp_servers"] = serde_json::Value::Object(mcp_servers);
+        }
+
         Ok(config)
     }
 }
 
-/// The Hermes config file this launcher instance writes and points `HERMES_HOME` at.
-/// Lives under the launcher state dir rather than the user's own Hermes config
-/// directory — it is never read by anything else.
-fn hermes_config_path(ctx: &LaunchContext) -> anyhow::Result<PathBuf> {
-    Ok(crate::config::Config::launcher_state_dir(&ctx.launcher_id)?
-        .join(HERMES_CONFIG_FILE))
+/// The granite-cli-owned Hermes config directory for this launcher instance.
+fn hermes_state_dir(ctx: &LaunchContext) -> anyhow::Result<PathBuf> {
+    crate::config::Config::launcher_state_dir(&ctx.launcher_id)
 }
 
-/// Wraps the bound model info in the top-level hermes config shape.
-fn write_hermes_config(path: &Path, config: &serde_json::Value) -> anyhow::Result<()> {
-    if let Some(parent) = path.parent() {
-        std::fs::create_dir_all(parent)
-            .with_context(|| format!("Failed to create {}", parent.display()))?;
+/// The user's own Hermes profile directory, which we only ever read from:
+/// `$HERMES_HOME` when set, else `~/.hermes`.
+fn hermes_source_dir() -> anyhow::Result<PathBuf> {
+    if let Ok(val) = std::env::var(HERMES_HOME_ENV)
+        && !val.is_empty()
+    {
+        return Ok(PathBuf::from(val));
     }
-    let mut content = serde_json::to_string_pretty(config)?;
-    content.push('\n');
-    std::fs::write(path, content)
-        .with_context(|| format!("Failed to write {}", path.display()))?;
-    Ok(())
+    let home = dirs::home_dir()
+        .ok_or_else(|| anyhow::anyhow!("Could not determine home directory for Hermes's config"))?;
+    Ok(home.join(".hermes"))
+}
+
+/// Builds `state_dir` into a usable Hermes profile: pass-through links to
+/// everything in the user's real profile (`.env`, `auth.json`, `SOUL.md`,
+/// `memories/`, `skills/`, `cron/`, `sessions/`, `logs/`), plus a freshly
+/// written `config.yaml` that granite-cli owns outright. Nothing under
+/// `source_dir` is written.
+fn materialize_hermes_config(
+    state_dir: &Path,
+    source_dir: &Path,
+    config: &serde_json::Value,
+    ui: &dyn Ui,
+) -> anyhow::Result<()> {
+    std::fs::create_dir_all(state_dir)
+        .with_context(|| format!("Failed to create {}", state_dir.display()))?;
+
+    // A nested launch can land here with source == state (the parent already
+    // redirected HERMES_HOME at us); linking a directory into itself is
+    // meaningless, and config.yaml is already ours.
+    if !same_dir(state_dir, source_dir) {
+        link_pass_through_resources(state_dir, source_dir, ui);
+    }
+
+    write_owned_yaml(&state_dir.join(HERMES_CONFIG_FILE), config)
+}
+
+/// Links every top-level entry of the user's Hermes profile into `state_dir`,
+/// so their secrets, OAuth credentials, memories, skills, cron jobs, and
+/// sessions still apply. `config.yaml` is skipped (granite-cli generates its
+/// own).
+///
+/// Best-effort: a platform or permission that refuses symlinks costs the user
+/// those resources for granite-cli launches, not the launch itself.
+fn link_pass_through_resources(state_dir: &Path, source_dir: &Path, ui: &dyn Ui) {
+    let entries = match std::fs::read_dir(source_dir) {
+        Ok(entries) => entries,
+        // No Hermes profile of their own yet -- nothing to pass through.
+        Err(_) => return,
+    };
+
+    let mut failed = 0usize;
+    for entry in entries.flatten() {
+        let name = entry.file_name();
+        if name == HERMES_CONFIG_FILE {
+            continue;
+        }
+        // The link target must be absolute: a relative one resolves against
+        // the *link's* directory, not ours, and would dangle.
+        let Ok(target) = entry.path().canonicalize() else {
+            failed += 1;
+            continue;
+        };
+        let link = state_dir.join(&name);
+        match std::fs::symlink_metadata(&link) {
+            // Refresh our own link in case the target moved.
+            Ok(md) if md.file_type().is_symlink() => {
+                if std::fs::remove_file(&link).is_err() {
+                    failed += 1;
+                    continue;
+                }
+            }
+            // Something real is sitting there; leave it be.
+            Ok(_) => continue,
+            Err(_) => {}
+        }
+        if symlink(&target, &link).is_err() {
+            failed += 1;
+        }
+    }
+
+    if failed > 0 {
+        ui.warn(&format!(
+            "Could not link {failed} Hermes resource(s) from {} into {}; \
+             secrets, auth and memories from there will not apply to this launch.",
+            source_dir.display(),
+            state_dir.display()
+        ));
+    }
+}
+
+/// Writes a file granite-cli owns outright. Any symlink already at `path` is
+/// removed first -- writing through one would land in whatever it points at,
+/// which is exactly the user's file we are trying not to touch.
+fn write_owned_yaml(path: &Path, value: &serde_json::Value) -> anyhow::Result<()> {
+    if std::fs::symlink_metadata(path).is_ok_and(|md| md.file_type().is_symlink()) {
+        std::fs::remove_file(path)
+            .with_context(|| format!("Failed to replace symlink at {}", path.display()))?;
+    }
+    let content = serde_yaml::to_string(value)
+        .with_context(|| format!("Failed to serialize {}", path.display()))?;
+    std::fs::write(path, content).with_context(|| format!("Failed to write {}", path.display()))
+}
+
+/// Whether two paths denote the same directory, comparing canonical forms when
+/// both exist and falling back to a literal comparison when they don't.
+fn same_dir(a: &Path, b: &Path) -> bool {
+    match (a.canonicalize(), b.canonicalize()) {
+        (Ok(a), Ok(b)) => a == b,
+        _ => a == b,
+    }
+}
+
+#[cfg(unix)]
+fn symlink(target: &Path, link: &Path) -> std::io::Result<()> {
+    std::os::unix::fs::symlink(target, link)
+}
+
+#[cfg(windows)]
+fn symlink(target: &Path, link: &Path) -> std::io::Result<()> {
+    if target.is_dir() {
+        std::os::windows::fs::symlink_dir(target, link)
+    } else {
+        std::os::windows::fs::symlink_file(target, link)
+    }
 }
 
 /*-- tests --*/
@@ -226,7 +435,7 @@ fn write_hermes_config(path: &Path, config: &serde_json::Value) -> anyhow::Resul
 mod tests {
     use super::*;
     use crate::capabilities::BindingType;
-    use crate::registry::Named;
+    use crate::registry::{Named, Secret};
     use crate::utils::ui::base::tests::CaptureUi;
 
     fn launcher(cfg: serde_json::Value) -> HermesLauncher {
@@ -294,10 +503,8 @@ mod tests {
         let meta = HermesLauncher::metadata();
         assert_eq!(meta.name, "Hermes CLI");
         assert_eq!(meta.default_command, "hermes");
-        assert!(
-            meta.supported_capabilities
-                .contains(&BindingType::AgentModel)
-        );
+        assert!(meta.supported_capabilities.contains(&BindingType::AgentModel));
+        assert!(meta.supported_capabilities.contains(&BindingType::Mcp));
     }
 
     #[test]
@@ -327,11 +534,13 @@ mod tests {
     // -- generate_config ------------------------------------------------------
 
     #[test]
-    fn generate_config_sets_provider_and_model() {
-        let l = launcher(serde_json::json!({}));
-        let config = l.generate_config(&binding()).unwrap();
-        assert_eq!(config["model"]["provider"], "my-ollama");
-        assert_eq!(config["model"]["model"], "granite4.1:8b");
+    fn generate_config_sets_default_model_and_custom_provider() {
+        let l = bound(serde_json::json!({}), binding());
+        let config = l.generate_config().unwrap();
+        // Key is `default`, not `model` -- and `provider` is always the
+        // "custom" discriminator, never the granite-cli provider name.
+        assert_eq!(config["model"]["default"], "granite4.1:8b");
+        assert_eq!(config["model"]["provider"], "custom");
         assert_eq!(config["model"]["base_url"], "http://localhost:11434");
         assert_eq!(config["model"]["context_length"], serde_json::json!(131072));
     }
@@ -342,26 +551,83 @@ mod tests {
             context_length: None,
             ..binding()
         };
-        let l = launcher(serde_json::json!({}));
-        let config = l.generate_config(&b).unwrap();
-        assert!(!config["model"].get("context_length").is_some());
+        let l = bound(serde_json::json!({}), b);
+        let config = l.generate_config().unwrap();
+        assert!(config["model"].get("context_length").is_none());
+    }
+
+    #[test]
+    fn generate_config_interpolates_api_key_env_when_present() {
+        let b = AgentModelBinding {
+            api_key: Some(Secret::from("sk-test")),
+            ..binding()
+        };
+        let l = bound(serde_json::json!({}), b);
+        let config = l.generate_config().unwrap();
+        assert_eq!(config["model"]["api_key"], "${GRANITE_CLI_HERMES_API_KEY}");
+    }
+
+    #[test]
+    fn generate_config_omits_api_key_when_absent() {
+        let l = bound(serde_json::json!({}), binding());
+        let config = l.generate_config().unwrap();
+        assert!(config["model"].get("api_key").is_none());
     }
 
     #[test]
     fn generate_config_merges_overrides() {
-        let l = launcher(serde_json::json!({
-            "model_overrides": {
-                "model": {
-                    "context_length": 4000
+        let l = bound(
+            serde_json::json!({
+                "model_overrides": {
+                    "model": {
+                        "context_length": 4000
+                    }
                 }
-            }
-        }));
-        let config = l.generate_config(&binding()).unwrap();
+            }),
+            binding(),
+        );
+        let config = l.generate_config().unwrap();
         // Override wins
         assert_eq!(config["model"]["context_length"], serde_json::json!(4000));
         // Generated keys survive the merge
-        assert_eq!(config["model"]["provider"], "my-ollama");
-        assert_eq!(config["model"]["model"], "granite4.1:8b");
+        assert_eq!(config["model"]["provider"], "custom");
+        assert_eq!(config["model"]["default"], "granite4.1:8b");
+    }
+
+    #[test]
+    fn generate_config_writes_mcp_servers_stdio_and_http() {
+        let mut l = launcher(serde_json::json!({}));
+        l.bound_mcp_bindings.push((
+            "vision".to_string(),
+            McpBinding::Stdio {
+                command: "/usr/local/bin/granite-cli".to_string(),
+                args: vec!["__mcp-serve".to_string(), "vision".to_string()],
+                env: std::collections::HashMap::from([("FOO".to_string(), "bar".to_string())]),
+            },
+        ));
+        l.bound_mcp_bindings.push((
+            "remote".to_string(),
+            McpBinding::Http {
+                url: "http://127.0.0.1:9999".to_string(),
+                headers: std::collections::HashMap::from([(
+                    "Authorization".to_string(),
+                    "Bearer x".to_string(),
+                )]),
+            },
+        ));
+        let config = l.generate_config().unwrap();
+        assert_eq!(
+            config["mcp_servers"]["vision"]["command"],
+            "/usr/local/bin/granite-cli"
+        );
+        assert_eq!(config["mcp_servers"]["vision"]["args"][0], "__mcp-serve");
+        assert_eq!(config["mcp_servers"]["vision"]["env"]["FOO"], "bar");
+        assert_eq!(config["mcp_servers"]["remote"]["url"], "http://127.0.0.1:9999");
+        assert_eq!(
+            config["mcp_servers"]["remote"]["headers"]["Authorization"],
+            "Bearer x"
+        );
+        assert!(config.get("model").is_none());
     }
 
     // -- env overlay -----------------------------------------------------------
@@ -385,11 +651,152 @@ mod tests {
             .iter()
             .find(|b| b.key == HERMES_HOME_ENV)
             .expect("HERMES_HOME env");
-        assert!(
-            home.value.ends_with("launcher-state/hermes/config.yaml"),
-            "{}",
-            home.value
+        assert!(home.value.ends_with("launcher-state/hermes"), "{}", home.value);
+    }
+
+    #[tokio::test]
+    async fn env_overlay_sets_api_key_env_when_key_present() {
+        let b = AgentModelBinding {
+            api_key: Some(Secret::from("sk-test")),
+            ..binding()
+        };
+        let overlay = bound(serde_json::json!({}), b)
+            .env_overlay(&ctx(false))
+            .await
+            .unwrap();
+        let key = overlay
+            .iter()
+            .find(|b| b.key == API_KEY_ENV)
+            .expect("api key env");
+        assert_eq!(key.value, "sk-test");
+    }
+
+    // -- pass-through linking ---------------------------------------------------
+
+    /// A (state_dir, source_dir) pair inside one tempdir.
+    fn dirs(tmp: &tempfile::TempDir) -> (PathBuf, PathBuf) {
+        let source = tmp.path().join("user-hermes");
+        std::fs::create_dir_all(&source).unwrap();
+        (tmp.path().join("state"), source)
+    }
+
+    #[test]
+    fn materialize_writes_config_and_never_touches_source_dir() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let (state, source) = dirs(&tmp);
+        std::fs::write(source.join("config.yaml"), "model:\n  default: user-model\n").unwrap();
+
+        materialize_hermes_config(
+            &state,
+            &source,
+            &serde_json::json!({ "model": { "default": "granite4.1:8b" } }),
+            &CaptureUi::default(),
+        )
+        .unwrap();
+
+        assert_eq!(
+            std::fs::read_to_string(source.join("config.yaml")).unwrap(),
+            "model:\n  default: user-model\n"
         );
+        let written: serde_json::Value =
+            serde_yaml::from_str(&std::fs::read_to_string(state.join("config.yaml")).unwrap())
+                .unwrap();
+        assert_eq!(written["model"]["default"], "granite4.1:8b");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn materialize_links_user_resources_but_not_config() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let (state, source) = dirs(&tmp);
+        std::fs::write(source.join(".env"), "SECRET=1").unwrap();
+        std::fs::write(source.join("auth.json"), "{}").unwrap();
+        std::fs::create_dir(source.join("memories")).unwrap();
+        std::fs::create_dir(source.join("skills")).unwrap();
+        std::fs::write(source.join("config.yaml"), "{}").unwrap();
+
+        materialize_hermes_config(
+            &state,
+            &source,
+            &serde_json::json!({}),
+            &CaptureUi::default(),
+        )
+        .unwrap();
+
+        for linked in [".env", "auth.json", "memories", "skills"] {
+            let path = state.join(linked);
+            let md = std::fs::symlink_metadata(&path)
+                .unwrap_or_else(|_| panic!("{linked} should be linked"));
+            assert!(md.file_type().is_symlink(), "{linked} should be a symlink");
+            let target = std::fs::read_link(&path).unwrap();
+            assert!(target.is_absolute(), "{linked} -> {} must be absolute", target.display());
+            assert!(path.exists(), "{linked} link must resolve");
+        }
+        assert_eq!(std::fs::read_to_string(state.join(".env")).unwrap(), "SECRET=1");
+        // config.yaml is ours, not a link into the user's directory.
+        assert!(
+            !std::fs::symlink_metadata(state.join("config.yaml"))
+                .unwrap()
+                .file_type()
+                .is_symlink()
+        );
+    }
+
+    #[test]
+    fn materialize_works_with_no_user_hermes_profile_at_all() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let state = tmp.path().join("state");
+        let source = tmp.path().join("does-not-exist");
+
+        materialize_hermes_config(
+            &state,
+            &source,
+            &serde_json::json!({ "model": { "default": "x" } }),
+            &CaptureUi::default(),
+        )
+        .unwrap();
+
+        let written: serde_json::Value =
+            serde_yaml::from_str(&std::fs::read_to_string(state.join("config.yaml")).unwrap())
+                .unwrap();
+        assert_eq!(written["model"]["default"], "x");
+    }
+
+    #[test]
+    fn materialize_tolerates_source_equal_to_state() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let dir = tmp.path().join("both");
+        std::fs::create_dir_all(&dir).unwrap();
+
+        materialize_hermes_config(
+            &dir,
+            &dir,
+            &serde_json::json!({ "model": { "default": "x" } }),
+            &CaptureUi::default(),
+        )
+        .unwrap();
+
+        let written: serde_json::Value =
+            serde_yaml::from_str(&std::fs::read_to_string(dir.join("config.yaml")).unwrap())
+                .unwrap();
+        assert_eq!(written["model"]["default"], "x");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn write_owned_yaml_replaces_a_symlink_instead_of_writing_through_it() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let victim = tmp.path().join("users-real-file.yaml");
+        std::fs::write(&victim, "SACRED").unwrap();
+        let link = tmp.path().join("config.yaml");
+        std::os::unix::fs::symlink(&victim, &link).unwrap();
+
+        write_owned_yaml(&link, &serde_json::json!({ "ours": true })).unwrap();
+
+        assert_eq!(std::fs::read_to_string(&victim).unwrap(), "SACRED");
+        let written: serde_json::Value =
+            serde_yaml::from_str(&std::fs::read_to_string(&link).unwrap()).unwrap();
+        assert_eq!(written["ours"], true);
     }
 
     // -- launch ---------------------------------------------------------------
@@ -412,16 +819,18 @@ mod tests {
 
         let infos = ui.infos.borrow();
         assert!(
-            infos
-                .iter()
-                .any(|m| m.contains("Would write Hermes config")),
+            infos.iter().any(|m| m.contains("Would write Hermes config")),
             "expected a dry-run notice, got {infos:?}"
         );
         assert!(
-            infos
-                .iter()
-                .any(|m| m.contains(r#""provider": "my-ollama""#) && m.contains(r#""model": "granite4.1:8b""#)),
+            infos.iter().any(|m| {
+                m.contains(r#""default": "granite4.1:8b""#) && m.contains(r#""provider": "custom""#)
+            }),
             "expected the generated config to select the model, got {infos:?}"
+        );
+        assert!(
+            infos.iter().any(|m| m.contains("left unmodified")),
+            "expected the source profile to be called out as untouched, got {infos:?}"
         );
         assert!(
             infos.iter().any(|m| m.contains("args: --help")),

--- a/src/launchers/hermes.rs
+++ b/src/launchers/hermes.rs
@@ -95,7 +95,7 @@ impl Launcher for HermesLauncher {
             return Ok(vec![]);
         };
         let overlay = vec![EnvBinding {
-            key: "HERMES_HOME".to_string(),
+            key: HERMES_HOME_ENV.to_string(),
             value: hermes_config_path(ctx)?.to_string_lossy().to_string(),
         }];
         Ok(overlay)
@@ -383,7 +383,7 @@ mod tests {
             .unwrap();
         let home = overlay
             .iter()
-            .find(|b| b.key == "HERMES_HOME")
+            .find(|b| b.key == HERMES_HOME_ENV)
             .expect("HERMES_HOME env");
         assert!(
             home.value.ends_with("launcher-state/hermes/config.yaml"),

--- a/src/launchers/hermes.rs
+++ b/src/launchers/hermes.rs
@@ -12,7 +12,9 @@
 //! `$HERMES_HOME`/`~/.hermes` through into its own generated directory and
 //! only ever writes `config.yaml` itself.
 
-use crate::capabilities::{AgentModelBinding, ApiType, Binding, BindingType, Capability, McpBinding};
+use crate::capabilities::{
+    AgentModelBinding, ApiType, Binding, BindingType, Capability, McpBinding,
+};
 use crate::launchers::base::{EnvBinding, LaunchContext, Launcher, LauncherMetadata, run_command};
 use crate::launchers::shared::mcp_cli::mcp_binding_request;
 use crate::registry::ConfigConstructable;
@@ -518,7 +520,10 @@ mod tests {
         let meta = HermesLauncher::metadata();
         assert_eq!(meta.name, "Hermes CLI");
         assert_eq!(meta.default_command, "hermes");
-        assert!(meta.supported_capabilities.contains(&BindingType::AgentModel));
+        assert!(
+            meta.supported_capabilities
+                .contains(&BindingType::AgentModel)
+        );
         assert!(meta.supported_capabilities.contains(&BindingType::Mcp));
     }
 
@@ -653,7 +658,10 @@ mod tests {
         );
         assert_eq!(config["mcp_servers"]["vision"]["args"][0], "__mcp-serve");
         assert_eq!(config["mcp_servers"]["vision"]["env"]["FOO"], "bar");
-        assert_eq!(config["mcp_servers"]["remote"]["url"], "http://127.0.0.1:9999");
+        assert_eq!(
+            config["mcp_servers"]["remote"]["url"],
+            "http://127.0.0.1:9999"
+        );
         assert_eq!(
             config["mcp_servers"]["remote"]["headers"]["Authorization"],
             "Bearer x"
@@ -682,7 +690,11 @@ mod tests {
             .iter()
             .find(|b| b.key == HERMES_HOME_ENV)
             .expect("HERMES_HOME env");
-        assert!(home.value.ends_with("launcher-state/hermes"), "{}", home.value);
+        assert!(
+            home.value.ends_with("launcher-state/hermes"),
+            "{}",
+            home.value
+        );
     }
 
     #[tokio::test]
@@ -715,7 +727,11 @@ mod tests {
     fn materialize_writes_config_and_never_touches_source_dir() {
         let tmp = tempfile::TempDir::new().unwrap();
         let (state, source) = dirs(&tmp);
-        std::fs::write(source.join("config.yaml"), "model:\n  default: user-model\n").unwrap();
+        std::fs::write(
+            source.join("config.yaml"),
+            "model:\n  default: user-model\n",
+        )
+        .unwrap();
 
         materialize_hermes_config(
             &state,
@@ -760,10 +776,17 @@ mod tests {
                 .unwrap_or_else(|_| panic!("{linked} should be linked"));
             assert!(md.file_type().is_symlink(), "{linked} should be a symlink");
             let target = std::fs::read_link(&path).unwrap();
-            assert!(target.is_absolute(), "{linked} -> {} must be absolute", target.display());
+            assert!(
+                target.is_absolute(),
+                "{linked} -> {} must be absolute",
+                target.display()
+            );
             assert!(path.exists(), "{linked} link must resolve");
         }
-        assert_eq!(std::fs::read_to_string(state.join(".env")).unwrap(), "SECRET=1");
+        assert_eq!(
+            std::fs::read_to_string(state.join(".env")).unwrap(),
+            "SECRET=1"
+        );
         // config.yaml is ours, not a link into the user's directory.
         assert!(
             !std::fs::symlink_metadata(state.join("config.yaml"))
@@ -850,7 +873,9 @@ mod tests {
 
         let infos = ui.infos.borrow();
         assert!(
-            infos.iter().any(|m| m.contains("Would write Hermes config")),
+            infos
+                .iter()
+                .any(|m| m.contains("Would write Hermes config")),
             "expected a dry-run notice, got {infos:?}"
         );
         assert!(
@@ -886,7 +911,9 @@ mod tests {
         let infos = ui.infos.borrow();
         assert!(infos.iter().any(|m| m.contains("--version")));
         assert!(
-            !infos.iter().any(|m| m.contains("Would write Hermes config")),
+            !infos
+                .iter()
+                .any(|m| m.contains("Would write Hermes config")),
             "expected no config write without binding"
         );
         // Without a binding there is no generated config, so hermes keeps

--- a/src/launchers/mod.rs
+++ b/src/launchers/mod.rs
@@ -15,6 +15,9 @@ pub static LAUNCHER_REGISTRY: LazyLock<base::LauncherFactory> = LazyLock::new(||
     factory.register::<bob::BobLauncher>("bob");
     factory.register::<pi::PiLauncher>("pi");
     factory.register::<opencode::OpenCodeLauncher>("opencode");
+    factory.register::<hermes::HermesLauncher>("hermes");
+    factory.register::<goose::GooseLauncher>("goose");
+    factory.register::<openclaw::OpenClawLauncher>("openclaw");
     factory
 });
 
@@ -79,14 +82,20 @@ impl crate::dependency::Configured<dyn Launcher> for LauncherSource {
 mod base;
 pub mod bob;
 pub mod claude;
+pub mod hermes;
+pub mod goose;
 pub mod opencode;
 pub mod pi;
+pub mod openclaw;
 
 pub use base::{EnvBinding, LaunchContext, Launcher, LauncherMetadata};
 pub use bob::{BobLauncher, BobLauncherConfig};
 pub use claude::{ClaudeLauncher, ClaudeLauncherConfig};
+pub use hermes::{HermesLauncher, HermesLauncherConfig};
 pub use opencode::{OpenCodeLauncher, OpenCodeLauncherConfig};
 pub use pi::{PiLauncher, PiLauncherConfig};
+pub use goose::{GooseLauncher, GooseLauncherConfig};
+pub use openclaw::{OpenClawLauncher, OpenClawLauncherConfig};
 
 /*-- private shared modules --*/
 
@@ -119,6 +128,9 @@ mod tests {
         assert!(LAUNCHER_REGISTRY.get("bob").is_some());
         assert!(LAUNCHER_REGISTRY.get("pi").is_some());
         assert!(LAUNCHER_REGISTRY.get("opencode").is_some());
+        assert!(LAUNCHER_REGISTRY.get("hermes").is_some());
+        assert!(LAUNCHER_REGISTRY.get("goose").is_some());
+        assert!(LAUNCHER_REGISTRY.get("openclaw").is_some());
         assert!(LAUNCHER_REGISTRY.get("nonexistent").is_none());
     }
 
@@ -163,6 +175,9 @@ mod tests {
         assert!(catalog.contains_key("bob"));
         assert!(catalog.contains_key("pi"));
         assert!(catalog.contains_key("opencode"));
+        assert!(catalog.contains_key("hermes"));
+        assert!(catalog.contains_key("goose"));
+        assert!(catalog.contains_key("openclaw"));
     }
 
     #[test]
@@ -173,6 +188,9 @@ mod tests {
         assert!(source.config_schema("bob").is_some());
         assert!(source.config_schema("pi").is_some());
         assert!(source.config_schema("opencode").is_some());
+        assert!(source.config_schema("hermes").is_some());
+        assert!(source.config_schema("goose").is_some());
+        assert!(source.config_schema("openclaw").is_some());
         assert!(source.config_schema("nonexistent").is_none());
     }
 }

--- a/src/launchers/mod.rs
+++ b/src/launchers/mod.rs
@@ -82,20 +82,20 @@ impl crate::dependency::Configured<dyn Launcher> for LauncherSource {
 mod base;
 pub mod bob;
 pub mod claude;
-pub mod hermes;
 pub mod goose;
+pub mod hermes;
+pub mod openclaw;
 pub mod opencode;
 pub mod pi;
-pub mod openclaw;
 
 pub use base::{EnvBinding, LaunchContext, Launcher, LauncherMetadata};
 pub use bob::{BobLauncher, BobLauncherConfig};
 pub use claude::{ClaudeLauncher, ClaudeLauncherConfig};
+pub use goose::{GooseLauncher, GooseLauncherConfig};
 pub use hermes::{HermesLauncher, HermesLauncherConfig};
+pub use openclaw::{OpenClawLauncher, OpenClawLauncherConfig};
 pub use opencode::{OpenCodeLauncher, OpenCodeLauncherConfig};
 pub use pi::{PiLauncher, PiLauncherConfig};
-pub use goose::{GooseLauncher, GooseLauncherConfig};
-pub use openclaw::{OpenClawLauncher, OpenClawLauncherConfig};
 
 /*-- private shared modules --*/
 

--- a/src/launchers/openclaw.rs
+++ b/src/launchers/openclaw.rs
@@ -2,11 +2,10 @@ use crate::capabilities::{AgentModelBinding, ApiType, Capability};
 use crate::launchers::base::{EnvBinding, LaunchContext, Launcher, LauncherMetadata};
 use crate::registry::ConfigConstructable;
 use crate::utils::resolve_shell_command;
-use anyhow::Context;
 use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
 use std::collections::HashSet;
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 
 /*-- public --*/
 
@@ -92,7 +91,7 @@ impl Launcher for OpenClawLauncher {
         if let Some(binding) = &self.bound_binding {
             // Point OpenClaw at the generated ephemeral config file
             overlay.push(EnvBinding {
-                key: "OPENCLAW_CONFIG_PATH".to_string(),
+                key: CONFIG_ENV.to_string(),
                 value: openclaw_config_path(ctx)?.to_string_lossy().to_string(),
             });
 
@@ -166,54 +165,11 @@ const CONFIG_ENV: &str = "OPENCLAW_CONFIG_PATH";
 /// The generated config file's name, relative to the launcher state dir.
 const CONFIG_FILE: &str = "openclaw.json";
 
-impl OpenClawLauncher {
-    /// Builds the OpenClaw config describing the bound model.
-    /// The generated config serves as a base that env vars then override,
-    /// ensuring the bound model takes precedence over user defaults.
-    fn generate_config(&self, binding: &AgentModelBinding) -> anyhow::Result<serde_json::Value> {
-        let mut config = serde_json::json!({
-            "brain": {
-                "provider": binding.provider_name,
-                "model": binding.model_name,
-            }
-        });
-
-        if !binding.base_url.is_empty() {
-            // For local models, also set local endpoint in config
-            config["brain"]["local"] = serde_json::json!({
-                "endpoint": binding.base_url,
-                "model": binding.model_name,
-            });
-        }
-        if let Some(context_length) = binding.context_length {
-            config["brain"]["maxTokens"] = context_length.into();
-        }
-        if let Some(temperature) = binding.temperature {
-            config["brain"]["temperature"] = temperature.into();
-        }
-
-        Ok(config)
-    }
-}
-
 /// The OpenClaw config file this launcher instance writes and points `OPENCLAW_CONFIG_PATH` at.
 /// Lives under the launcher state dir rather than the user's own OpenClaw config directory.
 fn openclaw_config_path(ctx: &LaunchContext) -> anyhow::Result<PathBuf> {
     Ok(crate::config::Config::launcher_state_dir(&ctx.launcher_id)?
         .join(CONFIG_FILE))
-}
-
-/// Wraps the bound model info in the top-level OpenClaw config shape.
-fn write_openclaw_config(path: &Path, config: &serde_json::Value) -> anyhow::Result<()> {
-    if let Some(parent) = path.parent() {
-        std::fs::create_dir_all(parent)
-            .with_context(|| format!("Failed to create {}", parent.display()))?;
-    }
-    let mut content = serde_json::to_string_pretty(config)?;
-    content.push('\n');
-    std::fs::write(path, content)
-        .with_context(|| format!("Failed to write {}", path.display()))?;
-    Ok(())
 }
 
 /*-- tests --*/
@@ -310,36 +266,6 @@ mod tests {
             .and_then(|p| p.as_object())
             .unwrap();
         assert!(props.contains_key("command_path"));
-    }
-
-    // -- generate_config ------------------------------------------------------
-
-    #[test]
-    fn generate_config_sets_provider_and_model() {
-        let l = launcher(serde_json::json!({}));
-        let config = l.generate_config(&binding()).unwrap();
-        assert_eq!(config["brain"]["provider"], "ollama");
-        assert_eq!(config["brain"]["model"], "mistral/mistral-large-v0.2");
-        assert_eq!(config["brain"]["maxTokens"], serde_json::json!(131072));
-    }
-
-    #[test]
-    fn generate_config_sets_local_endpoint() {
-        let l = launcher(serde_json::json!({}));
-        let config = l.generate_config(&binding()).unwrap();
-        assert_eq!(config["brain"]["local"]["endpoint"], "http://localhost:11434");
-        assert_eq!(config["brain"]["local"]["model"], "mistral/mistral-large-v0.2");
-    }
-
-    #[test]
-    fn generate_config_omits_context_length_when_none() {
-        let b = AgentModelBinding {
-            context_length: None,
-            ..binding()
-        };
-        let l = launcher(serde_json::json!({}));
-        let config = l.generate_config(&b).unwrap();
-        assert!(!config["brain"].get("maxTokens").is_some());
     }
 
     // -- env overlay -----------------------------------------------------------

--- a/src/launchers/openclaw.rs
+++ b/src/launchers/openclaw.rs
@@ -1,11 +1,24 @@
-use crate::capabilities::{AgentModelBinding, ApiType, Capability};
-use crate::launchers::base::{EnvBinding, LaunchContext, Launcher, LauncherMetadata};
+//! Launcher for the `openclaw` self-hosted AI agent/gateway
+//! (<https://docs.openclaw.ai>).
+//!
+//! OpenClaw's model/provider selection and MCP servers are both purely
+//! config-file-driven (no env vars for either), so this launcher generates a
+//! throwaway `openclaw.json` under the launcher state dir and points
+//! `OPENCLAW_CONFIG_PATH` at it, exactly like `opencode.rs` does for
+//! OpenCode's `OPENCODE_CONFIG`. The user's own `~/.openclaw/openclaw.json`
+//! is never touched.
+
+use crate::capabilities::{AgentModelBinding, ApiType, Binding, BindingType, Capability, McpBinding};
+use crate::launchers::base::{EnvBinding, LaunchContext, Launcher, LauncherMetadata, run_command};
+use crate::launchers::shared::mcp_cli::mcp_binding_request;
 use crate::registry::ConfigConstructable;
 use crate::utils::resolve_shell_command;
+use crate::utils::ui::Ui;
+use anyhow::Context;
 use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
 use std::collections::HashSet;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 /*-- public --*/
 
@@ -20,6 +33,9 @@ pub struct OpenClawLauncher {
     instance_id: String,
     config: OpenClawLauncherConfig,
     bound_binding: Option<AgentModelBinding>,
+    /// `(server_name, binding)` for every MCP-capable capability bound to
+    /// this launcher, written into the generated config's `mcp.servers` block.
+    bound_mcp_bindings: Vec<(String, McpBinding)>,
 }
 
 impl ConfigConstructable for OpenClawLauncher {
@@ -30,11 +46,13 @@ impl ConfigConstructable for OpenClawLauncher {
         cfg: &serde_json::Value,
         _global_config: &crate::config::Config,
     ) -> Self {
-        let config: OpenClawLauncherConfig = serde_json::from_value(cfg.clone()).unwrap_or_default();
+        let config: OpenClawLauncherConfig =
+            serde_json::from_value(cfg.clone()).unwrap_or_default();
         Self {
             instance_id: instance_id.to_string(),
             config,
             bound_binding: None,
+            bound_mcp_bindings: vec![],
         }
     }
 }
@@ -55,10 +73,7 @@ impl Launcher for OpenClawLauncher {
         self.config.command_path.as_deref().unwrap_or("openclaw")
     }
 
-    async fn bind_capability(
-        &mut self,
-        capability: &dyn Capability,
-    ) -> anyhow::Result<()> {
+    async fn bind_capability(&mut self, capability: &dyn Capability) -> anyhow::Result<()> {
         let supported = Self::metadata().supported_capabilities;
         let capability_types = capability.binding_types();
         if !capability_types.is_subset(&supported) {
@@ -68,15 +83,36 @@ impl Launcher for OpenClawLauncher {
             );
         }
 
-        let binding = capability.bind(crate::capabilities::BindingRequest::AgentModel(
-            crate::capabilities::AgentModelBindingRequest {
-                api_type: ApiType::OpenAI,
-            },
-        )).await?;
+        if capability_types.contains(&BindingType::Mcp) {
+            let binding = capability.bind(mcp_binding_request()).await?;
+            match binding {
+                Binding::Mcp(binding) => {
+                    self.bound_mcp_bindings
+                        .push((capability.instance_id().to_string(), binding));
+                }
+                other => anyhow::bail!("expected an Mcp binding, got {:?}", other.binding_type()),
+            }
+            return Ok(());
+        }
+
+        // OpenClaw's custom-provider config speaks a plain OpenAI-compatible
+        // dialect (`api: "openai-completions"`), which every granite-cli
+        // provider can serve.
+        let binding = capability
+            .bind(crate::capabilities::BindingRequest::AgentModel(
+                crate::capabilities::AgentModelBindingRequest {
+                    api_type: ApiType::OpenAI,
+                },
+            ))
+            .await?;
         match binding {
-            crate::capabilities::Binding::AgentModel(binding) => {
+            Binding::AgentModel(binding) => {
                 self.bound_binding = Some(binding);
             }
+            other => anyhow::bail!(
+                "expected an AgentModel binding, got {:?}",
+                other.binding_type()
+            ),
         }
         Ok(())
     }
@@ -85,60 +121,51 @@ impl Launcher for OpenClawLauncher {
         resolve_shell_command(&self.config.command_path, "openclaw")
     }
 
+    /// Points OpenClaw at the granite-cli-generated config file. There is no
+    /// env var for provider/model/API-key -- OpenClaw reads all of it from
+    /// `OPENCLAW_CONFIG_PATH` itself, written by `launch()`.
     async fn env_overlay(&self, ctx: &LaunchContext) -> anyhow::Result<Vec<EnvBinding>> {
-        let mut overlay = Vec::new();
-
-        if let Some(binding) = &self.bound_binding {
-            // Point OpenClaw at the generated ephemeral config file
+        let mut overlay = vec![];
+        if self.bound_binding.is_some() || !self.bound_mcp_bindings.is_empty() {
             overlay.push(EnvBinding {
                 key: CONFIG_ENV.to_string(),
                 value: openclaw_config_path(ctx)?.to_string_lossy().to_string(),
             });
-
-            // Set provider and model via env vars (they override config.json)
-            overlay.push(EnvBinding {
-                key: "OPENCLAW_PROVIDER".to_string(),
-                value: binding.provider_name.clone(),
-            });
-            overlay.push(EnvBinding {
-                key: "OPENCLAW_MODEL".to_string(),
-                value: binding.model_name.clone(),
-            });
-
-            if !binding.base_url.is_empty() {
-                // For local models, OPENCLAW_LOCAL_ENDPOINT and OPENCLAW_LOCAL_MODEL
-                // are used together. Set both for provider compatibility.
-                overlay.push(EnvBinding {
-                    key: "OPENCLAW_LOCAL_ENDPOINT".to_string(),
-                    value: binding.base_url.clone(),
-                });
-                // LOCAL_MODEL is typically the model name when using a local server
-                overlay.push(EnvBinding {
-                    key: "OPENCLAW_LOCAL_MODEL".to_string(),
-                    value: binding.model_name.clone(),
-                });
-            }
-
-            if let Some(context_length) = binding.context_length {
-                // OPENCLAW_MAX_TOKENS controls the context window (equivalent to context_length)
-                overlay.push(EnvBinding {
-                    key: "OPENCLAW_MAX_TOKENS".to_string(),
-                    value: context_length.to_string(),
-                });
-            }
         }
-
         Ok(overlay)
     }
 
+    /// Writes the granite-cli OpenClaw config file, then execs `openclaw`
+    /// with the caller's arguments untouched.
     async fn launch(
         &self,
         args: &[String],
         ctx: &LaunchContext,
-        ui: &dyn crate::utils::ui::Ui,
+        ui: &dyn Ui,
     ) -> anyhow::Result<std::process::ExitStatus> {
+        if self.bound_binding.is_some() || !self.bound_mcp_bindings.is_empty() {
+            let config = generate_config(self.bound_binding.as_ref(), &self.bound_mcp_bindings);
+            let config_path = openclaw_config_path(ctx)?;
+
+            if ctx.dry_run {
+                ui.info(&format!(
+                    "Would write OpenClaw config to {}:",
+                    config_path.display()
+                ));
+                ui.info(&serde_json::to_string_pretty(&config)?);
+            } else {
+                write_openclaw_config(&config_path, &config)?;
+                ui.info(&format!(
+                    "Wrote OpenClaw config to {}",
+                    config_path.display()
+                ));
+            }
+        }
+
         let binary = self.validate_command()?;
-        crate::launchers::base::run_command(binary, &self.env_overlay(ctx).await?, args, ctx, ui).await
+        let overlay = self.env_overlay(ctx).await?;
+
+        run_command(binary, &overlay, args, ctx, ui).await
     }
 }
 
@@ -146,9 +173,9 @@ impl HasOpenClawLauncherMetadata for OpenClawLauncher {
     fn metadata() -> LauncherMetadata {
         LauncherMetadata {
             name: "OpenClaw CLI".to_string(),
-            description: "OpenClaw autonomous AI agent launcher".to_string(),
+            description: "OpenClaw self-hosted AI agent launcher".to_string(),
             default_command: "openclaw".to_string(),
-            supported_capabilities: HashSet::from([crate::capabilities::BindingType::AgentModel]),
+            supported_capabilities: HashSet::from([BindingType::AgentModel, BindingType::Mcp]),
             tags: vec!["openclaw".to_string(), "agent".to_string()],
         }
     }
@@ -158,18 +185,113 @@ impl HasOpenClawLauncherMetadata for OpenClawLauncher {
 
 use crate::launchers::base::HasLauncherMetadata as HasOpenClawLauncherMetadata;
 
-/// Env var OpenClaw merges an extra config file from, in addition to its own
-/// global/project config.
+/// Env var OpenClaw reads to override which config file it treats as active,
+/// entirely replacing (not merging with) `~/.openclaw/openclaw.json` for the
+/// life of the process.
 const CONFIG_ENV: &str = "OPENCLAW_CONFIG_PATH";
 
 /// The generated config file's name, relative to the launcher state dir.
 const CONFIG_FILE: &str = "openclaw.json";
 
-/// The OpenClaw config file this launcher instance writes and points `OPENCLAW_CONFIG_PATH` at.
-/// Lives under the launcher state dir rather than the user's own OpenClaw config directory.
+/// OpenClaw's `baseUrl` is the API root its OpenAI-compatible adapter appends
+/// operation paths to, same derivation as `opencode.rs`'s equivalent.
+fn openclaw_base_url(binding: &AgentModelBinding) -> String {
+    let root = binding.base_url.trim_end_matches('/');
+    let prefix = binding
+        .endpoint_path
+        .strip_suffix("/chat/completions")
+        .unwrap_or("");
+    format!("{root}{prefix}")
+}
+
+/// The granite-cli-owned OpenClaw config file this launcher instance writes
+/// and points `OPENCLAW_CONFIG_PATH` at. Lives under the launcher state dir
+/// rather than the user's own `~/.openclaw`, so it is never read by anything
+/// else.
 fn openclaw_config_path(ctx: &LaunchContext) -> anyhow::Result<PathBuf> {
-    Ok(crate::config::Config::launcher_state_dir(&ctx.launcher_id)?
-        .join(CONFIG_FILE))
+    Ok(crate::config::Config::launcher_state_dir(&ctx.launcher_id)?.join(CONFIG_FILE))
+}
+
+/// Builds the top-level `openclaw.json` shape (see
+/// docs.openclaw.ai/gateway/configuration-reference and
+/// docs.openclaw.ai/gateway/config-agents): a `models.providers.<name>` entry
+/// plus `agents.defaults.model` set to `"<provider>/<model>"` (if bound), and
+/// an `mcp.servers` block (if any MCP servers are bound) using OpenClaw's
+/// stdio (`command`/`args`/`env`) and remote (`url`/`transport`/`headers`)
+/// server shapes.
+fn generate_config(
+    binding: Option<&AgentModelBinding>,
+    mcp_bindings: &[(String, McpBinding)],
+) -> serde_json::Value {
+    let mut config = serde_json::json!({});
+    if let Some(binding) = binding {
+        let mut model_entry = serde_json::json!({
+            "id": binding.model_name,
+            "name": binding.model_name,
+        });
+        if let Some(context_length) = binding.context_length {
+            model_entry["contextWindow"] = serde_json::json!(context_length);
+        }
+
+        let mut provider_entry = serde_json::json!({
+            "baseUrl": openclaw_base_url(binding),
+            "api": "openai-completions",
+            "models": [model_entry],
+        });
+        if let Some(api_key) = binding
+            .api_key
+            .as_ref()
+            .map(|api_key| api_key.0.clone())
+            .filter(|key| !key.is_empty())
+        {
+            provider_entry["apiKey"] = serde_json::Value::String(api_key);
+        }
+
+        let mut providers = serde_json::Map::new();
+        providers.insert(binding.provider_name.clone(), provider_entry);
+        config["models"] = serde_json::json!({ "providers": providers });
+        config["agents"] = serde_json::json!({
+            "defaults": {
+                "model": format!("{}/{}", binding.provider_name, binding.model_name),
+            }
+        });
+    }
+    if !mcp_bindings.is_empty() {
+        let mut servers = serde_json::Map::new();
+        for (name, binding) in mcp_bindings {
+            servers.insert(name.clone(), {
+                match binding {
+                    McpBinding::Stdio { command, args, env } => serde_json::json!({
+                        "command": command,
+                        "args": args,
+                        "env": env,
+                    }),
+                    McpBinding::Http { url, headers } => serde_json::json!({
+                        "url": url,
+                        "transport": "streamable-http",
+                        "headers": headers,
+                    }),
+                    McpBinding::Sse { url, headers } => serde_json::json!({
+                        "url": url,
+                        "transport": "sse",
+                        "headers": headers,
+                    }),
+                }
+            });
+        }
+        config["mcp"] = serde_json::json!({ "servers": servers });
+    }
+    config
+}
+
+fn write_openclaw_config(path: &Path, config: &serde_json::Value) -> anyhow::Result<()> {
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)
+            .with_context(|| format!("Failed to create {}", parent.display()))?;
+    }
+    let mut content = serde_json::to_string_pretty(config)?;
+    content.push('\n');
+    std::fs::write(path, content).with_context(|| format!("Failed to write {}", path.display()))
 }
 
 /*-- tests --*/
@@ -177,7 +299,7 @@ fn openclaw_config_path(ctx: &LaunchContext) -> anyhow::Result<PathBuf> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::registry::Named;
+    use crate::registry::{Named, Secret};
     use crate::utils::ui::base::tests::CaptureUi;
 
     fn launcher(cfg: serde_json::Value) -> OpenClawLauncher {
@@ -187,9 +309,9 @@ mod tests {
     fn binding() -> AgentModelBinding {
         AgentModelBinding {
             api_type: ApiType::OpenAI,
-            provider_name: "ollama".to_string(),
+            provider_name: "my-ollama".to_string(),
             base_url: "http://localhost:11434".to_string(),
-            model_name: "mistral/mistral-large-v0.2".to_string(),
+            model_name: "granite4.1:8b".to_string(),
             endpoint_path: "/v1/chat/completions".to_string(),
             api_key: None,
             verify_ssl: true,
@@ -204,10 +326,10 @@ mod tests {
         l
     }
 
-    fn ctx(dry_run: bool) -> crate::launchers::base::LaunchContext {
-        crate::launchers::base::LaunchContext {
+    fn ctx(dry_run: bool) -> LaunchContext {
+        LaunchContext {
             launcher_id: "openclaw".to_string(),
-            working_dir: std::path::PathBuf::from("/tmp"),
+            working_dir: PathBuf::from("/tmp"),
             base_env: std::collections::HashMap::new(),
             dry_run,
         }
@@ -239,10 +361,8 @@ mod tests {
         let meta = OpenClawLauncher::metadata();
         assert_eq!(meta.name, "OpenClaw CLI");
         assert_eq!(meta.default_command, "openclaw");
-        assert!(
-            meta.supported_capabilities
-                .contains(&crate::capabilities::BindingType::AgentModel)
-        );
+        assert!(meta.supported_capabilities.contains(&BindingType::AgentModel));
+        assert!(meta.supported_capabilities.contains(&BindingType::Mcp));
     }
 
     #[test]
@@ -268,6 +388,82 @@ mod tests {
         assert!(props.contains_key("command_path"));
     }
 
+    // -- base url ----------------------------------------------------------
+
+    #[test]
+    fn base_url_keeps_version_prefix_and_drops_operation() {
+        assert_eq!(openclaw_base_url(&binding()), "http://localhost:11434/v1");
+    }
+
+    // -- generate_config -----------------------------------------------------
+
+    #[test]
+    fn generate_config_nests_provider_under_models_providers() {
+        let config = generate_config(Some(&binding()), &[]);
+        assert_eq!(
+            config["models"]["providers"]["my-ollama"]["baseUrl"],
+            "http://localhost:11434/v1"
+        );
+        assert_eq!(
+            config["models"]["providers"]["my-ollama"]["api"],
+            "openai-completions"
+        );
+        assert_eq!(
+            config["models"]["providers"]["my-ollama"]["models"][0]["id"],
+            "granite4.1:8b"
+        );
+        assert_eq!(
+            config["models"]["providers"]["my-ollama"]["models"][0]["contextWindow"],
+            131072
+        );
+        assert_eq!(config["agents"]["defaults"]["model"], "my-ollama/granite4.1:8b");
+        // No key means no apiKey field at all.
+        assert!(config["models"]["providers"]["my-ollama"]
+            .get("apiKey")
+            .is_none());
+    }
+
+    #[test]
+    fn generate_config_includes_api_key_when_present() {
+        let b = AgentModelBinding {
+            api_key: Some(Secret::from("sk-test")),
+            ..binding()
+        };
+        let config = generate_config(Some(&b), &[]);
+        assert_eq!(config["models"]["providers"]["my-ollama"]["apiKey"], "sk-test");
+    }
+
+    #[test]
+    fn generate_config_writes_mcp_servers_block_without_a_model_binding() {
+        let mcp_binding = McpBinding::Http {
+            url: "http://127.0.0.1:9999".to_string(),
+            headers: Default::default(),
+        };
+        let config = generate_config(None, &[("vision".to_string(), mcp_binding)]);
+        assert!(config.get("models").is_none());
+        assert_eq!(config["mcp"]["servers"]["vision"]["url"], "http://127.0.0.1:9999");
+        assert_eq!(
+            config["mcp"]["servers"]["vision"]["transport"],
+            "streamable-http"
+        );
+    }
+
+    #[test]
+    fn generate_config_writes_stdio_mcp_server_with_command_args_env() {
+        let mcp_binding = McpBinding::Stdio {
+            command: "/usr/local/bin/granite-cli".to_string(),
+            args: vec!["__mcp-serve".to_string(), "vision".to_string()],
+            env: std::collections::HashMap::from([("FOO".to_string(), "bar".to_string())]),
+        };
+        let config = generate_config(None, &[("vision".to_string(), mcp_binding)]);
+        assert_eq!(
+            config["mcp"]["servers"]["vision"]["command"],
+            "/usr/local/bin/granite-cli"
+        );
+        assert_eq!(config["mcp"]["servers"]["vision"]["args"][0], "__mcp-serve");
+        assert_eq!(config["mcp"]["servers"]["vision"]["env"]["FOO"], "bar");
+    }
+
     // -- env overlay -----------------------------------------------------------
 
     #[tokio::test]
@@ -280,63 +476,59 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn env_overlay_sets_openclaw_config_path_when_bound() {
+    async fn env_overlay_redirects_config_path_when_bound() {
         let overlay = bound(serde_json::json!({}), binding())
             .env_overlay(&ctx(false))
             .await
             .unwrap();
-        let config_path = overlay
+        let config = overlay
             .iter()
             .find(|b| b.key == "OPENCLAW_CONFIG_PATH")
-            .expect("OPENCLAW_CONFIG_PATH env");
-        assert!(config_path.value.ends_with("launcher-state/openclaw/openclaw.json"));
+            .expect("config redirect");
+        assert!(
+            config.value.ends_with("launcher-state/openclaw/openclaw.json"),
+            "{}",
+            config.value
+        );
     }
 
+    // -- launch ----------------------------------------------------------------
+
+    // Deliberately reads whatever `GRANITE_CLI_HOME` is ambient rather than
+    // setting it: env mutation would race the other tests in this binary that
+    // point that var at their own tempdirs.
     #[tokio::test]
-    async fn env_overlay_sets_openclaw_provider_and_model() {
-        let overlay = bound(serde_json::json!({}), binding())
-            .env_overlay(&ctx(false))
+    async fn dry_run_launch_reports_without_writing_anything() {
+        let state_dir = crate::config::Config::launcher_state_dir("openclaw").unwrap();
+        let existed_before = state_dir.exists();
+
+        let l = bound(serde_json::json!({ "command_path": "ls" }), binding());
+        let ui = CaptureUi::default();
+        let status = l
+            .launch(&["--help".to_string()], &ctx(true), &ui)
             .await
             .unwrap();
-        let provider = overlay
-            .iter()
-            .find(|b| b.key == "OPENCLAW_PROVIDER")
-            .expect("OPENCLAW_PROVIDER env");
-        assert_eq!(provider.value, "ollama");
-        let model = overlay
-            .iter()
-            .find(|b| b.key == "OPENCLAW_MODEL")
-            .expect("OPENCLAW_MODEL env");
-        assert_eq!(model.value, "mistral/mistral-large-v0.2");
-    }
+        assert!(status.success());
 
-    #[tokio::test]
-    async fn env_overlay_sets_openclaw_local_endpoint() {
-        let overlay = bound(serde_json::json!({}), binding())
-            .env_overlay(&ctx(false))
-            .await
-            .unwrap();
-        let endpoint = overlay
-            .iter()
-            .find(|b| b.key == "OPENCLAW_LOCAL_ENDPOINT")
-            .expect("OPENCLAW_LOCAL_ENDPOINT env");
-        assert_eq!(endpoint.value, "http://localhost:11434");
+        let infos = ui.infos.borrow();
+        assert!(
+            infos.iter().any(|m| m.contains("Would write OpenClaw config")),
+            "expected a dry-run notice, got {infos:?}"
+        );
+        assert!(
+            infos
+                .iter()
+                .any(|m| m.contains(r#""model": "my-ollama/granite4.1:8b""#)),
+            "expected the generated config to select the model, got {infos:?}"
+        );
+        assert!(infos.iter().any(|m| m.contains("args: --help")));
+        assert_eq!(
+            state_dir.exists(),
+            existed_before,
+            "dry run must not create {}",
+            state_dir.display()
+        );
     }
-
-    #[tokio::test]
-    async fn env_overlay_sets_openclaw_max_tokens() {
-        let overlay = bound(serde_json::json!({}), binding())
-            .env_overlay(&ctx(false))
-            .await
-            .unwrap();
-        let max_tokens = overlay
-            .iter()
-            .find(|b| b.key == "OPENCLAW_MAX_TOKENS")
-            .expect("OPENCLAW_MAX_TOKENS env");
-        assert_eq!(max_tokens.value, "131072");
-    }
-
-    // -- launch ---------------------------------------------------------------
 
     #[tokio::test]
     async fn launch_without_binding_passes_args_through_unchanged() {
@@ -347,8 +539,8 @@ mod tests {
             .unwrap();
 
         let infos = ui.infos.borrow();
-        assert!(infos.iter().any(|m| m.contains("--version")));
-        // Without a binding there is no OPENCLAW_* env override.
-        assert!(!infos.iter().any(|m| m.contains("OPENCLAW_PROVIDER")));
+        assert!(infos.iter().any(|m| m.contains("args: --version")));
+        assert!(!infos.iter().any(|m| m.contains("Would write OpenClaw config")));
+        assert!(!infos.iter().any(|m| m.contains(CONFIG_ENV)));
     }
 }

--- a/src/launchers/openclaw.rs
+++ b/src/launchers/openclaw.rs
@@ -1,0 +1,428 @@
+use crate::capabilities::{AgentModelBinding, ApiType, Capability};
+use crate::launchers::base::{EnvBinding, LaunchContext, Launcher, LauncherMetadata};
+use crate::registry::ConfigConstructable;
+use crate::utils::resolve_shell_command;
+use anyhow::Context;
+use async_trait::async_trait;
+use serde::{Deserialize, Serialize};
+use std::collections::HashSet;
+use std::path::{Path, PathBuf};
+
+/*-- public --*/
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default, schemars::JsonSchema)]
+pub struct OpenClawLauncherConfig {
+    /// Override path to the `openclaw` binary for non-PATH installs.
+    #[serde(default)]
+    pub command_path: Option<String>,
+}
+
+pub struct OpenClawLauncher {
+    instance_id: String,
+    config: OpenClawLauncherConfig,
+    bound_binding: Option<AgentModelBinding>,
+}
+
+impl ConfigConstructable for OpenClawLauncher {
+    type Config = OpenClawLauncherConfig;
+
+    fn new(
+        instance_id: &str,
+        cfg: &serde_json::Value,
+        _global_config: &crate::config::Config,
+    ) -> Self {
+        let config: OpenClawLauncherConfig = serde_json::from_value(cfg.clone()).unwrap_or_default();
+        Self {
+            instance_id: instance_id.to_string(),
+            config,
+            bound_binding: None,
+        }
+    }
+}
+
+impl crate::registry::Named for OpenClawLauncher {
+    fn instance_id(&self) -> &str {
+        &self.instance_id
+    }
+}
+
+#[async_trait]
+impl Launcher for OpenClawLauncher {
+    fn name(&self) -> &str {
+        "OpenClaw CLI"
+    }
+
+    fn command(&self) -> &str {
+        self.config.command_path.as_deref().unwrap_or("openclaw")
+    }
+
+    async fn bind_capability(
+        &mut self,
+        capability: &dyn Capability,
+    ) -> anyhow::Result<()> {
+        let supported = Self::metadata().supported_capabilities;
+        let capability_types = capability.binding_types();
+        if !capability_types.is_subset(&supported) {
+            anyhow::bail!(
+                "capability supports {:?} which this launcher does not support",
+                capability_types.difference(&supported).collect::<Vec<_>>()
+            );
+        }
+
+        let binding = capability.bind(crate::capabilities::BindingRequest::AgentModel(
+            crate::capabilities::AgentModelBindingRequest {
+                api_type: ApiType::OpenAI,
+            },
+        )).await?;
+        match binding {
+            crate::capabilities::Binding::AgentModel(binding) => {
+                self.bound_binding = Some(binding);
+            }
+        }
+        Ok(())
+    }
+
+    fn validate_command(&self) -> anyhow::Result<PathBuf> {
+        resolve_shell_command(&self.config.command_path, "openclaw")
+    }
+
+    async fn env_overlay(&self, ctx: &LaunchContext) -> anyhow::Result<Vec<EnvBinding>> {
+        let mut overlay = Vec::new();
+
+        if let Some(binding) = &self.bound_binding {
+            // Point OpenClaw at the generated ephemeral config file
+            overlay.push(EnvBinding {
+                key: "OPENCLAW_CONFIG_PATH".to_string(),
+                value: openclaw_config_path(ctx)?.to_string_lossy().to_string(),
+            });
+
+            // Set provider and model via env vars (they override config.json)
+            overlay.push(EnvBinding {
+                key: "OPENCLAW_PROVIDER".to_string(),
+                value: binding.provider_name.clone(),
+            });
+            overlay.push(EnvBinding {
+                key: "OPENCLAW_MODEL".to_string(),
+                value: binding.model_name.clone(),
+            });
+
+            if !binding.base_url.is_empty() {
+                // For local models, OPENCLAW_LOCAL_ENDPOINT and OPENCLAW_LOCAL_MODEL
+                // are used together. Set both for provider compatibility.
+                overlay.push(EnvBinding {
+                    key: "OPENCLAW_LOCAL_ENDPOINT".to_string(),
+                    value: binding.base_url.clone(),
+                });
+                // LOCAL_MODEL is typically the model name when using a local server
+                overlay.push(EnvBinding {
+                    key: "OPENCLAW_LOCAL_MODEL".to_string(),
+                    value: binding.model_name.clone(),
+                });
+            }
+
+            if let Some(context_length) = binding.context_length {
+                // OPENCLAW_MAX_TOKENS controls the context window (equivalent to context_length)
+                overlay.push(EnvBinding {
+                    key: "OPENCLAW_MAX_TOKENS".to_string(),
+                    value: context_length.to_string(),
+                });
+            }
+        }
+
+        Ok(overlay)
+    }
+
+    async fn launch(
+        &self,
+        args: &[String],
+        ctx: &LaunchContext,
+        ui: &dyn crate::utils::ui::Ui,
+    ) -> anyhow::Result<std::process::ExitStatus> {
+        let binary = self.validate_command()?;
+        crate::launchers::base::run_command(binary, &self.env_overlay(ctx).await?, args, ctx, ui).await
+    }
+}
+
+impl HasOpenClawLauncherMetadata for OpenClawLauncher {
+    fn metadata() -> LauncherMetadata {
+        LauncherMetadata {
+            name: "OpenClaw CLI".to_string(),
+            description: "OpenClaw autonomous AI agent launcher".to_string(),
+            default_command: "openclaw".to_string(),
+            supported_capabilities: HashSet::from([crate::capabilities::BindingType::AgentModel]),
+            tags: vec!["openclaw".to_string(), "agent".to_string()],
+        }
+    }
+}
+
+/*-- private --*/
+
+use crate::launchers::base::HasLauncherMetadata as HasOpenClawLauncherMetadata;
+
+/// Env var OpenClaw merges an extra config file from, in addition to its own
+/// global/project config.
+const CONFIG_ENV: &str = "OPENCLAW_CONFIG_PATH";
+
+/// The generated config file's name, relative to the launcher state dir.
+const CONFIG_FILE: &str = "openclaw.json";
+
+impl OpenClawLauncher {
+    /// Builds the OpenClaw config describing the bound model.
+    /// The generated config serves as a base that env vars then override,
+    /// ensuring the bound model takes precedence over user defaults.
+    fn generate_config(&self, binding: &AgentModelBinding) -> anyhow::Result<serde_json::Value> {
+        let mut config = serde_json::json!({
+            "brain": {
+                "provider": binding.provider_name,
+                "model": binding.model_name,
+            }
+        });
+
+        if !binding.base_url.is_empty() {
+            // For local models, also set local endpoint in config
+            config["brain"]["local"] = serde_json::json!({
+                "endpoint": binding.base_url,
+                "model": binding.model_name,
+            });
+        }
+        if let Some(context_length) = binding.context_length {
+            config["brain"]["maxTokens"] = context_length.into();
+        }
+        if let Some(temperature) = binding.temperature {
+            config["brain"]["temperature"] = temperature.into();
+        }
+
+        Ok(config)
+    }
+}
+
+/// The OpenClaw config file this launcher instance writes and points `OPENCLAW_CONFIG_PATH` at.
+/// Lives under the launcher state dir rather than the user's own OpenClaw config directory.
+fn openclaw_config_path(ctx: &LaunchContext) -> anyhow::Result<PathBuf> {
+    Ok(crate::config::Config::launcher_state_dir(&ctx.launcher_id)?
+        .join(CONFIG_FILE))
+}
+
+/// Wraps the bound model info in the top-level OpenClaw config shape.
+fn write_openclaw_config(path: &Path, config: &serde_json::Value) -> anyhow::Result<()> {
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)
+            .with_context(|| format!("Failed to create {}", parent.display()))?;
+    }
+    let mut content = serde_json::to_string_pretty(config)?;
+    content.push('\n');
+    std::fs::write(path, content)
+        .with_context(|| format!("Failed to write {}", path.display()))?;
+    Ok(())
+}
+
+/*-- tests --*/
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::registry::Named;
+    use crate::utils::ui::base::tests::CaptureUi;
+
+    fn launcher(cfg: serde_json::Value) -> OpenClawLauncher {
+        OpenClawLauncher::new("openclaw", &cfg, &crate::config::Config::default())
+    }
+
+    fn binding() -> AgentModelBinding {
+        AgentModelBinding {
+            api_type: ApiType::OpenAI,
+            provider_name: "ollama".to_string(),
+            base_url: "http://localhost:11434".to_string(),
+            model_name: "mistral/mistral-large-v0.2".to_string(),
+            endpoint_path: "/v1/chat/completions".to_string(),
+            api_key: None,
+            verify_ssl: true,
+            context_length: Some(131072),
+            temperature: None,
+        }
+    }
+
+    fn bound(cfg: serde_json::Value, binding: AgentModelBinding) -> OpenClawLauncher {
+        let mut l = launcher(cfg);
+        l.bound_binding = Some(binding);
+        l
+    }
+
+    fn ctx(dry_run: bool) -> crate::launchers::base::LaunchContext {
+        crate::launchers::base::LaunchContext {
+            launcher_id: "openclaw".to_string(),
+            working_dir: std::path::PathBuf::from("/tmp"),
+            base_env: std::collections::HashMap::new(),
+            dry_run,
+        }
+    }
+
+    // -- command resolution ----------------------------------------------------
+
+    #[test]
+    fn command_defaults_to_openclaw() {
+        assert_eq!(launcher(serde_json::json!({})).command(), "openclaw");
+    }
+
+    #[test]
+    fn command_uses_explicit_path_when_set() {
+        let l = launcher(serde_json::json!({ "command_path": "/opt/bin/openclaw" }));
+        assert_eq!(l.command(), "/opt/bin/openclaw");
+    }
+
+    #[test]
+    fn validate_command_falls_back_to_path_for_bare_command_name() {
+        let l = launcher(serde_json::json!({ "command_path": "ls" }));
+        assert!(l.validate_command().is_ok());
+    }
+
+    // -- metadata / schema -----------------------------------------------------
+
+    #[test]
+    fn metadata_name_is_openclaw_cli() {
+        let meta = OpenClawLauncher::metadata();
+        assert_eq!(meta.name, "OpenClaw CLI");
+        assert_eq!(meta.default_command, "openclaw");
+        assert!(
+            meta.supported_capabilities
+                .contains(&crate::capabilities::BindingType::AgentModel)
+        );
+    }
+
+    #[test]
+    fn instance_id_round_trips_from_construction() {
+        let l = OpenClawLauncher::new(
+            "openclaw-local",
+            &serde_json::json!({}),
+            &crate::config::Config::default(),
+        );
+        assert_eq!(l.instance_id(), "openclaw-local");
+    }
+
+    #[test]
+    fn config_schema_exposes_command_path() {
+        use crate::launchers::base::LauncherFactory;
+        let mut factory = LauncherFactory::new();
+        factory.register::<OpenClawLauncher>("openclaw");
+        let schema = factory.config_schema("openclaw").unwrap();
+        let props = schema
+            .get("properties")
+            .and_then(|p| p.as_object())
+            .unwrap();
+        assert!(props.contains_key("command_path"));
+    }
+
+    // -- generate_config ------------------------------------------------------
+
+    #[test]
+    fn generate_config_sets_provider_and_model() {
+        let l = launcher(serde_json::json!({}));
+        let config = l.generate_config(&binding()).unwrap();
+        assert_eq!(config["brain"]["provider"], "ollama");
+        assert_eq!(config["brain"]["model"], "mistral/mistral-large-v0.2");
+        assert_eq!(config["brain"]["maxTokens"], serde_json::json!(131072));
+    }
+
+    #[test]
+    fn generate_config_sets_local_endpoint() {
+        let l = launcher(serde_json::json!({}));
+        let config = l.generate_config(&binding()).unwrap();
+        assert_eq!(config["brain"]["local"]["endpoint"], "http://localhost:11434");
+        assert_eq!(config["brain"]["local"]["model"], "mistral/mistral-large-v0.2");
+    }
+
+    #[test]
+    fn generate_config_omits_context_length_when_none() {
+        let b = AgentModelBinding {
+            context_length: None,
+            ..binding()
+        };
+        let l = launcher(serde_json::json!({}));
+        let config = l.generate_config(&b).unwrap();
+        assert!(!config["brain"].get("maxTokens").is_some());
+    }
+
+    // -- env overlay -----------------------------------------------------------
+
+    #[tokio::test]
+    async fn env_overlay_is_empty_without_a_binding() {
+        let overlay = launcher(serde_json::json!({}))
+            .env_overlay(&ctx(false))
+            .await
+            .unwrap();
+        assert!(overlay.is_empty());
+    }
+
+    #[tokio::test]
+    async fn env_overlay_sets_openclaw_config_path_when_bound() {
+        let overlay = bound(serde_json::json!({}), binding())
+            .env_overlay(&ctx(false))
+            .await
+            .unwrap();
+        let config_path = overlay
+            .iter()
+            .find(|b| b.key == "OPENCLAW_CONFIG_PATH")
+            .expect("OPENCLAW_CONFIG_PATH env");
+        assert!(config_path.value.ends_with("launcher-state/openclaw/openclaw.json"));
+    }
+
+    #[tokio::test]
+    async fn env_overlay_sets_openclaw_provider_and_model() {
+        let overlay = bound(serde_json::json!({}), binding())
+            .env_overlay(&ctx(false))
+            .await
+            .unwrap();
+        let provider = overlay
+            .iter()
+            .find(|b| b.key == "OPENCLAW_PROVIDER")
+            .expect("OPENCLAW_PROVIDER env");
+        assert_eq!(provider.value, "ollama");
+        let model = overlay
+            .iter()
+            .find(|b| b.key == "OPENCLAW_MODEL")
+            .expect("OPENCLAW_MODEL env");
+        assert_eq!(model.value, "mistral/mistral-large-v0.2");
+    }
+
+    #[tokio::test]
+    async fn env_overlay_sets_openclaw_local_endpoint() {
+        let overlay = bound(serde_json::json!({}), binding())
+            .env_overlay(&ctx(false))
+            .await
+            .unwrap();
+        let endpoint = overlay
+            .iter()
+            .find(|b| b.key == "OPENCLAW_LOCAL_ENDPOINT")
+            .expect("OPENCLAW_LOCAL_ENDPOINT env");
+        assert_eq!(endpoint.value, "http://localhost:11434");
+    }
+
+    #[tokio::test]
+    async fn env_overlay_sets_openclaw_max_tokens() {
+        let overlay = bound(serde_json::json!({}), binding())
+            .env_overlay(&ctx(false))
+            .await
+            .unwrap();
+        let max_tokens = overlay
+            .iter()
+            .find(|b| b.key == "OPENCLAW_MAX_TOKENS")
+            .expect("OPENCLAW_MAX_TOKENS env");
+        assert_eq!(max_tokens.value, "131072");
+    }
+
+    // -- launch ---------------------------------------------------------------
+
+    #[tokio::test]
+    async fn launch_without_binding_passes_args_through_unchanged() {
+        let l = launcher(serde_json::json!({ "command_path": "ls" }));
+        let ui = CaptureUi::default();
+        l.launch(&["--version".to_string()], &ctx(true), &ui)
+            .await
+            .unwrap();
+
+        let infos = ui.infos.borrow();
+        assert!(infos.iter().any(|m| m.contains("--version")));
+        // Without a binding there is no OPENCLAW_* env override.
+        assert!(!infos.iter().any(|m| m.contains("OPENCLAW_PROVIDER")));
+    }
+}

--- a/src/launchers/openclaw.rs
+++ b/src/launchers/openclaw.rs
@@ -316,7 +316,6 @@ mod tests {
             api_key: None,
             verify_ssl: true,
             context_length: Some(131072),
-            temperature: None,
         }
     }
 

--- a/src/launchers/openclaw.rs
+++ b/src/launchers/openclaw.rs
@@ -8,7 +8,9 @@
 //! OpenCode's `OPENCODE_CONFIG`. The user's own `~/.openclaw/openclaw.json`
 //! is never touched.
 
-use crate::capabilities::{AgentModelBinding, ApiType, Binding, BindingType, Capability, McpBinding};
+use crate::capabilities::{
+    AgentModelBinding, ApiType, Binding, BindingType, Capability, McpBinding,
+};
 use crate::launchers::base::{EnvBinding, LaunchContext, Launcher, LauncherMetadata, run_command};
 use crate::launchers::shared::mcp_cli::mcp_binding_request;
 use crate::registry::ConfigConstructable;
@@ -360,7 +362,10 @@ mod tests {
         let meta = OpenClawLauncher::metadata();
         assert_eq!(meta.name, "OpenClaw CLI");
         assert_eq!(meta.default_command, "openclaw");
-        assert!(meta.supported_capabilities.contains(&BindingType::AgentModel));
+        assert!(
+            meta.supported_capabilities
+                .contains(&BindingType::AgentModel)
+        );
         assert!(meta.supported_capabilities.contains(&BindingType::Mcp));
     }
 
@@ -415,11 +420,16 @@ mod tests {
             config["models"]["providers"]["my-ollama"]["models"][0]["contextWindow"],
             131072
         );
-        assert_eq!(config["agents"]["defaults"]["model"], "my-ollama/granite4.1:8b");
+        assert_eq!(
+            config["agents"]["defaults"]["model"],
+            "my-ollama/granite4.1:8b"
+        );
         // No key means no apiKey field at all.
-        assert!(config["models"]["providers"]["my-ollama"]
-            .get("apiKey")
-            .is_none());
+        assert!(
+            config["models"]["providers"]["my-ollama"]
+                .get("apiKey")
+                .is_none()
+        );
     }
 
     #[test]
@@ -429,7 +439,10 @@ mod tests {
             ..binding()
         };
         let config = generate_config(Some(&b), &[]);
-        assert_eq!(config["models"]["providers"]["my-ollama"]["apiKey"], "sk-test");
+        assert_eq!(
+            config["models"]["providers"]["my-ollama"]["apiKey"],
+            "sk-test"
+        );
     }
 
     #[test]
@@ -440,7 +453,10 @@ mod tests {
         };
         let config = generate_config(None, &[("vision".to_string(), mcp_binding)]);
         assert!(config.get("models").is_none());
-        assert_eq!(config["mcp"]["servers"]["vision"]["url"], "http://127.0.0.1:9999");
+        assert_eq!(
+            config["mcp"]["servers"]["vision"]["url"],
+            "http://127.0.0.1:9999"
+        );
         assert_eq!(
             config["mcp"]["servers"]["vision"]["transport"],
             "streamable-http"
@@ -485,7 +501,9 @@ mod tests {
             .find(|b| b.key == "OPENCLAW_CONFIG_PATH")
             .expect("config redirect");
         assert!(
-            config.value.ends_with("launcher-state/openclaw/openclaw.json"),
+            config
+                .value
+                .ends_with("launcher-state/openclaw/openclaw.json"),
             "{}",
             config.value
         );
@@ -511,7 +529,9 @@ mod tests {
 
         let infos = ui.infos.borrow();
         assert!(
-            infos.iter().any(|m| m.contains("Would write OpenClaw config")),
+            infos
+                .iter()
+                .any(|m| m.contains("Would write OpenClaw config")),
             "expected a dry-run notice, got {infos:?}"
         );
         assert!(
@@ -539,7 +559,11 @@ mod tests {
 
         let infos = ui.infos.borrow();
         assert!(infos.iter().any(|m| m.contains("args: --version")));
-        assert!(!infos.iter().any(|m| m.contains("Would write OpenClaw config")));
+        assert!(
+            !infos
+                .iter()
+                .any(|m| m.contains("Would write OpenClaw config"))
+        );
         assert!(!infos.iter().any(|m| m.contains(CONFIG_ENV)));
     }
 }

--- a/src/launchers/opencode.rs
+++ b/src/launchers/opencode.rs
@@ -153,18 +153,17 @@ impl Launcher for OpenCodeLauncher {
                 value: opencode_config_path(ctx)?.to_string_lossy().to_string(),
             });
 
-            if let Some(binding) = &self.bound_agent_model {
-                if let Some(api_key) = binding
+            if let Some(binding) = &self.bound_agent_model
+                && let Some(api_key) = binding
                     .api_key
                     .as_ref()
                     .map(|api_key| api_key.0.clone())
                     .filter(|key| !key.is_empty())
-                {
-                    overlay.push(EnvBinding {
-                        key: API_KEY_ENV.to_string(),
-                        value: api_key,
-                    });
-                }
+            {
+                overlay.push(EnvBinding {
+                    key: API_KEY_ENV.to_string(),
+                    value: api_key,
+                });
             }
         }
         Ok(overlay)

--- a/src/launchers/opencode.rs
+++ b/src/launchers/opencode.rs
@@ -394,7 +394,8 @@ mod tests {
             endpoint_path: "/v1/chat/completions".to_string(),
             api_key: None,
             verify_ssl: true,
-            context_length: 131072,
+            context_length: Some(131072),
+            temperature: None,
         }
     }
 

--- a/src/launchers/opencode.rs
+++ b/src/launchers/opencode.rs
@@ -394,7 +394,6 @@ mod tests {
             api_key: None,
             verify_ssl: true,
             context_length: Some(131072),
-            temperature: None,
         }
     }
 

--- a/src/launchers/pi.rs
+++ b/src/launchers/pi.rs
@@ -467,7 +467,6 @@ mod tests {
             api_key: None,
             verify_ssl: true,
             context_length: Some(131072),
-            temperature: None,
         }
     }
 

--- a/src/launchers/pi.rs
+++ b/src/launchers/pi.rs
@@ -466,7 +466,8 @@ mod tests {
             endpoint_path: "/v1/chat/completions".to_string(),
             api_key: None,
             verify_ssl: true,
-            context_length: 131072,
+            context_length: Some(131072),
+            temperature: None,
         }
     }
 


### PR DESCRIPTION
## Description

This PR adds launcher support for `hermes`, `openclaw`, and `goose`

## Changes

- Add new launchers for `hermes`, `openclaw`, and `goose`
- Plumb through `AgentModelBinding` and `McpBinding` support for each
- Add a dockerized testing sandbox with `openclaw` and `hermes` pre-installed (should maybe add the others?)

## Testing

- Unit tests
- Installed `goose` locally and verified ability to use local model + delegate to vision MCP
- Used `agent-test` docker sandbox to test the same with `hermes` and `openclaw`

## Related Issue(s)

Closes #18 
Closes #16 
Closes #17 

## AI Usage

This PR was initialized by Herems w/ a combination of Granite and Qwen3.6-35b. It was then significantly improved by Claude Code and manual edits/reviews.

```sh
╔══════════════════════════════════════════════════════════╗
║           GIT AI USAGE ANALYSIS                          ║
╚══════════════════════════════════════════════════════════╝

📊 COMMITS BY AGENT

--- Aggregate ---
Commits                        |      Count
---------------------------------------------
Claude + Sonnet 5              |         16
none                           |          7
Hermes + Qwen3.6-35b           |          1
Claude + Sonnet 5, OpenCode + GraniteXXX |          1
Herems + GraniteXX, Herems + Qwen3.6-35b |          1
OpenCode + GraniteXXX          |          1
---------------------------------------------
TOTAL                          |         27

📊 COMMITS BY USAGE TYPE

--- Aggregate ---
Commits                        |      Count
---------------------------------------------
none                           |          7
draft                          |          6
full                           |         14
---------------------------------------------
TOTAL                          |         27

📈 LINES OF CODE BY AGENT

--- Aggregate ---
Agent                     |    Commits |  Additions |  Deletions
------------------------------------------------------------
Claude + Sonnet 5         |         16 |       3327 |       2555
none                      |          7 |         81 |         15
Hermes + Qwen3.6-35b      |          1 |       2203 |          0
Claude + Sonnet 5, OpenCode + GraniteXXX |          1 |        133 |         45
Herems + GraniteXX, Herems + Qwen3.6-35b |          1 |       1231 |          5
OpenCode + GraniteXXX     |          1 |          2 |         76
------------------------------------------------------------
TOTAL                     |         27 |       6977 |       2696

📈 LINES OF CODE BY USAGE TYPE

--- Aggregate ---
Usage Type           |    Commits |  Additions |  Deletions
-------------------------------------------------------
none                 |          7 |         81 |         15
draft                |          6 |       1637 |        167
full                 |         14 |       5259 |       2514
-------------------------------------------------------
TOTAL                |         27 |       6977 |       2696
```