### PR TITLE
Sub agent capability 72

### DIFF
--- a/docs/specs/0021-sub-agent-capability.md
+++ b/docs/specs/0021-sub-agent-capability.md
@@ -1,0 +1,268 @@
+# Plan: Sub-Agent Capability
+
+## Overview
+
+[Issue #72](https://github.com/ibm-granite-community/granite-cli/issues/72) asks
+for a new `Capability` that defines a sub-agent — a named agent with its own
+prompt, tool allow-list, and `Model`/`Provider` — that a launched coding agent
+can delegate to, independent of whatever model the main session is using. The
+issue calls out `claude` as the launcher to start with, and flags the real
+challenge: Claude Code has exactly **one** `ANTHROPIC_BASE_URL` for an entire
+session — the main agent's calls *and* every sub-agent's calls all go through
+it. A sub-agent's `model` field, when it's an arbitrary literal string, is
+sent verbatim in the Messages API request body for that sub-agent's turns. So
+giving a sub-agent its own provider means standing up a small reverse-proxy
+("mini-router," per the issue) in front of `ANTHROPIC_BASE_URL` that inspects
+each request's `model` field: a name that belongs to a configured sub-agent
+routes to that model's real provider; anything else (the main agent's own
+traffic) routes to the normal upstream, unchanged.
+
+The load-bearing Claude Code CLI behaviors were confirmed against current
+official docs and against the `claude` binary (v2.1.238) installed in the
+development environment:
+
+- **`--agents '<json>'` exists and is session-scoped**, e.g. `claude --agents
+  '{"reviewer": {"description": "...", "prompt": "...", "tools": [...],
+  "model": "..."}}'` — confirmed directly via `claude --help`. This is the
+  exact analog of the `mcp add-json`/`mcp remove --scope local` pattern
+  `src/launchers/shared/mcp_cli.rs` already uses for MCP servers, except
+  simpler: no register/remove around the launch is needed, it's just one CLI
+  arg.
+- **Custom model strings pass through unvalidated** once `ANTHROPIC_BASE_URL`
+  is non-default — Claude Code only validates model strings against the
+  direct Anthropic API; behind a custom base URL, the provider/gateway
+  defines the model names and Claude Code passes any string through
+  unchecked. So the router can freely use any resolved provider-side model
+  name (the same `model_name` `AgentModelCapability`/`VisionMCPCapability`
+  already compute) as the dispatch key.
+- **Auth headers aren't forced into one mode.** Claude Code attaches whatever
+  credential it has (OAuth subscription session, `ANTHROPIC_API_KEY`,
+  `ANTHROPIC_AUTH_TOKEN`, etc.) to requests against a custom base URL the same
+  way it would against the real API; a gateway must forward those headers
+  unchanged to preserve subscription-based auth. This means the "normal
+  upstream" (unknown model) branch of the router must **pass headers through
+  untouched** rather than injecting its own credentials — this transparently
+  preserves whichever auth mode the user already has configured, including
+  subscription billing, with zero credential-handling code of our own.
+- **Default real upstream** is `https://api.anthropic.com`, overridable via
+  `ANTHROPIC_BASE_URL` — this is the "read from env with fallback to a
+  well-known default" the issue asks for, applied to granite-cli's *own*
+  process environment (so a user who already points `ANTHROPIC_BASE_URL` at a
+  corporate gateway keeps working).
+
+The result: no dialect translation is needed, no credential-juggling for the
+subscription case, and no Anthropic-specific request/response parsing beyond
+reading one JSON field to pick a destination.
+
+### Key design decisions
+
+- **`ConfiguredModel` helper (`src/models/base.rs`)**: `AgentModelCapability`
+  and `VisionMCPCapability` each duplicated "resolve `model_id` through
+  `ModelSource`, remember any pinned variant, resolve that variant, then
+  check provider/api-type/function support and compute the provider-specific
+  model name." Factored into `ConfiguredModel`, shared by all three
+  model-backed capabilities, so `SubAgentCapability` doesn't add a third
+  copy. `resolve_provider_endpoint` takes `required_function` and
+  `endpoint_function` as separate parameters specifically because
+  `VisionMCPCapability` needs them to differ (model must support
+  `ImageUnderstanding`, but the endpoint is looked up via `Chat`).
+- **`SubAgentBinding` reuses `AgentModelBinding` by composition** rather than
+  duplicating connection fields (base_url, model_name, api_key, verify_ssl,
+  endpoint_path, context_length).
+- **The mini-router (`ModelRouter`, `src/launchers/shared/model_router.rs`)
+  is launcher-side plumbing, not capability-side** — only a launcher sees
+  every bound capability at once, so only it can build the full
+  model-name-to-target routing table. Placed alongside `mcp_cli.rs`, the
+  existing precedent for launcher-side helpers that turn one `BindingType`'s
+  bindings into something a downstream CLI tool understands.
+- **The router is deliberately not Anthropic-specific in its mechanics** — it
+  only reads a top-level JSON `"model"` string, a shape OpenAI/Ollama-style
+  bodies share too, even though Claude/Anthropic is its first and only
+  consumer.
+- **`v1` requires the sub-agent's provider to itself support
+  `ApiType::Anthropic`** — same restriction `AgentModelCapability` already
+  has for the main model. No Anthropic Messages ⟷ OpenAI Chat Completions
+  translation is attempted.
+- **Usage tracking composes underneath this for free.** Because
+  `SubAgentCapability` resolves its model through `ConfiguredModel::resolve`
+  → `ModelSource::take`, exactly like `AgentModelCapability`, a
+  usage-tracking session (spec 0020) transparently wraps it the same way —
+  no changes needed there.
+
+## Out of Scope (Future Work)
+
+**Dialect translation.** Serving a sub-agent off an OpenAI-only provider by
+translating Anthropic Messages ⟷ OpenAI Chat Completions on the fly. Today
+that means Ollama, LM Studio, and llama.cpp (the only providers that
+advertise `ApiType::Anthropic`) are the usable backends for a sub-agent.
+
+**Bedrock/Vertex/Foundry auth modes** for the "real upstream" fallback — only
+the direct-Anthropic-API credential precedence is exercised; passthrough
+mode doesn't care which credential scheme it's carrying, but genuinely
+cloud-provider-specific request signing is not something this proxy
+attempts.
+
+**Any launcher other than `claude`.** `pi`, `bob`, and `opencode` are
+unaffected — they simply don't declare `BindingType::SubAgent` in their
+`supported_capabilities`, so the existing subset check in
+`bind_capability`/`select_capabilities` rejects enabling a `SubAgentCapability`
+for them, the same way it already rejects any other unsupported binding
+type.
+
+**Cost/pricing accounting for subscription vs. API-key billing** — per the
+issue's own caveat.
+
+---
+
+## Sub-Tasks
+
+---
+
+### Sub-Task 1 — `ConfiguredModel` shared helper (`src/models/base.rs`)
+
+**Intent**
+Deduplicate the model-resolution logic `AgentModelCapability` and
+`VisionMCPCapability` each carried inline before `SubAgentCapability` would
+have become a third copy.
+
+**Expected Outcomes**
+- `ConfiguredModel { pub model: Arc<dyn Model>, configured_variant: Option<String> }`.
+- `ConfiguredModel::resolve(model_id, global_config)` — same
+  `ModelSource::from_config` + `take` + panic-on-missing resolution every
+  capability's `ConfigConstructable::new` did inline.
+- `ConfiguredModel::resolve_variant()` — case-insensitive `"format/precision"`
+  lookup against the model's catalog variants.
+- `ConfiguredModel::resolve_provider_endpoint(model_id, api_type,
+  required_function, endpoint_function) -> anyhow::Result<(Box<dyn Provider>,
+  ApiEndpoint, String)>` — resolves the provider, checks `api_type` and
+  `required_function` support, finds the `endpoint_function`/`api_type`
+  endpoint, and computes the provider-specific model name/alias.
+- `AgentModelCapability` and `VisionMCPCapability` updated to hold a
+  `configured_model: ConfiguredModel` field and call
+  `resolve_provider_endpoint` instead of their own inline checks. One
+  defensive check (`provider.supports_function`, redundant with a successful
+  endpoint lookup) is dropped as part of unifying the two shapes; two
+  existing tests' expected error substrings were updated to match the
+  resulting wording (still an error on the same condition, just reworded).
+
+**Status** — `[x] done`
+
+---
+
+### Sub-Task 2 — `BindingType::SubAgent` (`src/capabilities/base.rs`)
+
+**Intent**
+Declare the new binding surface alongside `AgentModel`/`Mcp`.
+
+**Expected Outcomes**
+- `SubAgentBindingRequest { api_type: ApiType }` — mirrors
+  `AgentModelBindingRequest`.
+- `SubAgentBinding { description: String, prompt: String, tools: Vec<String>,
+  model: AgentModelBinding }`.
+- Added to the `define_bindings!` macro invocation.
+
+**Status** — `[x] done`
+
+---
+
+### Sub-Task 3 — `SubAgentCapability` (`src/capabilities/sub_agent.rs`)
+
+**Intent**
+The capability itself: config, dependency declaration, and `bind()`.
+
+**Expected Outcomes**
+- Config: `{ description, prompt, tools: Vec<String> (default empty),
+  model_id }`, all but `tools` required (`min_length = 1`).
+- No separate `name` field — the capability's own `instance_id` is the
+  sub-agent's name (the key in the `--agents` JSON map), the same convention
+  `VisionMCPCapability` uses for its MCP server name.
+- `dependencies()`: one `Dependency::Model` requiring `[Chat, ToolCalling]`.
+- `bind()` calls `configured_model.resolve_provider_endpoint(model_id,
+  api_type, Chat, Chat)` and wraps the result into `SubAgentBinding`.
+- Registered as `"sub-agent"` in `CAPABILITY_REGISTRY`.
+
+**Status** — `[x] done`
+
+---
+
+### Sub-Task 4 — Mini-router (`src/launchers/shared/model_router.rs`)
+
+**Intent**
+The reverse-proxy that makes per-sub-agent routing possible under Claude
+Code's single `ANTHROPIC_BASE_URL`.
+
+**Expected Outcomes**
+- `UpstreamTarget { base_url, verify_ssl, auth: UpstreamAuth }`,
+  `UpstreamAuth::Inject(Option<Secret>)` (strip client auth, inject this) or
+  `UpstreamAuth::Passthrough` (forward client auth headers byte-for-byte).
+- `ModelRouter::start(default: UpstreamTarget, routes: HashMap<String,
+  UpstreamTarget>) -> anyhow::Result<Self>` — synchronous, built on
+  `SubServer::spawn`. Exposes `local_base_url`; `shutdown(self)` is async.
+- The handler buffers the request body, best-effort parses it as JSON and
+  reads a top-level `"model"` string; a match against `routes` selects that
+  target, anything else (parse failure, missing field, no match) falls
+  through to `default`. Forwards method/path/query/headers (minus
+  hop-by-hop headers) to the target, applying its `auth` mode; streams the
+  response back unmodified.
+
+**Status** — `[x] done`
+
+---
+
+### Sub-Task 5 — `ClaudeLauncher` wiring (`src/launchers/claude.rs`)
+
+**Intent**
+Bind `SubAgentCapability` instances, build the `--agents` JSON, and start the
+router only when at least one sub-agent is bound.
+
+**Expected Outcomes**
+- `bound_sub_agents: Vec<(String, SubAgentBinding)>` field; `bind_capability`
+  gains a `BindingType::SubAgent` branch (checked before the `Mcp` branch and
+  the `AgentModel` fallthrough).
+- `LauncherMetadata::supported_capabilities` gains `BindingType::SubAgent`.
+- `launch()`: builds the overlay via the existing `env_overlay()`
+  (unchanged), then — when `bound_sub_agents` is non-empty and not
+  `ctx.dry_run` — builds the router's `default` target from
+  `bound_agent_model` if present (`Inject`) else from the ambient
+  `ANTHROPIC_BASE_URL` env var or the well-known fallback (`Passthrough`),
+  builds `routes` from every bound sub-agent's `model.model_name`, starts the
+  `ModelRouter`, and overrides just the `ANTHROPIC_BASE_URL` overlay entry
+  with the router's local address. `--agents <json>` is prepended to the exec
+  args when any sub-agent is bound; the router is shut down after the
+  process exits.
+- Under `--dry-run`, no socket is started, but the overlay still gets a
+  placeholder value and `--agents` is still shown, so the dry-run output
+  stays informative.
+
+**Status** — `[x] done`
+
+---
+
+### Sub-Task 6 — Tests
+
+**Intent**
+Cover the new resolution helper, the capability, the router's dispatch
+logic, and the launcher wiring — without needing a real provider or a real
+`claude` invocation.
+
+**Expected Outcomes**
+- `src/models/base.rs`: `ConfiguredModel::resolve_provider_endpoint` tests
+  covering the success path, each failure mode, the
+  required-function-vs-endpoint-function-differ case (mirroring
+  `VisionMCPCapability`), and alias resolution.
+- `src/capabilities/sub_agent.rs`: `bind()` success (carries
+  description/prompt/tools and connection details), failure modes, binding
+  type/dependency/metadata checks — mirroring `agent_model.rs`'s test-double
+  pattern.
+- `src/launchers/shared/model_router.rs`: end-to-end tests with two real
+  fake upstream HTTP servers verifying model-based dispatch with injected
+  auth, default fallback for an unknown model, passthrough leaving client
+  auth untouched, and graceful fallback for a non-JSON body.
+- `src/launchers/claude.rs`: `build_agents_json` shape (tools omitted when
+  empty, included when present, multiple sub-agents), `default_upstream_target`
+  (well-known fallback, ambient env override, main-model binding takes
+  precedence over the ambient env), `set_env_binding` (overwrite vs. append),
+  and `bind_capability` pushing a `SubAgent` binding via a minimal
+  `Capability` test double.
+
+**Status** — `[x] done`

--- a/docs/specs/0022-tool-name-abstraction.md
+++ b/docs/specs/0022-tool-name-abstraction.md
@@ -1,0 +1,177 @@
+# Plan: Launcher-Agnostic Tool-Name Abstraction + Schema-Driven Enum Prompting
+
+## Overview
+
+`SubAgentCapability` (spec [0021](0021-sub-agent-capability.md)) carried
+`tools: Vec<String>` straight through from user config into `ClaudeLauncher`'s
+`--agents` JSON, unmodified — Claude Code-specific strings baked into a
+capability that's meant to be launcher-agnostic. This plan replaces that with
+a canonical `ToolName` enum (with an `Other(String)` escape hatch) mapped to
+each launcher's own native strings via a per-launcher function — the same
+shape `pi.rs` already uses for `ApiType` (`pi_api_name`), generalized and
+made a proper `Launcher` trait extension point since more launchers are
+expected to implement it over time. It also matters for where the project is
+headed: `SubAgentCapability` is meant to become the generic fallback once
+pre-baked sub-agents (e.g. "Explore," "Research") exist, and those need to
+specify a sensible tool set in Rust, independent of whichever launcher ends
+up running them.
+
+Making `ToolName` a real config field type (`Vec<ToolName>`, not a
+stringly-typed workaround with a parsing layer) surfaced a genuine gap: the
+schema-driven setup wizard (`src/utils/ui/prompt.rs`) had no rendering path
+for enums at all — a plain enum degraded to free-text entry (the schema's
+`enum` constraint silently ignored), and a mixed enum with data-carrying
+variants degraded further to broken `null` array entries. Rather than route
+around this, the wizard itself was fixed: generic Select/Multi-Select
+rendering for enum-shaped schemas, driven by the name↔string mapping the
+schema already carries. This benefits every future enum-typed config field,
+not just this one.
+
+### Key design decisions
+
+- **`map_tool_name` returns `Option<String>`, not `Result`** (unlike
+  `pi_api_name`), because a sub-agent's `tools` is a list — one unmappable
+  entry shouldn't sink the rest. The caller (`ClaudeLauncher::build_agents_json`)
+  skips-with-a-warning per entry instead of failing the whole bind.
+- **Exact schema shape confirmed by reading the vendored `schemars_derive`
+  1.2.1 source** (not guessed): a mixed externally-tagged enum renders as
+  `oneOf: [{"type":"string","enum":[<all unit variants>]}, {"type":"object","properties":{"<Variant>":<fields>},"required":["<Variant>"]}, ...]` —
+  one alternative for all unit variants "grouped together, one per
+  data-carrying variant, each a single-property object keyed by its own
+  variant name. A pure unit-only enum skips the `oneOf` wrapper and *is*
+  that first alternative directly. This uniform shape is what let one
+  generic detector (`enum_choices`) handle both the plain and mixed cases,
+  and was verified empirically via a `CaptureUi`-driven round-trip test
+  against a real `#[derive(schemars::JsonSchema)]` enum, not just schema
+  literals.
+- **The wizard's new enum support is fully generic**, not `ToolName`-specific:
+  any future enum-typed config field (unit-only, or mixed with tagged
+  variants) gets Select/Multi-Select rendering for free.
+- **`ToolName`'s starter set is deliberately small** (`FileRead`,
+  `FileWrite`, `FileEdit`, `Search`, `FileSearch`, `Shell`, `WebFetch`,
+  `WebSearch`, plus `Mcp{server,tool}` and `Other`) — enough for a generic
+  coding sub-agent and for "Explore"/"Research"-shaped pre-baked agents
+  (read/search/web, no write/shell), expected to grow incrementally rather
+  than trying to be exhaustive now.
+
+## Out of Scope (Future Work)
+
+- `pi`/`bob`/`opencode` implementing `BindingType::SubAgent` or their own
+  `map_tool_name` — no launcher-specific subagent mechanism exists yet in
+  those tools' integration code to map onto.
+- Cross-checking that an `Mcp{server, ..}` reference matches a capability
+  actually bound on the same launcher — a typo'd server name silently
+  resolves to nothing downstream, same as today's raw strings.
+- Other wizard gaps: enum-keyed maps, untagged/internally-tagged enums.
+  Only the externally-tagged shape schemars derives by default is handled.
+- Pre-baked sub-agent capabilities (Explore/Research) themselves.
+
+---
+
+## Sub-Tasks
+
+---
+
+### Sub-Task 1 — Generic enum prompting (`src/utils/ui/prompt.rs`)
+
+**Intent**
+Make the schema-driven setup wizard render Select/Multi-Select for
+enum-shaped schema nodes, so `ToolName` (and any future enum-typed config
+field) doesn't need a stringly-typed workaround.
+
+**Expected Outcomes**
+- `EnumChoice { Literal(String), Tagged { key: String, schema: Value } }` and
+  `fn enum_choices(root: &Value, node: &Value) -> Option<Vec<EnumChoice>>`,
+  detecting a plain `{"type":"string","enum":[...]}` node or a `oneOf` mixing
+  that shape with single-property tagged object alternatives. `None` for
+  anything else.
+- `prompt_enum_scalar` (Select one choice; `Tagged` recurses into
+  `prompt_value` for its sub-schema, wrapping the result as `{key: value}`)
+  and `prompt_enum_array` (one-shot Multi-Select over an all-`Literal`
+  array).
+- `prompt_value` dispatches to `prompt_enum_scalar` before the existing
+  `get_promptable_type` match; `prompt_object`'s per-property skip check no
+  longer drops enum-typed properties; `prompt_array` uses `prompt_enum_array`
+  for a pure-literal items schema, or `prompt_enum_scalar` per iteration of
+  the existing "Add another?" loop for a mixed one.
+- Zero behavior change for any non-enum schema (verified: all 10 pre-existing
+  tests in this file still pass unmodified).
+
+**Status** — `[x] done`
+
+---
+
+### Sub-Task 2 — `ToolName` enum (`src/capabilities/base.rs`)
+
+**Intent**
+The canonical, launcher-agnostic tool-name representation.
+
+**Expected Outcomes**
+- `ToolName` enum (see starter set above), deriving `Serialize`,
+  `Deserialize`, `schemars::JsonSchema` — no custom parsing needed, since
+  Sub-Task 1 makes it round-trip through config/schema directly.
+- `SubAgentBinding.tools` and `SubAgentCapabilityConfig.tools` both
+  `Vec<ToolName>` (`sub_agent.rs`'s `bind()` needed no other change —
+  `tools: self.config.tools.clone()` already worked once both sides agreed
+  on the element type).
+
+**Status** — `[x] done`
+
+---
+
+### Sub-Task 3 — `Launcher::map_tool_name` (`src/launchers/base.rs`)
+
+**Intent**
+The per-launcher mapping extension point.
+
+**Expected Outcomes**
+- `fn map_tool_name(&self, tool: &ToolName) -> Option<String>` on the
+  `Launcher` trait, default: `Other` passes through verbatim, every other
+  variant returns `None` — mirrors `env_overlay`'s "no-op until you actually
+  support the feature" default, so `pi`/`bob`/`opencode` need no changes.
+
+**Status** — `[x] done`
+
+---
+
+### Sub-Task 4 — `ClaudeLauncher` wiring (`src/launchers/claude.rs`)
+
+**Intent**
+Give Claude Code's sub-agents real, correct tool names instead of an opaque
+passthrough.
+
+**Expected Outcomes**
+- `map_tool_name` override covering all 8 canonical variants plus
+  `Mcp{server,tool}` → `mcp__<server>[__<tool>]` and `Other` → itself.
+- `build_agents_json` (previously `serde_json::json!(binding.tools)`
+  verbatim) now maps each `ToolName` via `self.map_tool_name`, skipping (and
+  `ui.warn`-ing, per sub-agent) anything with no mapping — needed `ui: &dyn
+  Ui` threaded in from `launch()`.
+
+**Status** — `[x] done`
+
+---
+
+### Sub-Task 5 — Tests
+
+**Intent**
+Cover the new wizard mechanics end-to-end (not just the detection heuristic
+in isolation), the enum itself, the trait default, and the launcher mapping.
+
+**Expected Outcomes**
+- `prompt.rs`: unit tests on `enum_choices` (pure enum, mixed with tagged
+  variants, non-enum schemas, malformed `oneOf` alternatives), plus two
+  `CaptureUi`-driven round-trip tests against a real derived mixed test enum
+  (one picking a tagged variant and filling its sub-fields, one picking a
+  plain literal) and one against a pure unit-only test enum proving the
+  one-shot Multi-Select path.
+- `sub_agent.rs`: `bind()` test updated to construct `Vec<ToolName>`
+  (a canonical name, and the `Other` escape hatch) and assert the binding
+  carries them.
+- `launchers/base.rs`: `map_tool_name`'s default behavior via the existing
+  `FakeLauncher` double.
+- `launchers/claude.rs`: every canonical variant's mapping, `Mcp` formatting
+  with/without a specific tool, `Other` passthrough; `build_agents_json`
+  tests updated to construct `ToolName` values.
+
+**Status** — `[x] done`

--- a/src/capabilities/agent_model.rs
+++ b/src/capabilities/agent_model.rs
@@ -7,13 +7,12 @@ use crate::capabilities::base::{
     CapabilityMetadata, Dependency, HasCapabilityMetadata,
 };
 use crate::capabilities::requirement::ModelRequirement;
-use crate::models::{Model, ModelFunction};
+use crate::models::{ConfiguredModel, ModelFunction};
 use crate::registry::ConfigConstructable;
 use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
 use serde_valid::Validate;
 use std::collections::HashSet;
-use std::sync::Arc;
 
 /*-- AgentModelCapabilityConfig ---------------------------------------------------*/
 
@@ -29,20 +28,17 @@ pub struct AgentModelCapabilityConfig {
 pub struct AgentModelCapability {
     instance_id: String,
     config: AgentModelCapabilityConfig,
-    model: Arc<dyn Model>,
-    /// The raw `"format/precision"` string from `ModelConfig.variant`, if the
-    /// user configured a specific variant. Used at bind time to resolve the
-    /// provider-specific model alias.
-    configured_variant: Option<String>,
+    configured_model: ConfiguredModel,
 }
 
 impl ConfigConstructable for AgentModelCapability {
     type Config = AgentModelCapabilityConfig;
 
     /// Constructs the capability by resolving its model through
-    /// `ModelSource`, which handles provider resolution (so `model.provider()`
-    /// works at bind time) and, when a usage-tracking session is active,
-    /// transparently wraps the model in a local tracking proxy.
+    /// `ConfiguredModel`, which handles provider resolution (so
+    /// `model.provider()` works at bind time) and, when a usage-tracking
+    /// session is active, transparently wraps the model in a local tracking
+    /// proxy.
     ///
     /// `cfg` contains the capability's instance config (e.g. `{"model_id": "my-model"}`)
     /// where `model_id` is the key into `global_config.models`. The resolved
@@ -54,22 +50,11 @@ impl ConfigConstructable for AgentModelCapability {
     ) -> Self {
         let config: AgentModelCapabilityConfig =
             serde_json::from_value(cfg.clone()).unwrap_or_default();
-        let mut source = crate::models::ModelSource::from_config(global_config);
-        let model = source.take(&config.model_id).unwrap_or_else(|| {
-            panic!(
-                "Configured model '{}' not found or could not be constructed",
-                config.model_id
-            )
-        });
-        let configured_variant = global_config
-            .models
-            .get(&config.model_id)
-            .and_then(|mc| mc.variant.clone());
+        let configured_model = ConfiguredModel::resolve(&config.model_id, global_config);
         Self {
             instance_id: instance_id.to_string(),
             config,
-            model,
-            configured_variant,
+            configured_model,
         }
     }
 }
@@ -83,17 +68,6 @@ impl crate::registry::Named for AgentModelCapability {
 impl AgentModelCapability {
     pub fn configured_model_id(&self) -> &str {
         &self.config.model_id
-    }
-
-    /// Resolves `configured_variant` (stored as `"format/precision"`) to the
-    /// matching `ModelVariant` in the model's catalog variants, using the same
-    /// case-insensitive lookup as the pull command.
-    fn resolve_variant<'a>(&self, model: &'a dyn Model) -> Option<&'a crate::models::ModelVariant> {
-        let variant_str = self.configured_variant.as_deref()?;
-        let (format, precision) = variant_str.split_once('/')?;
-        model.variants().iter().find(|v| {
-            v.format.eq_ignore_ascii_case(format) && v.precision.eq_ignore_ascii_case(precision)
-        })
     }
 }
 
@@ -134,42 +108,12 @@ impl Capability for AgentModelCapability {
         };
         let model_id = &self.config.model_id;
 
-        let provider = self
-            .model
-            .provider()
-            .map_err(|e| anyhow::anyhow!("model '{model_id}' has no usable provider: {e}"))?;
-
-        // Primary check -- which ApiType a launcher wants is only known here.
-        anyhow::ensure!(
-            provider.supported_api_types().contains(&api_type),
-            "provider for model '{model_id}' does not support {api_type}"
-        );
-        // Defensive only: setup-time resolution already guarantees these.
-        anyhow::ensure!(
-            self.model
-                .supported_functions()
-                .contains(&ModelFunction::Chat),
-            "model '{model_id}' does not support Chat"
-        );
-        anyhow::ensure!(
-            provider.supports_function(&ModelFunction::Chat),
-            "provider for model '{model_id}' does not support Chat"
-        );
-
-        let endpoint = provider
-            .endpoints_for_function(&ModelFunction::Chat)
-            .into_iter()
-            .find(|e| e.api_type() == api_type)
-            .ok_or_else(|| {
-                anyhow::anyhow!(
-                    "provider for model '{model_id}' has no {api_type} endpoint for Chat"
-                )
-            })?;
-
-        let resolved_variant = self.resolve_variant(self.model.as_ref());
-        let model_name = provider
-            .model_alias(resolved_variant)
-            .unwrap_or_else(|| model_id.to_string());
+        let (provider, endpoint, model_name) = self.configured_model.resolve_provider_endpoint(
+            model_id,
+            api_type.clone(),
+            ModelFunction::Chat,
+            ModelFunction::Chat,
+        )?;
 
         Ok(Binding::AgentModel(AgentModelBinding {
             api_type,
@@ -179,7 +123,7 @@ impl Capability for AgentModelCapability {
             endpoint_path: endpoint.path().to_string(),
             api_key: provider.api_key().cloned(),
             verify_ssl: provider.verify_ssl(),
-            context_length: Some(self.model.context_length()),
+            context_length: Some(self.configured_model.model.context_length()),
         }))
     }
 }
@@ -210,6 +154,7 @@ impl HasCapabilityMetadata for AgentModelCapability {
 mod tests {
     use super::*;
     use crate::config::{Config, ModelConfig};
+    use crate::models::Model;
     use crate::providers::{
         ApiEndpoint, ApiType, HealthStatus, ModelFormat, Provider, ProviderError,
     };
@@ -335,12 +280,14 @@ mod tests {
         AgentModelCapability {
             instance_id: cap.instance_id,
             config: cap.config,
-            configured_variant: variant_str,
-            model: Arc::new(TestModelWithVariants {
-                supported_functions: functions,
-                provider,
-                variants,
-            }),
+            configured_model: crate::models::ConfiguredModel::for_test(
+                Arc::new(TestModelWithVariants {
+                    supported_functions: functions,
+                    provider,
+                    variants,
+                }),
+                variant_str,
+            ),
         }
     }
 
@@ -439,7 +386,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn bind_fails_when_model_has_no_provider() {
+    async fn bind_fails_when_provider_has_no_endpoints_for_function() {
         let cap = capability_with_test_model(
             vec![ModelFunction::Chat],
             FakeProvider {
@@ -459,7 +406,7 @@ mod tests {
             }))
             .await
             .unwrap_err();
-        assert!(err.to_string().contains("does not support"));
+        assert!(err.to_string().contains("has no OpenAI endpoint for Chat"));
     }
 
     #[tokio::test]

--- a/src/capabilities/base.rs
+++ b/src/capabilities/base.rs
@@ -106,6 +106,42 @@ pub struct SubAgentBindingRequest {
     pub api_type: ApiType,
 }
 
+/// Launcher-agnostic tool-name concept for `SubAgentBinding.tools` /
+/// `SubAgentCapabilityConfig.tools`. Each `Launcher` maps these to its own
+/// native tool-name strings via `Launcher::map_tool_name`; `Other` is the
+/// escape hatch for anything not covered by the canonical set, passed
+/// through verbatim by every launcher's default mapping.
+///
+/// Deliberately a small starter set -- covers what a generic coding
+/// sub-agent plausibly needs, expected to grow incrementally as pre-baked
+/// sub-agent capabilities (e.g. "Explore," "Research") are added rather
+/// than trying to be exhaustive now.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, schemars::JsonSchema)]
+pub enum ToolName {
+    FileRead,
+    FileWrite,
+    FileEdit,
+    /// Content search (e.g. grep-style).
+    Search,
+    /// Filename/path search (e.g. glob-style).
+    FileSearch,
+    /// Execute a shell command.
+    Shell,
+    WebFetch,
+    WebSearch,
+    /// An MCP-provided tool. `server` is the MCP server's configured name
+    /// (for a granite-cli-bound MCP capability, that's the capability's own
+    /// `instance_id` -- see `ClaudeLauncher::bound_mcp_bindings`). `tool` is
+    /// `None` for "every tool that server exposes," `Some(name)` for one
+    /// specific tool.
+    Mcp {
+        server: String,
+        tool: Option<String>,
+    },
+    /// Escape hatch: an exact, launcher-native tool-name string.
+    Other(String),
+}
+
 /// Result payload for `BindingType::SubAgent`: a named sub-agent's prompt,
 /// tool allow-list, and the connection details for the model it should run
 /// on. Reuses `AgentModelBinding` by composition for the connection details
@@ -117,7 +153,7 @@ pub struct SubAgentBinding {
     /// Tool allow-list. Empty means "inherit all tools" -- callers should
     /// omit rather than send an empty list where the downstream tool
     /// distinguishes the two.
-    pub tools: Vec<String>,
+    pub tools: Vec<ToolName>,
     pub model: AgentModelBinding,
 }
 

--- a/src/capabilities/base.rs
+++ b/src/capabilities/base.rs
@@ -98,6 +98,29 @@ pub struct AgentModelBinding {
     pub context_length: Option<u64>,
 }
 
+/// Request payload for `BindingType::SubAgent` -- which `ApiType` the
+/// launcher wants the sub-agent's model to speak (mirrors
+/// `AgentModelBindingRequest`).
+#[derive(Debug, Clone)]
+pub struct SubAgentBindingRequest {
+    pub api_type: ApiType,
+}
+
+/// Result payload for `BindingType::SubAgent`: a named sub-agent's prompt,
+/// tool allow-list, and the connection details for the model it should run
+/// on. Reuses `AgentModelBinding` by composition for the connection details
+/// rather than duplicating those fields.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SubAgentBinding {
+    pub description: String,
+    pub prompt: String,
+    /// Tool allow-list. Empty means "inherit all tools" -- callers should
+    /// omit rather than send an empty list where the downstream tool
+    /// distinguishes the two.
+    pub tools: Vec<String>,
+    pub model: AgentModelBinding,
+}
+
 /// Which wire transport an MCP server binding uses. Payload-free and
 /// hashable so a `Launcher` can declare which transports it can register
 /// (per `McpBindingRequest::supported_transports`) and a `Capability` can
@@ -150,6 +173,11 @@ define_bindings! {
         request: McpBindingRequest,
         result: McpBinding,
         display: "MCP Server",
+    },
+    SubAgent {
+        request: SubAgentBindingRequest,
+        result: SubAgentBinding,
+        display: "Sub-Agent",
     },
 }
 

--- a/src/capabilities/mod.rs
+++ b/src/capabilities/mod.rs
@@ -11,6 +11,7 @@ pub static CAPABILITY_REGISTRY: LazyLock<base::CapabilityFactory> = LazyLock::ne
     let mut factory = base::CapabilityFactory::new();
     factory.register::<agent_model::AgentModelCapability>("agent-model");
     factory.register::<vision_mcp::VisionMCPCapability>("vision-mcp");
+    factory.register::<sub_agent::SubAgentCapability>("sub-agent");
     factory
 });
 
@@ -150,5 +151,10 @@ mod tests {
     #[test]
     fn capability_registry_has_agent_model() {
         assert!(CAPABILITY_REGISTRY.get("agent-model").is_some());
+    }
+
+    #[test]
+    fn capability_registry_has_sub_agent() {
+        assert!(CAPABILITY_REGISTRY.get("sub-agent").is_some());
     }
 }

--- a/src/capabilities/mod.rs
+++ b/src/capabilities/mod.rs
@@ -76,7 +76,7 @@ pub use crate::providers::ApiType;
 pub use base::{
     AgentModelBinding, AgentModelBindingRequest, Binding, BindingRequest, BindingType, Capability,
     CapabilityMetadata, Dependency, EnvBinding, LaunchContext, McpBinding, McpBindingRequest,
-    McpTransportKind,
+    McpTransportKind, SubAgentBinding, SubAgentBindingRequest,
 };
 
 mod requirement;
@@ -87,6 +87,9 @@ pub use agent_model::{AgentModelCapability, AgentModelCapabilityConfig};
 
 mod vision_mcp;
 pub use vision_mcp::{VisionMCPCapability, VisionMCPCapabilityConfig};
+
+mod sub_agent;
+pub use sub_agent::{SubAgentCapability, SubAgentCapabilityConfig};
 
 /*-- tests ---------------------------------------------------------------------*/
 

--- a/src/capabilities/mod.rs
+++ b/src/capabilities/mod.rs
@@ -76,7 +76,7 @@ pub use crate::providers::ApiType;
 pub use base::{
     AgentModelBinding, AgentModelBindingRequest, Binding, BindingRequest, BindingType, Capability,
     CapabilityMetadata, Dependency, EnvBinding, LaunchContext, McpBinding, McpBindingRequest,
-    McpTransportKind, SubAgentBinding, SubAgentBindingRequest,
+    McpTransportKind, SubAgentBinding, SubAgentBindingRequest, ToolName,
 };
 
 mod requirement;

--- a/src/capabilities/sub_agent.rs
+++ b/src/capabilities/sub_agent.rs
@@ -1,0 +1,471 @@
+//! `SubAgentCapability`: defines a named sub-agent -- a prompt, a tool
+//! allow-list, and a `Model`/`Provider` of its own -- that a launched coding
+//! agent can delegate to independently of whichever model the main session
+//! uses. See `docs/specs/0021-sub-agent-capability.md`.
+
+use crate::capabilities::base::{
+    AgentModelBinding, Binding, BindingRequest, BindingType, Capability, CapabilityMetadata,
+    Dependency, HasCapabilityMetadata, SubAgentBinding, SubAgentBindingRequest, ToolName,
+};
+use crate::capabilities::requirement::ModelRequirement;
+use crate::models::{ConfiguredModel, ModelFunction};
+use crate::registry::ConfigConstructable;
+use async_trait::async_trait;
+use serde::{Deserialize, Serialize};
+use serde_valid::Validate;
+use std::collections::HashSet;
+
+/*-- SubAgentCapabilityConfig ------------------------------------------------------*/
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default, schemars::JsonSchema, Validate)]
+pub struct SubAgentCapabilityConfig {
+    /// Shown to the main agent so it can decide when to delegate to this
+    /// sub-agent -- the same role Claude Code's own subagent `description`
+    /// field plays.
+    #[validate(min_length = 1)]
+    pub description: String,
+    /// The sub-agent's system prompt.
+    #[validate(min_length = 1)]
+    pub prompt: String,
+    /// Tool allow-list. Empty (the default) means "inherit all tools."
+    #[serde(default)]
+    pub tools: Vec<ToolName>,
+    /// Key into the configured models map (the user-chosen instance ID) for
+    /// the model this sub-agent runs on.
+    #[validate(min_length = 1)]
+    pub model_id: String,
+}
+
+/*-- SubAgentCapability -------------------------------------------------------------*/
+
+pub struct SubAgentCapability {
+    instance_id: String,
+    config: SubAgentCapabilityConfig,
+    configured_model: ConfiguredModel,
+}
+
+impl ConfigConstructable for SubAgentCapability {
+    type Config = SubAgentCapabilityConfig;
+
+    /// Constructs the capability by resolving its model through
+    /// `ConfiguredModel`, exactly like `AgentModelCapability::new` -- so
+    /// `model.provider()` works at bind time and, when a usage-tracking
+    /// session is active, the model is transparently tracked.
+    fn new(
+        instance_id: &str,
+        cfg: &serde_json::Value,
+        global_config: &crate::config::Config,
+    ) -> Self {
+        let config: SubAgentCapabilityConfig =
+            serde_json::from_value(cfg.clone()).unwrap_or_default();
+        let configured_model = ConfiguredModel::resolve(&config.model_id, global_config);
+        Self {
+            instance_id: instance_id.to_string(),
+            config,
+            configured_model,
+        }
+    }
+}
+
+impl crate::registry::Named for SubAgentCapability {
+    fn instance_id(&self) -> &str {
+        &self.instance_id
+    }
+}
+
+#[async_trait]
+impl Capability for SubAgentCapability {
+    fn name(&self) -> &str {
+        "Sub-Agent"
+    }
+
+    fn description(&self) -> &str {
+        "Defines a named sub-agent (prompt, tool allow-list, and model) that a launched coding agent can delegate to."
+    }
+
+    fn dependencies(&self) -> Vec<Dependency> {
+        vec![Dependency::Model {
+            config_key: "model_id".to_string(),
+            requirement: ModelRequirement {
+                supported_functions: vec![ModelFunction::Chat, ModelFunction::ToolCalling],
+                ..Default::default()
+            },
+            resolved_id: Some(self.config.model_id.clone()),
+            required: true,
+        }]
+    }
+
+    fn binding_types(&self) -> HashSet<BindingType> {
+        HashSet::from([BindingType::SubAgent])
+    }
+
+    async fn bind(&self, request: BindingRequest) -> anyhow::Result<Binding> {
+        let api_type = match request {
+            BindingRequest::SubAgent(SubAgentBindingRequest { api_type }) => api_type,
+            other => anyhow::bail!(
+                "SubAgentCapability does not handle {:?} binding requests",
+                other.binding_type()
+            ),
+        };
+        let model_id = &self.config.model_id;
+
+        let (provider, endpoint, model_name) = self.configured_model.resolve_provider_endpoint(
+            model_id,
+            api_type.clone(),
+            ModelFunction::Chat,
+            ModelFunction::Chat,
+        )?;
+
+        Ok(Binding::SubAgent(SubAgentBinding {
+            description: self.config.description.clone(),
+            prompt: self.config.prompt.clone(),
+            tools: self.config.tools.clone(),
+            model: AgentModelBinding {
+                api_type,
+                provider_name: provider.instance_id().to_string(),
+                base_url: provider.base_url().to_string(),
+                model_name,
+                endpoint_path: endpoint.path().to_string(),
+                api_key: provider.api_key().cloned(),
+                verify_ssl: provider.verify_ssl(),
+                context_length: self.configured_model.model.context_length(),
+            },
+        }))
+    }
+}
+
+impl HasCapabilityMetadata for SubAgentCapability {
+    fn metadata() -> CapabilityMetadata {
+        CapabilityMetadata {
+            name: "Sub-Agent".to_string(),
+            description: "Defines a named sub-agent (prompt, tool allow-list, and model) that a launched coding agent can delegate to.".to_string(),
+            dependencies: vec![Dependency::Model {
+                config_key: "model_id".to_string(),
+                requirement: ModelRequirement {
+                    supported_functions: vec![ModelFunction::Chat, ModelFunction::ToolCalling],
+                    ..Default::default()
+                },
+                resolved_id: None,
+                required: true,
+            }],
+            tags: vec!["agent".to_string(), "sub-agent".to_string()],
+            supported_binding_types: HashSet::from([BindingType::SubAgent]),
+        }
+    }
+}
+
+/*-- tests -------------------------------------------------------------------------*/
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::{Config, ModelConfig};
+    use crate::models::Model;
+    use crate::providers::{
+        ApiEndpoint, ApiType, HealthStatus, ModelFormat, Provider, ProviderError,
+    };
+    use crate::registry::Secret;
+    use std::collections::HashMap;
+    use std::sync::Arc;
+
+    #[derive(Clone, Default)]
+    struct FakeProvider {
+        instance_id: String,
+        base_url: String,
+        api_key: Option<Secret>,
+        verify_ssl: bool,
+        api_types: Vec<ApiType>,
+        endpoints: HashMap<ModelFunction, Vec<ApiEndpoint>>,
+        alias: Option<String>,
+    }
+
+    impl ConfigConstructable for FakeProvider {
+        type Config = crate::registry::NoConfig;
+        fn new(_: &str, _: &serde_json::Value, _: &crate::config::Config) -> Self {
+            unimplemented!("not used in tests")
+        }
+    }
+
+    impl crate::registry::Named for FakeProvider {
+        fn instance_id(&self) -> &str {
+            &self.instance_id
+        }
+    }
+
+    #[async_trait]
+    impl Provider for FakeProvider {
+        fn name(&self) -> &str {
+            "Fake Provider"
+        }
+        fn function_endpoints(&self) -> HashMap<ModelFunction, Vec<ApiEndpoint>> {
+            self.endpoints.clone()
+        }
+        fn supported_api_types(&self) -> Vec<ApiType> {
+            self.api_types.clone()
+        }
+        fn base_url(&self) -> &str {
+            &self.base_url
+        }
+        fn api_key(&self) -> Option<&Secret> {
+            self.api_key.as_ref()
+        }
+        fn verify_ssl(&self) -> bool {
+            self.verify_ssl
+        }
+        fn supported_formats(&self) -> Vec<ModelFormat> {
+            vec![]
+        }
+        fn model_alias(&self, _variant: Option<&crate::models::ModelVariant>) -> Option<String> {
+            self.alias.clone()
+        }
+        async fn health_check(&self) -> Result<HealthStatus, ProviderError> {
+            unimplemented!("not used in tests")
+        }
+    }
+
+    fn ok_provider() -> FakeProvider {
+        let mut endpoints = HashMap::new();
+        endpoints.insert(
+            ModelFunction::Chat,
+            vec![ApiEndpoint::OpenAIChat, ApiEndpoint::AnthropicMessages],
+        );
+        FakeProvider {
+            instance_id: "my-ollama".to_string(),
+            base_url: "http://localhost:11434".to_string(),
+            api_key: None,
+            verify_ssl: true,
+            api_types: vec![ApiType::OpenAI, ApiType::Anthropic],
+            endpoints,
+            alias: None,
+        }
+    }
+
+    struct TestModel {
+        supported_functions: Vec<ModelFunction>,
+        provider: FakeProvider,
+    }
+
+    impl ConfigConstructable for TestModel {
+        type Config = crate::registry::NoConfig;
+        fn new(_: &str, _: &serde_json::Value, _: &crate::config::Config) -> Self {
+            unimplemented!("not used in tests")
+        }
+    }
+
+    impl crate::registry::Named for TestModel {
+        fn instance_id(&self) -> &str {
+            "granite-3.1-8b-instruct"
+        }
+    }
+
+    impl Model for TestModel {
+        fn family(&self) -> &str {
+            "Test"
+        }
+        fn version(&self) -> &str {
+            "1.0"
+        }
+        fn size(&self) -> u64 {
+            1
+        }
+        fn context_length(&self) -> u64 {
+            4096
+        }
+        fn model_type(&self) -> &crate::models::ModelType {
+            &crate::models::ModelType::Text
+        }
+        fn huggingface_repo(&self) -> &str {
+            "test/test"
+        }
+        fn native_dtype(&self) -> &str {
+            "bfloat16"
+        }
+        fn architecture(&self) -> &crate::models::ModelArchitecture {
+            unimplemented!("not used in tests")
+        }
+        fn variants(&self) -> &[crate::models::ModelVariant] {
+            &[]
+        }
+        fn description(&self) -> Option<&str> {
+            None
+        }
+        fn tags(&self) -> &[String] {
+            &[]
+        }
+        fn supported_functions(&self) -> &[ModelFunction] {
+            &self.supported_functions
+        }
+        fn provider(&self) -> anyhow::Result<Box<dyn Provider>> {
+            Ok(Box::new(self.provider.clone()))
+        }
+    }
+
+    /// Builds a `SubAgentCapability` with a real registry model id (so
+    /// construction succeeds) and then swaps in a test double model/provider,
+    /// mirroring `agent_model.rs`'s test pattern.
+    fn capability_with_test_model(
+        functions: Vec<ModelFunction>,
+        provider: FakeProvider,
+    ) -> SubAgentCapability {
+        let mut config = Config::default();
+        config.models.insert(
+            "granite-3.1-8b-instruct".to_string(),
+            ModelConfig {
+                model_id: "granite-3.1-8b-instruct".to_string(),
+                provider_id: None,
+                variant: None,
+            },
+        );
+        let cap = SubAgentCapability::new(
+            "reviewer",
+            &serde_json::json!({
+                "description": "Reviews code",
+                "prompt": "You are a meticulous code reviewer.",
+                "model_id": "granite-3.1-8b-instruct",
+            }),
+            &config,
+        );
+        SubAgentCapability {
+            instance_id: cap.instance_id,
+            config: cap.config,
+            configured_model: crate::models::ConfiguredModel::for_test(
+                Arc::new(TestModel {
+                    supported_functions: functions,
+                    provider,
+                }),
+                None,
+            ),
+        }
+    }
+
+    fn request(api_type: ApiType) -> BindingRequest {
+        BindingRequest::SubAgent(SubAgentBindingRequest { api_type })
+    }
+
+    #[tokio::test]
+    async fn bind_succeeds_and_carries_description_prompt_and_tools() {
+        let mut config = Config::default();
+        config.models.insert(
+            "granite-3.1-8b-instruct".to_string(),
+            ModelConfig {
+                model_id: "granite-3.1-8b-instruct".to_string(),
+                provider_id: None,
+                variant: None,
+            },
+        );
+        let cap = SubAgentCapability::new(
+            "reviewer",
+            &serde_json::json!({
+                "description": "Reviews code",
+                "prompt": "You are a meticulous code reviewer.",
+                "tools": ["FileRead", "Search", {"Other": "SomeRawClaudeTool"}],
+                "model_id": "granite-3.1-8b-instruct",
+            }),
+            &config,
+        );
+        let cap = SubAgentCapability {
+            instance_id: cap.instance_id,
+            config: cap.config,
+            configured_model: crate::models::ConfiguredModel::for_test(
+                Arc::new(TestModel {
+                    supported_functions: vec![ModelFunction::Chat],
+                    provider: ok_provider(),
+                }),
+                None,
+            ),
+        };
+
+        let binding = cap.bind(request(ApiType::Anthropic)).await.unwrap();
+        let Binding::SubAgent(binding) = binding else {
+            panic!("expected SubAgent binding")
+        };
+        assert_eq!(binding.description, "Reviews code");
+        assert_eq!(binding.prompt, "You are a meticulous code reviewer.");
+        assert_eq!(
+            binding.tools,
+            vec![
+                ToolName::FileRead,
+                ToolName::Search,
+                ToolName::Other("SomeRawClaudeTool".to_string()),
+            ]
+        );
+        assert_eq!(binding.model.base_url, "http://localhost:11434");
+        assert_eq!(binding.model.model_name, "granite-3.1-8b-instruct");
+        assert_eq!(binding.model.api_type, ApiType::Anthropic);
+    }
+
+    #[tokio::test]
+    async fn bind_fails_when_provider_lacks_requested_api_type() {
+        let cap = capability_with_test_model(
+            vec![ModelFunction::Chat],
+            FakeProvider {
+                api_types: vec![ApiType::OpenAI],
+                ..ok_provider()
+            },
+        );
+        let err = cap
+            .bind(request(ApiType::Anthropic))
+            .await
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("does not support Anthropic"));
+    }
+
+    #[tokio::test]
+    async fn bind_fails_when_model_lacks_chat() {
+        let cap = capability_with_test_model(vec![ModelFunction::Embeddings], ok_provider());
+        let err = cap
+            .bind(request(ApiType::Anthropic))
+            .await
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("does not support Chat"));
+    }
+
+    #[tokio::test]
+    async fn bind_rejects_non_sub_agent_requests() {
+        let cap = capability_with_test_model(vec![ModelFunction::Chat], ok_provider());
+        let err = cap
+            .bind(BindingRequest::AgentModel(
+                crate::capabilities::base::AgentModelBindingRequest {
+                    api_type: ApiType::Anthropic,
+                },
+            ))
+            .await
+            .unwrap_err();
+        assert!(err.to_string().contains("does not handle"));
+    }
+
+    #[test]
+    fn binding_types_reports_sub_agent() {
+        let cap = capability_with_test_model(vec![ModelFunction::Chat], ok_provider());
+        assert_eq!(cap.binding_types(), HashSet::from([BindingType::SubAgent]));
+    }
+
+    #[test]
+    fn dependencies_carry_resolved_model_id() {
+        let cap = capability_with_test_model(vec![ModelFunction::Chat], ok_provider());
+        let deps = cap.dependencies();
+        assert_eq!(deps.len(), 1);
+        assert!(deps.iter().any(|d| matches!(
+            d,
+            Dependency::Model { resolved_id: Some(id), .. } if id == "granite-3.1-8b-instruct"
+        )));
+    }
+
+    #[test]
+    fn metadata_reports_supported_binding_types_and_wildcard_dependency() {
+        let meta = SubAgentCapability::metadata();
+        assert_eq!(
+            meta.supported_binding_types,
+            HashSet::from([BindingType::SubAgent])
+        );
+        assert!(meta.dependencies.iter().any(|d| matches!(
+            d,
+            Dependency::Model {
+                resolved_id: None,
+                ..
+            }
+        )));
+    }
+}

--- a/src/capabilities/sub_agent.rs
+++ b/src/capabilities/sub_agent.rs
@@ -128,7 +128,7 @@ impl Capability for SubAgentCapability {
                 endpoint_path: endpoint.path().to_string(),
                 api_key: provider.api_key().cloned(),
                 verify_ssl: provider.verify_ssl(),
-                context_length: self.configured_model.model.context_length(),
+                context_length: Some(self.configured_model.model.context_length()),
             },
         }))
     }

--- a/src/capabilities/vision_mcp/mod.rs
+++ b/src/capabilities/vision_mcp/mod.rs
@@ -22,7 +22,7 @@ use crate::capabilities::base::{
     HasCapabilityMetadata, LaunchContext, McpBinding, McpBindingRequest, McpTransportKind,
 };
 use crate::capabilities::requirement::ModelRequirement;
-use crate::models::{Model, ModelFunction, ModelType};
+use crate::models::{ConfiguredModel, ModelFunction, ModelType};
 use crate::providers::ApiType;
 use crate::registry::ConfigConstructable;
 use crate::utils::subserver::SubServer;
@@ -80,11 +80,7 @@ impl Default for VisionMCPCapabilityConfig {
 pub struct VisionMCPCapability {
     instance_id: String,
     config: VisionMCPCapabilityConfig,
-    model: Arc<dyn Model>,
-    /// The raw `"format/precision"` string from `ModelConfig.variant`, if the
-    /// user configured a specific variant. Used at bind time to resolve the
-    /// provider-specific model alias, mirroring `AgentModelCapability`.
-    configured_variant: Option<String>,
+    configured_model: ConfiguredModel,
     /// The in-process Streamable HTTP server started by `bind()`. `None`
     /// before `bind()` runs.
     http_server: Mutex<Option<SubServer>>,
@@ -94,7 +90,7 @@ impl ConfigConstructable for VisionMCPCapability {
     type Config = VisionMCPCapabilityConfig;
 
     /// Constructs the capability by resolving its model through
-    /// `ModelSource`, exactly like `AgentModelCapability::new` -- so
+    /// `ConfiguredModel`, exactly like `AgentModelCapability::new` -- so
     /// `model.provider()` works at bind time and, when a usage-tracking
     /// session is active, the model is transparently tracked.
     fn new(
@@ -104,22 +100,11 @@ impl ConfigConstructable for VisionMCPCapability {
     ) -> Self {
         let config: VisionMCPCapabilityConfig =
             serde_json::from_value(cfg.clone()).unwrap_or_default();
-        let mut source = crate::models::ModelSource::from_config(global_config);
-        let model = source.take(&config.model_id).unwrap_or_else(|| {
-            panic!(
-                "Configured model '{}' not found or could not be constructed",
-                config.model_id
-            )
-        });
-        let configured_variant = global_config
-            .models
-            .get(&config.model_id)
-            .and_then(|mc| mc.variant.clone());
+        let configured_model = ConfiguredModel::resolve(&config.model_id, global_config);
         Self {
             instance_id: instance_id.to_string(),
             config,
-            model,
-            configured_variant,
+            configured_model,
             http_server: Mutex::new(None),
         }
     }
@@ -128,19 +113,6 @@ impl ConfigConstructable for VisionMCPCapability {
 impl crate::registry::Named for VisionMCPCapability {
     fn instance_id(&self) -> &str {
         &self.instance_id
-    }
-}
-
-impl VisionMCPCapability {
-    /// Resolves `configured_variant` (stored as `"format/precision"`) to the
-    /// matching `ModelVariant` in the model's catalog variants -- identical
-    /// to `AgentModelCapability::resolve_variant`.
-    fn resolve_variant<'a>(&self, model: &'a dyn Model) -> Option<&'a crate::models::ModelVariant> {
-        let variant_str = self.configured_variant.as_deref()?;
-        let (format, precision) = variant_str.split_once('/')?;
-        model.variants().iter().find(|v| {
-            v.format.eq_ignore_ascii_case(format) && v.precision.eq_ignore_ascii_case(precision)
-        })
     }
 }
 
@@ -188,37 +160,18 @@ impl Capability for VisionMCPCapability {
         );
 
         let model_id = &self.config.model_id;
-        let provider = self
-            .model
-            .provider()
-            .map_err(|e| anyhow::anyhow!("model '{model_id}' has no usable provider: {e}"))?;
-
         // The vision backend speaks the OpenAI-compatible chat/vision
         // dialect, the one every granite-cli provider can serve -- same
-        // rationale as `pi`/`opencode`'s AgentModel binding.
-        anyhow::ensure!(
-            provider.supported_api_types().contains(&ApiType::OpenAI),
-            "provider for model '{model_id}' does not support an OpenAI-compatible API"
-        );
-        anyhow::ensure!(
-            self.model
-                .supported_functions()
-                .contains(&ModelFunction::ImageUnderstanding),
-            "model '{model_id}' does not support ImageUnderstanding"
-        );
-
-        let endpoint = provider
-            .endpoints_for_function(&ModelFunction::Chat)
-            .into_iter()
-            .find(|e| e.api_type() == ApiType::OpenAI)
-            .ok_or_else(|| {
-                anyhow::anyhow!("provider for model '{model_id}' has no OpenAI endpoint for Chat")
-            })?;
-
-        let resolved_variant = self.resolve_variant(self.model.as_ref());
-        let model_name = provider
-            .model_alias(resolved_variant)
-            .unwrap_or_else(|| model_id.to_string());
+        // rationale as `pi`/`opencode`'s AgentModel binding. The model must
+        // support ImageUnderstanding, but the endpoint is looked up via
+        // Chat, since that's the endpoint that actually serves vision
+        // requests.
+        let (provider, endpoint, model_name) = self.configured_model.resolve_provider_endpoint(
+            model_id,
+            ApiType::OpenAI,
+            ModelFunction::ImageUnderstanding,
+            ModelFunction::Chat,
+        )?;
 
         let vlm = OpenAiCompatibleVlm::new(
             vlm_base_url(provider.base_url(), endpoint.path()),
@@ -293,7 +246,7 @@ fn vlm_base_url(base_url: &str, endpoint_path: &str) -> String {
 mod tests {
     use super::*;
     use crate::config::{Config, ModelConfig};
-    use crate::models::ModelVariant;
+    use crate::models::{Model, ModelVariant};
     use crate::providers::{ApiEndpoint, HealthStatus, ModelFormat, Provider, ProviderError};
     use crate::registry::Secret;
     use std::collections::HashMap as StdHashMap;
@@ -451,11 +404,13 @@ mod tests {
         VisionMCPCapability {
             instance_id: cap.instance_id,
             config: cap.config,
-            configured_variant: cap.configured_variant,
-            model: Arc::new(TestVisionModel {
-                supported_functions: functions,
-                provider,
-            }),
+            configured_model: ConfiguredModel::for_test(
+                Arc::new(TestVisionModel {
+                    supported_functions: functions,
+                    provider,
+                }),
+                None,
+            ),
             http_server: Mutex::new(None),
         }
     }
@@ -549,7 +504,7 @@ mod tests {
             .unwrap_err();
         assert!(
             err.to_string()
-                .contains("does not support ImageUnderstanding")
+                .contains("does not support Image Understanding")
         );
     }
 
@@ -566,10 +521,7 @@ mod tests {
             .bind(request([McpTransportKind::Http]))
             .await
             .unwrap_err();
-        assert!(
-            err.to_string()
-                .contains("does not support an OpenAI-compatible API")
-        );
+        assert!(err.to_string().contains("does not support OpenAI"));
     }
 
     #[tokio::test]

--- a/src/launchers/base.rs
+++ b/src/launchers/base.rs
@@ -8,7 +8,7 @@ use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
 
 // Local
-use crate::capabilities::BindingType;
+use crate::capabilities::{BindingType, ToolName};
 use crate::define_factory;
 use crate::registry::ConfigConstructable;
 use crate::utils::ui::Ui;
@@ -54,6 +54,20 @@ pub trait Launcher: crate::registry::Named + Send + Sync {
     /// override this once capability hooks are wired up.
     async fn env_overlay(&self, _ctx: &LaunchContext) -> anyhow::Result<Vec<EnvBinding>> {
         Ok(vec![])
+    }
+
+    /// Maps a canonical `ToolName` to this launcher's own native tool-name
+    /// string, if it has an equivalent. Only meaningful for launchers
+    /// implementing `BindingType::SubAgent`; the default handles the escape
+    /// hatch (`ToolName::Other`, passed through verbatim) and returns `None`
+    /// for every canonical/MCP variant, mirroring `env_overlay`'s "no-op
+    /// until you actually support the feature" default -- a launcher that
+    /// hasn't implemented sub-agent support needs no changes.
+    fn map_tool_name(&self, tool: &ToolName) -> Option<String> {
+        match tool {
+            ToolName::Other(raw) => Some(raw.clone()),
+            _ => None,
+        }
     }
 
     /// Exec the tool as a subprocess with the env overlay applied.
@@ -318,6 +332,27 @@ pub(crate) mod tests {
         };
         let overlay = launcher.env_overlay(&ctx).await.unwrap();
         assert!(overlay.is_empty());
+    }
+
+    #[test]
+    fn map_tool_name_default_passes_through_other_and_returns_none_for_everything_else() {
+        let launcher = FakeLauncher::new(
+            "my-fake",
+            &serde_json::json!({}),
+            &crate::config::Config::default(),
+        );
+        assert_eq!(
+            launcher.map_tool_name(&ToolName::Other("SomeRawTool".to_string())),
+            Some("SomeRawTool".to_string())
+        );
+        assert_eq!(launcher.map_tool_name(&ToolName::FileRead), None);
+        assert_eq!(
+            launcher.map_tool_name(&ToolName::Mcp {
+                server: "vision".to_string(),
+                tool: None,
+            }),
+            None
+        );
     }
 
     #[test]

--- a/src/launchers/claude.rs
+++ b/src/launchers/claude.rs
@@ -539,7 +539,7 @@ mod tests {
                 endpoint_path: "/v1/messages".to_string(),
                 api_key: None,
                 verify_ssl: true,
-                context_length: 4096,
+                context_length: Some(4096),
             },
         }
     }
@@ -645,7 +645,7 @@ mod tests {
             endpoint_path: "/v1/messages".to_string(),
             api_key: Some(crate::registry::Secret("real-key".to_string())),
             verify_ssl: true,
-            context_length: 4096,
+            context_length: Some(4096),
         };
         let l = launcher_with(Some(main_model), vec![]);
         let target = l.default_upstream_target(Some("http://corporate-gateway.internal"));

--- a/src/launchers/claude.rs
+++ b/src/launchers/claude.rs
@@ -1,5 +1,5 @@
 // Standard
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use std::path::PathBuf;
 
 // Third Party
@@ -7,12 +7,15 @@ use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
 
 // Local
-use crate::capabilities::{Binding, BindingType, Capability, McpBinding};
+use crate::capabilities::{
+    Binding, BindingType, Capability, McpBinding, SubAgentBinding, ToolName,
+};
 use crate::launchers::base::HasLauncherMetadata as HasClaudeLauncherMetadata;
 use crate::launchers::base::{EnvBinding, LaunchContext, Launcher, LauncherMetadata, run_command};
 use crate::launchers::shared::mcp_cli::{
     mcp_binding_request, register_mcp_server, remove_mcp_server,
 };
+use crate::launchers::shared::model_router::{ModelRouter, UpstreamAuth, UpstreamTarget};
 use crate::registry::ConfigConstructable;
 use crate::utils::resolve_shell_command;
 use crate::utils::ui::Ui;
@@ -34,6 +37,12 @@ pub struct ClaudeLauncher {
     /// `(server_name, binding)` for every MCP-capable capability bound to
     /// this launcher, registered/removed around `run_command` in `launch()`.
     bound_mcp_bindings: Vec<(String, McpBinding)>,
+    /// `(name, binding)` for every `SubAgentCapability` bound to this
+    /// launcher -- `name` is the capability's own `instance_id`, used as the
+    /// sub-agent's name in the `--agents` JSON map. When non-empty, `launch()`
+    /// starts a `ModelRouter` in front of `ANTHROPIC_BASE_URL` so each
+    /// sub-agent's model reaches its own resolved provider.
+    bound_sub_agents: Vec<(String, SubAgentBinding)>,
 }
 
 impl ConfigConstructable for ClaudeLauncher {
@@ -50,6 +59,7 @@ impl ConfigConstructable for ClaudeLauncher {
             config,
             bound_agent_model: None,
             bound_mcp_bindings: vec![],
+            bound_sub_agents: vec![],
         }
     }
 }
@@ -88,6 +98,26 @@ impl Launcher for ClaudeLauncher {
                         .push((capability.instance_id().to_string(), binding));
                 }
                 other => anyhow::bail!("expected an Mcp binding, got {:?}", other.binding_type()),
+            }
+            return Ok(());
+        }
+
+        if capability_types.contains(&BindingType::SubAgent) {
+            let request = crate::capabilities::BindingRequest::SubAgent(
+                crate::capabilities::SubAgentBindingRequest {
+                    api_type: crate::providers::ApiType::Anthropic,
+                },
+            );
+            let binding = capability.bind(request).await?;
+            match binding {
+                Binding::SubAgent(binding) => {
+                    self.bound_sub_agents
+                        .push((capability.instance_id().to_string(), binding));
+                }
+                other => anyhow::bail!(
+                    "expected a SubAgent binding, got {:?}",
+                    other.binding_type()
+                ),
             }
             return Ok(());
         }
@@ -152,6 +182,29 @@ impl Launcher for ClaudeLauncher {
         }
     }
 
+    /// Maps a canonical `ToolName` onto Claude Code's own built-in tool
+    /// names (confirmed against the installed `claude` binary's compiled
+    /// tool-name table) and its `mcp__<server>[__<tool>]` MCP tool-naming
+    /// convention.
+    fn map_tool_name(&self, tool: &ToolName) -> Option<String> {
+        Some(match tool {
+            ToolName::FileRead => "Read".to_string(),
+            ToolName::FileWrite => "Write".to_string(),
+            ToolName::FileEdit => "Edit".to_string(),
+            ToolName::Search => "Grep".to_string(),
+            ToolName::FileSearch => "Glob".to_string(),
+            ToolName::Shell => "Bash".to_string(),
+            ToolName::WebFetch => "WebFetch".to_string(),
+            ToolName::WebSearch => "WebSearch".to_string(),
+            ToolName::Mcp { server, tool: None } => format!("mcp__{server}"),
+            ToolName::Mcp {
+                server,
+                tool: Some(t),
+            } => format!("mcp__{server}__{t}"),
+            ToolName::Other(raw) => raw.clone(),
+        })
+    }
+
     /// Registers each bound MCP server with `claude mcp add-json` (scoped
     /// `local` so it only applies to this invocation) before exec'ing, and
     /// best-effort removes them again afterwards -- failure to clean up is
@@ -164,20 +217,162 @@ impl Launcher for ClaudeLauncher {
         ui: &dyn Ui,
     ) -> anyhow::Result<std::process::ExitStatus> {
         let binary = self.validate_command()?;
-        let overlay = self.env_overlay(ctx).await?;
+        let mut overlay = self.env_overlay(ctx).await?;
+        let router = self.start_sub_agent_router(ctx, &mut overlay)?;
+
+        let mut full_args = Vec::new();
+        if !self.bound_sub_agents.is_empty() {
+            full_args.push("--agents".to_string());
+            full_args.push(self.build_agents_json(ui));
+        }
+        full_args.extend_from_slice(args);
 
         const SCOPE: &[&str] = &["--scope", "local"];
         for (name, binding) in &self.bound_mcp_bindings {
             register_mcp_server(&binary, name, binding, SCOPE, ctx, ui)?;
         }
 
-        let result = run_command(binary.clone(), &overlay, args, ctx, ui).await;
+        let result = run_command(binary.clone(), &overlay, &full_args, ctx, ui).await;
 
         for (name, _) in &self.bound_mcp_bindings {
             remove_mcp_server(&binary, name, SCOPE, ctx, ui);
         }
 
+        if let Some(router) = router {
+            router.shutdown().await;
+        }
+
         result
+    }
+}
+
+impl ClaudeLauncher {
+    /// If any `SubAgentCapability` is bound, starts a `ModelRouter` in front
+    /// of whatever `ANTHROPIC_BASE_URL` would otherwise be and overrides
+    /// `overlay`'s `ANTHROPIC_BASE_URL` entry to point at it, so a sub-agent's
+    /// model reaches its own resolved provider while everything else (the
+    /// main session's own traffic) keeps reaching the normal upstream. Under
+    /// `--dry-run`, no socket is started, but `overlay` still gets a
+    /// placeholder value so the dry-run output stays informative.
+    fn start_sub_agent_router(
+        &self,
+        ctx: &LaunchContext,
+        overlay: &mut Vec<EnvBinding>,
+    ) -> anyhow::Result<Option<ModelRouter>> {
+        if self.bound_sub_agents.is_empty() {
+            return Ok(None);
+        }
+
+        let router = if ctx.dry_run {
+            None
+        } else {
+            let routes = self
+                .bound_sub_agents
+                .iter()
+                .map(|(_, binding)| {
+                    (
+                        binding.model.model_name.clone(),
+                        UpstreamTarget {
+                            base_url: binding.model.base_url.clone(),
+                            verify_ssl: binding.model.verify_ssl,
+                            auth: UpstreamAuth::Inject(binding.model.api_key.clone()),
+                        },
+                    )
+                })
+                .collect::<HashMap<_, _>>();
+            let ambient_base_url = std::env::var("ANTHROPIC_BASE_URL").ok();
+            Some(ModelRouter::start(
+                self.default_upstream_target(ambient_base_url.as_deref()),
+                routes,
+            )?)
+        };
+
+        let base_url_override = match &router {
+            Some(router) => router.local_base_url.clone(),
+            None => "<sub-agent router: not started under --dry-run>".to_string(),
+        };
+        set_env_binding(overlay, "ANTHROPIC_BASE_URL", base_url_override);
+
+        Ok(router)
+    }
+
+    /// The default target a sub-agent router forwards non-matching (main
+    /// session) traffic to: the main model's provider if `AgentModelCapability`
+    /// is also bound, or the real Anthropic API otherwise -- using
+    /// `ambient_anthropic_base_url` (the caller's own `ANTHROPIC_BASE_URL`,
+    /// read from `start_sub_agent_router`'s process environment) if set,
+    /// falling back to the well-known default. Taking this as a parameter
+    /// rather than reading the environment directly here keeps the fallback
+    /// logic deterministically testable.
+    fn default_upstream_target(&self, ambient_anthropic_base_url: Option<&str>) -> UpstreamTarget {
+        match &self.bound_agent_model {
+            Some(binding) => UpstreamTarget {
+                base_url: binding.base_url.clone(),
+                verify_ssl: binding.verify_ssl,
+                auth: UpstreamAuth::Inject(binding.api_key.clone()),
+            },
+            None => UpstreamTarget {
+                base_url: ambient_anthropic_base_url
+                    .map(str::to_string)
+                    .unwrap_or_else(|| "https://api.anthropic.com".to_string()),
+                verify_ssl: true,
+                auth: UpstreamAuth::Passthrough,
+            },
+        }
+    }
+
+    /// Builds the `--agents` JSON: `{ name: { description, prompt, model,
+    /// tools? } }` for every bound sub-agent. `tools` is omitted entirely
+    /// when empty -- an empty array would mean "no tools" to Claude Code,
+    /// whereas omitting means "inherit all," the correct default. Each
+    /// `ToolName` is mapped to Claude's own tool-name string via
+    /// `map_tool_name`; a tool with no mapping is dropped with a warning
+    /// (per sub-agent, so one unmappable tool doesn't sink the rest of that
+    /// sub-agent's list, let alone the whole launch).
+    fn build_agents_json(&self, ui: &dyn Ui) -> String {
+        let agents: serde_json::Map<String, serde_json::Value> = self
+            .bound_sub_agents
+            .iter()
+            .map(|(name, binding)| {
+                let mut entry = serde_json::json!({
+                    "description": binding.description,
+                    "prompt": binding.prompt,
+                    "model": binding.model.model_name,
+                });
+                let mapped_tools: Vec<String> = binding
+                    .tools
+                    .iter()
+                    .filter_map(|tool| {
+                        let mapped = self.map_tool_name(tool);
+                        if mapped.is_none() {
+                            ui.warn(&format!(
+                                "sub-agent '{name}': tool {tool:?} has no mapping for the claude launcher, skipping"
+                            ));
+                        }
+                        mapped
+                    })
+                    .collect();
+                if !mapped_tools.is_empty() {
+                    entry["tools"] = serde_json::json!(mapped_tools);
+                }
+                (name.clone(), entry)
+            })
+            .collect();
+        serde_json::Value::Object(agents).to_string()
+    }
+}
+
+/// Overwrites `key`'s value in `overlay` if `env_overlay` already produced
+/// an entry for it (the case when `AgentModelCapability` is also bound), or
+/// appends one (the case when it isn't, so `env_overlay` produced nothing at
+/// all).
+fn set_env_binding(overlay: &mut Vec<EnvBinding>, key: &str, value: String) {
+    match overlay.iter_mut().find(|b| b.key == key) {
+        Some(binding) => binding.value = value,
+        None => overlay.push(EnvBinding {
+            key: key.to_string(),
+            value,
+        }),
     }
 }
 
@@ -187,7 +382,11 @@ impl HasClaudeLauncherMetadata for ClaudeLauncher {
             name: "Claude CLI".to_string(),
             description: "Anthropic's Claude CLI tool".to_string(),
             default_command: "claude".to_string(),
-            supported_capabilities: HashSet::from([BindingType::AgentModel, BindingType::Mcp]),
+            supported_capabilities: HashSet::from([
+                BindingType::AgentModel,
+                BindingType::Mcp,
+                BindingType::SubAgent,
+            ]),
             tags: vec!["claude".to_string(), "anthropic".to_string()],
         }
     }
@@ -262,5 +461,279 @@ mod tests {
         let props = schema.get("properties").and_then(|p| p.as_object());
         assert!(props.is_some());
         assert!(props.unwrap().contains_key("command_path"));
+    }
+
+    #[test]
+    fn metadata_supports_sub_agent_binding() {
+        let meta = ClaudeLauncher::metadata();
+        assert!(meta.supported_capabilities.contains(&BindingType::SubAgent));
+    }
+
+    #[test]
+    fn map_tool_name_covers_every_canonical_variant_and_formats_mcp_references() {
+        let l = ClaudeLauncher::new(
+            "my-claude",
+            &serde_json::json!({}),
+            &crate::config::Config::default(),
+        );
+        assert_eq!(
+            l.map_tool_name(&ToolName::FileRead),
+            Some("Read".to_string())
+        );
+        assert_eq!(
+            l.map_tool_name(&ToolName::FileWrite),
+            Some("Write".to_string())
+        );
+        assert_eq!(
+            l.map_tool_name(&ToolName::FileEdit),
+            Some("Edit".to_string())
+        );
+        assert_eq!(l.map_tool_name(&ToolName::Search), Some("Grep".to_string()));
+        assert_eq!(
+            l.map_tool_name(&ToolName::FileSearch),
+            Some("Glob".to_string())
+        );
+        assert_eq!(l.map_tool_name(&ToolName::Shell), Some("Bash".to_string()));
+        assert_eq!(
+            l.map_tool_name(&ToolName::WebFetch),
+            Some("WebFetch".to_string())
+        );
+        assert_eq!(
+            l.map_tool_name(&ToolName::WebSearch),
+            Some("WebSearch".to_string())
+        );
+        assert_eq!(
+            l.map_tool_name(&ToolName::Mcp {
+                server: "vision".to_string(),
+                tool: None,
+            }),
+            Some("mcp__vision".to_string())
+        );
+        assert_eq!(
+            l.map_tool_name(&ToolName::Mcp {
+                server: "vision".to_string(),
+                tool: Some("vlm_compare_images".to_string()),
+            }),
+            Some("mcp__vision__vlm_compare_images".to_string())
+        );
+        assert_eq!(
+            l.map_tool_name(&ToolName::Other("SomeRawClaudeTool".to_string())),
+            Some("SomeRawClaudeTool".to_string())
+        );
+    }
+
+    fn sub_agent_binding(
+        description: &str,
+        model_name: &str,
+        tools: Vec<ToolName>,
+    ) -> SubAgentBinding {
+        SubAgentBinding {
+            description: description.to_string(),
+            prompt: "You are a helpful sub-agent.".to_string(),
+            tools,
+            model: crate::capabilities::AgentModelBinding {
+                api_type: crate::providers::ApiType::Anthropic,
+                provider_name: "my-ollama".to_string(),
+                base_url: "http://localhost:11434".to_string(),
+                model_name: model_name.to_string(),
+                endpoint_path: "/v1/messages".to_string(),
+                api_key: None,
+                verify_ssl: true,
+                context_length: 4096,
+            },
+        }
+    }
+
+    fn launcher_with(
+        bound_agent_model: Option<crate::capabilities::AgentModelBinding>,
+        bound_sub_agents: Vec<(String, SubAgentBinding)>,
+    ) -> ClaudeLauncher {
+        let mut l = ClaudeLauncher::new(
+            "my-claude",
+            &serde_json::json!({}),
+            &crate::config::Config::default(),
+        );
+        l.bound_agent_model = bound_agent_model;
+        l.bound_sub_agents = bound_sub_agents;
+        l
+    }
+
+    #[test]
+    fn build_agents_json_includes_description_prompt_and_model_but_omits_empty_tools() {
+        let ui = crate::utils::ui::backends::plain::PlainOutput;
+        let l = launcher_with(
+            None,
+            vec![(
+                "reviewer".to_string(),
+                sub_agent_binding("Reviews code", "granite-3.1-8b-instruct", vec![]),
+            )],
+        );
+        let json: serde_json::Value = serde_json::from_str(&l.build_agents_json(&ui)).unwrap();
+        let entry = &json["reviewer"];
+        assert_eq!(entry["description"], "Reviews code");
+        assert_eq!(entry["prompt"], "You are a helpful sub-agent.");
+        assert_eq!(entry["model"], "granite-3.1-8b-instruct");
+        assert!(entry.get("tools").is_none());
+    }
+
+    #[test]
+    fn build_agents_json_includes_tools_when_present() {
+        let ui = crate::utils::ui::backends::plain::PlainOutput;
+        let l = launcher_with(
+            None,
+            vec![(
+                "reviewer".to_string(),
+                sub_agent_binding(
+                    "Reviews code",
+                    "granite-3.1-8b-instruct",
+                    vec![ToolName::FileRead, ToolName::Search],
+                ),
+            )],
+        );
+        let json: serde_json::Value = serde_json::from_str(&l.build_agents_json(&ui)).unwrap();
+        assert_eq!(
+            json["reviewer"]["tools"],
+            serde_json::json!(["Read", "Grep"])
+        );
+    }
+
+    #[test]
+    fn build_agents_json_covers_every_bound_sub_agent_by_instance_id() {
+        let ui = crate::utils::ui::backends::plain::PlainOutput;
+        let l = launcher_with(
+            None,
+            vec![
+                (
+                    "reviewer".to_string(),
+                    sub_agent_binding("Reviews code", "model-a", vec![]),
+                ),
+                (
+                    "summarizer".to_string(),
+                    sub_agent_binding("Summarizes text", "model-b", vec![]),
+                ),
+            ],
+        );
+        let json: serde_json::Value = serde_json::from_str(&l.build_agents_json(&ui)).unwrap();
+        assert_eq!(json.as_object().unwrap().len(), 2);
+        assert_eq!(json["reviewer"]["model"], "model-a");
+        assert_eq!(json["summarizer"]["model"], "model-b");
+    }
+
+    #[test]
+    fn default_upstream_target_falls_back_to_well_known_default_without_a_main_model() {
+        let l = launcher_with(None, vec![]);
+        let target = l.default_upstream_target(None);
+        assert_eq!(target.base_url, "https://api.anthropic.com");
+        assert!(matches!(target.auth, UpstreamAuth::Passthrough));
+    }
+
+    #[test]
+    fn default_upstream_target_uses_ambient_base_url_without_a_main_model() {
+        let l = launcher_with(None, vec![]);
+        let target = l.default_upstream_target(Some("http://corporate-gateway.internal"));
+        assert_eq!(target.base_url, "http://corporate-gateway.internal");
+        assert!(matches!(target.auth, UpstreamAuth::Passthrough));
+    }
+
+    #[test]
+    fn default_upstream_target_prefers_bound_main_model_over_ambient_env() {
+        let main_model = crate::capabilities::AgentModelBinding {
+            api_type: crate::providers::ApiType::Anthropic,
+            provider_name: "my-ollama".to_string(),
+            base_url: "http://localhost:11434".to_string(),
+            model_name: "granite-3.1-8b-instruct".to_string(),
+            endpoint_path: "/v1/messages".to_string(),
+            api_key: Some(crate::registry::Secret("real-key".to_string())),
+            verify_ssl: true,
+            context_length: 4096,
+        };
+        let l = launcher_with(Some(main_model), vec![]);
+        let target = l.default_upstream_target(Some("http://corporate-gateway.internal"));
+        assert_eq!(target.base_url, "http://localhost:11434");
+        assert!(matches!(target.auth, UpstreamAuth::Inject(Some(_))));
+    }
+
+    #[test]
+    fn set_env_binding_overwrites_existing_entry() {
+        let mut overlay = vec![EnvBinding {
+            key: "ANTHROPIC_BASE_URL".to_string(),
+            value: "http://original".to_string(),
+        }];
+        set_env_binding(
+            &mut overlay,
+            "ANTHROPIC_BASE_URL",
+            "http://router".to_string(),
+        );
+        assert_eq!(overlay.len(), 1);
+        assert_eq!(overlay[0].value, "http://router");
+    }
+
+    #[test]
+    fn set_env_binding_appends_when_absent() {
+        let mut overlay = vec![];
+        set_env_binding(
+            &mut overlay,
+            "ANTHROPIC_BASE_URL",
+            "http://router".to_string(),
+        );
+        assert_eq!(overlay.len(), 1);
+        assert_eq!(overlay[0].key, "ANTHROPIC_BASE_URL");
+        assert_eq!(overlay[0].value, "http://router");
+    }
+
+    /// Minimal `Capability` double that always resolves to a fixed
+    /// `SubAgentBinding`, so `bind_capability`'s dispatch can be exercised
+    /// without going through real model/provider resolution.
+    struct FakeSubAgentCapability {
+        instance_id: String,
+        binding: SubAgentBinding,
+    }
+
+    impl crate::registry::Named for FakeSubAgentCapability {
+        fn instance_id(&self) -> &str {
+            &self.instance_id
+        }
+    }
+
+    #[async_trait]
+    impl Capability for FakeSubAgentCapability {
+        fn name(&self) -> &str {
+            "Fake Sub-Agent"
+        }
+        fn description(&self) -> &str {
+            "test double"
+        }
+        fn dependencies(&self) -> Vec<crate::capabilities::Dependency> {
+            vec![]
+        }
+        fn binding_types(&self) -> HashSet<BindingType> {
+            HashSet::from([BindingType::SubAgent])
+        }
+        async fn bind(
+            &self,
+            _request: crate::capabilities::BindingRequest,
+        ) -> anyhow::Result<Binding> {
+            Ok(Binding::SubAgent(self.binding.clone()))
+        }
+    }
+
+    #[tokio::test]
+    async fn bind_capability_pushes_sub_agent_binding() {
+        let mut l = ClaudeLauncher::new(
+            "my-claude",
+            &serde_json::json!({}),
+            &crate::config::Config::default(),
+        );
+        let cap = FakeSubAgentCapability {
+            instance_id: "reviewer".to_string(),
+            binding: sub_agent_binding("Reviews code", "granite-3.1-8b-instruct", vec![]),
+        };
+        l.bind_capability(&cap).await.unwrap();
+        assert_eq!(l.bound_sub_agents.len(), 1);
+        assert_eq!(l.bound_sub_agents[0].0, "reviewer");
+        assert_eq!(
+            l.bound_sub_agents[0].1.model.model_name,
+            "granite-3.1-8b-instruct"
+        );
     }
 }

--- a/src/launchers/claude.rs
+++ b/src/launchers/claude.rs
@@ -3,6 +3,7 @@ use std::collections::{HashMap, HashSet};
 use std::path::PathBuf;
 
 // Third Party
+use alog::{alog_channel, use_channel, MessageLevel};
 use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
 
@@ -19,6 +20,8 @@ use crate::launchers::shared::model_router::{ModelRouter, UpstreamAuth, Upstream
 use crate::registry::ConfigConstructable;
 use crate::utils::resolve_shell_command;
 use crate::utils::ui::Ui;
+
+use_channel!("CLAUD");
 
 /*-- public --*/
 
@@ -219,6 +222,7 @@ impl Launcher for ClaudeLauncher {
         let binary = self.validate_command()?;
         let mut overlay = self.env_overlay(ctx).await?;
         let router = self.start_sub_agent_router(ctx, &mut overlay)?;
+        alog_channel!(MessageLevel::Debug4, "Env overlay: {:#?}", overlay);
 
         let mut full_args = Vec::new();
         if !self.bound_sub_agents.is_empty() {
@@ -232,6 +236,8 @@ impl Launcher for ClaudeLauncher {
             register_mcp_server(&binary, name, binding, SCOPE, ctx, ui)?;
         }
 
+        alog_channel!(MessageLevel::Debug3, "Binary: {:#?}", &binary);
+        alog_channel!(MessageLevel::Debug3, "Full args: {:#?}", full_args);
         let result = run_command(binary.clone(), &overlay, &full_args, ctx, ui).await;
 
         for (name, _) in &self.bound_mcp_bindings {

--- a/src/launchers/claude.rs
+++ b/src/launchers/claude.rs
@@ -3,7 +3,7 @@ use std::collections::{HashMap, HashSet};
 use std::path::PathBuf;
 
 // Third Party
-use alog::{alog_channel, use_channel, MessageLevel};
+use alog::{MessageLevel, alog_channel, use_channel};
 use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
 

--- a/src/launchers/shared/mod.rs
+++ b/src/launchers/shared/mod.rs
@@ -1,1 +1,2 @@
 pub mod mcp_cli;
+pub mod model_router;

--- a/src/launchers/shared/model_router.rs
+++ b/src/launchers/shared/model_router.rs
@@ -1,0 +1,418 @@
+//! A localhost reverse-proxy that dispatches each request to one of several
+//! upstream targets based on the top-level `"model"` field in its JSON body
+//! -- a known model routes to its own resolved provider; anything else
+//! (parse failure, missing field, no match) falls through to a `default`
+//! target unchanged. First consumer: `ClaudeLauncher`, which uses this to
+//! give each bound `SubAgentCapability` its own model/provider while Claude
+//! Code's single `ANTHROPIC_BASE_URL` still carries the main session's own
+//! traffic. See `docs/specs/0021-sub-agent-capability.md`.
+//!
+//! Deliberately not Anthropic-specific in its mechanics: it only reads a
+//! top-level JSON `"model"` string, a shape OpenAI/Ollama-style request
+//! bodies share too.
+
+// Standard
+use std::collections::HashMap;
+use std::sync::Arc;
+
+// Third Party
+use alog::{MessageLevel, alog_channel, use_channel};
+use axum::Router;
+use axum::body::Body;
+use axum::extract::State;
+use axum::http::{HeaderMap, HeaderName, HeaderValue, Method, StatusCode, Uri};
+use axum::response::{IntoResponse, Response};
+use axum::routing::any;
+
+// Local
+use crate::registry::Secret;
+use crate::utils::subserver::SubServer;
+
+use_channel!("MRTR");
+
+/*-- public --*/
+
+/// One destination the router can forward a request to.
+pub struct UpstreamTarget {
+    pub base_url: String,
+    pub verify_ssl: bool,
+    pub auth: UpstreamAuth,
+}
+
+/// How the router should handle auth headers when forwarding to a target.
+pub enum UpstreamAuth {
+    /// Strip whatever auth the client sent and inject this instead (or send
+    /// no auth at all if `None`) -- for a known granite-cli-resolved
+    /// provider, whose credentials are unrelated to whatever the client
+    /// attached.
+    Inject(Option<Secret>),
+    /// Forward the client's auth headers byte-for-byte -- for the real
+    /// upstream, so the client's own credential precedence (subscription
+    /// OAuth, API key, bearer token, etc.) keeps working untouched.
+    Passthrough,
+}
+
+/// A running model-based router. Bind an ephemeral localhost port and start
+/// dispatching immediately; `local_base_url` is what a launcher points its
+/// tool's base-URL env var at.
+pub struct ModelRouter {
+    pub local_base_url: String,
+    inner: SubServer,
+}
+
+impl ModelRouter {
+    /// Synchronous -- see `SubServer::spawn` -- so this can be called from
+    /// inside sync code as long as a Tokio runtime is already running
+    /// somewhere up the call stack.
+    pub fn start(
+        default: UpstreamTarget,
+        routes: HashMap<String, UpstreamTarget>,
+    ) -> anyhow::Result<Self> {
+        let default = ResolvedTarget::build(default)?;
+        let routes = routes
+            .into_iter()
+            .map(|(model, target)| Ok((model, ResolvedTarget::build(target)?)))
+            .collect::<anyhow::Result<HashMap<_, _>>>()?;
+        let state = Arc::new(RouterState { default, routes });
+
+        let app = Router::new()
+            .fallback(any(router_handler))
+            .with_state(state);
+        let inner = SubServer::spawn(app, "sub-agent model router")?;
+        let local_base_url = format!("http://{}", inner.local_addr);
+
+        Ok(Self {
+            local_base_url,
+            inner,
+        })
+    }
+
+    /// Signal the server to stop accepting new connections and wait for it
+    /// to finish draining in-flight ones.
+    pub async fn shutdown(self) {
+        self.inner.shutdown().await;
+    }
+}
+
+/*-- private --*/
+
+struct ResolvedTarget {
+    base_url: String,
+    auth: UpstreamAuth,
+    client: reqwest::Client,
+}
+
+impl ResolvedTarget {
+    fn build(target: UpstreamTarget) -> anyhow::Result<Self> {
+        let client = reqwest::Client::builder()
+            .danger_accept_invalid_certs(!target.verify_ssl)
+            .build()?;
+        Ok(Self {
+            base_url: target.base_url,
+            auth: target.auth,
+            client,
+        })
+    }
+}
+
+struct RouterState {
+    default: ResolvedTarget,
+    routes: HashMap<String, ResolvedTarget>,
+}
+
+impl RouterState {
+    fn target_for(&self, body: &[u8]) -> &ResolvedTarget {
+        model_from_body(body)
+            .and_then(|model| self.routes.get(&model))
+            .unwrap_or(&self.default)
+    }
+}
+
+/// Reads the top-level `"model"` string out of a JSON request body. A
+/// non-JSON body, or one without a string `"model"` field, yields `None` --
+/// not an error -- so the caller falls through to the default target.
+fn model_from_body(body: &[u8]) -> Option<String> {
+    let value: serde_json::Value = serde_json::from_slice(body).ok()?;
+    value.get("model")?.as_str().map(str::to_string)
+}
+
+/// Headers that must not be blindly forwarded in either direction:
+/// connection-specific framing that's re-derived for the new connection.
+/// Auth headers (`authorization`/`x-api-key`) are handled separately per
+/// `UpstreamAuth`, not covered by this list.
+fn is_hop_by_hop_header(name: &str) -> bool {
+    matches!(
+        name.to_ascii_lowercase().as_str(),
+        "host"
+            | "content-length"
+            | "connection"
+            | "keep-alive"
+            | "transfer-encoding"
+            | "te"
+            | "trailer"
+            | "upgrade"
+            | "proxy-authenticate"
+            | "proxy-authorization"
+    )
+}
+
+fn is_auth_header(name: &str) -> bool {
+    matches!(
+        name.to_ascii_lowercase().as_str(),
+        "authorization" | "x-api-key"
+    )
+}
+
+async fn router_handler(
+    State(state): State<Arc<RouterState>>,
+    method: Method,
+    uri: Uri,
+    headers: HeaderMap,
+    body: Body,
+) -> Response {
+    match forward(&state, method, uri, headers, body).await {
+        Ok(response) => response,
+        Err(e) => {
+            alog_channel!(
+                MessageLevel::Warning,
+                "sub-agent model router forward failed: {e}"
+            );
+            (StatusCode::BAD_GATEWAY, format!("router error: {e}")).into_response()
+        }
+    }
+}
+
+async fn forward(
+    state: &RouterState,
+    method: Method,
+    uri: Uri,
+    headers: HeaderMap,
+    body: Body,
+) -> anyhow::Result<Response> {
+    let body_bytes = axum::body::to_bytes(body, usize::MAX).await?;
+    let target = state.target_for(&body_bytes);
+
+    let path_and_query = uri.path_and_query().map(|p| p.as_str()).unwrap_or("/");
+    let url = format!(
+        "{}{}",
+        target.base_url.trim_end_matches('/'),
+        path_and_query
+    );
+
+    let outbound_method = reqwest::Method::from_bytes(method.as_str().as_bytes())?;
+    let mut outbound = target.client.request(outbound_method, &url);
+    let strip_client_auth = matches!(target.auth, UpstreamAuth::Inject(_));
+    for (name, value) in headers.iter() {
+        if is_hop_by_hop_header(name.as_str()) {
+            continue;
+        }
+        if strip_client_auth && is_auth_header(name.as_str()) {
+            continue;
+        }
+        if let Ok(v) = value.to_str() {
+            outbound = outbound.header(name.as_str(), v);
+        }
+    }
+    if let UpstreamAuth::Inject(Some(key)) = &target.auth {
+        // No `ApiType` is available at this layer, so send both header
+        // schemes a provider might expect -- harmless, since a real
+        // upstream only reads the one it understands. Mirrors
+        // `proxy::server::forward`'s existing convention.
+        outbound = outbound.header("x-api-key", &key.0).bearer_auth(&key.0);
+    }
+    let upstream_resp = outbound.body(body_bytes).send().await?;
+
+    let status = StatusCode::from_u16(upstream_resp.status().as_u16())?;
+    let mut builder = Response::builder().status(status);
+    for (name, value) in upstream_resp.headers().iter() {
+        if is_hop_by_hop_header(name.as_str()) {
+            continue;
+        }
+        if let (Ok(name), Ok(value)) = (
+            HeaderName::from_bytes(name.as_str().as_bytes()),
+            HeaderValue::from_bytes(value.as_bytes()),
+        ) {
+            builder = builder.header(name, value);
+        }
+    }
+
+    let body = Body::from_stream(upstream_resp.bytes_stream());
+    Ok(builder.body(body)?)
+}
+
+/*-- tests --*/
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::routing::post;
+    use std::net::SocketAddr;
+
+    async fn echo_model_and_auth(headers: HeaderMap, body: axum::body::Bytes) -> Response {
+        let model = model_from_body(&body).unwrap_or_default();
+        let auth = headers
+            .get("authorization")
+            .and_then(|v| v.to_str().ok())
+            .unwrap_or("")
+            .to_string();
+        let api_key = headers
+            .get("x-api-key")
+            .and_then(|v| v.to_str().ok())
+            .unwrap_or("")
+            .to_string();
+        axum::Json(
+            serde_json::json!({ "model": model, "authorization": auth, "x_api_key": api_key }),
+        )
+        .into_response()
+    }
+
+    async fn spawn_echo_server() -> SocketAddr {
+        let app = Router::new().route("/v1/messages", post(echo_model_and_auth));
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        tokio::spawn(async move {
+            axum::serve(listener, app).await.unwrap();
+        });
+        addr
+    }
+
+    fn target(base_url: String, auth: UpstreamAuth) -> UpstreamTarget {
+        UpstreamTarget {
+            base_url,
+            verify_ssl: true,
+            auth,
+        }
+    }
+
+    #[tokio::test]
+    async fn dispatches_known_model_to_its_own_route_with_injected_auth() {
+        let known_addr = spawn_echo_server().await;
+        let default_addr = spawn_echo_server().await;
+
+        let mut routes = HashMap::new();
+        routes.insert(
+            "granite-4.1-8b".to_string(),
+            target(
+                format!("http://{known_addr}"),
+                UpstreamAuth::Inject(Some(Secret("known-key".to_string()))),
+            ),
+        );
+        let router = ModelRouter::start(
+            target(format!("http://{default_addr}"), UpstreamAuth::Passthrough),
+            routes,
+        )
+        .unwrap();
+
+        let client = reqwest::Client::new();
+        let resp = client
+            .post(format!("{}/v1/messages", router.local_base_url))
+            .header("authorization", "Bearer client-token")
+            .json(&serde_json::json!({ "model": "granite-4.1-8b" }))
+            .send()
+            .await
+            .unwrap();
+        let body: serde_json::Value = resp.json().await.unwrap();
+        assert_eq!(body["model"], "granite-4.1-8b");
+        // Client auth was stripped and replaced with the route's own key.
+        assert_eq!(body["authorization"], "Bearer known-key");
+        assert_eq!(body["x_api_key"], "known-key");
+
+        router.shutdown().await;
+    }
+
+    #[tokio::test]
+    async fn falls_back_to_default_for_unknown_model() {
+        let default_addr = spawn_echo_server().await;
+        let router = ModelRouter::start(
+            target(format!("http://{default_addr}"), UpstreamAuth::Passthrough),
+            HashMap::new(),
+        )
+        .unwrap();
+
+        let client = reqwest::Client::new();
+        let resp = client
+            .post(format!("{}/v1/messages", router.local_base_url))
+            .json(&serde_json::json!({ "model": "claude-sonnet-5" }))
+            .send()
+            .await
+            .unwrap();
+        let body: serde_json::Value = resp.json().await.unwrap();
+        assert_eq!(body["model"], "claude-sonnet-5");
+
+        router.shutdown().await;
+    }
+
+    #[tokio::test]
+    async fn passthrough_default_leaves_client_auth_headers_untouched() {
+        let default_addr = spawn_echo_server().await;
+        let router = ModelRouter::start(
+            target(format!("http://{default_addr}"), UpstreamAuth::Passthrough),
+            HashMap::new(),
+        )
+        .unwrap();
+
+        let client = reqwest::Client::new();
+        let resp = client
+            .post(format!("{}/v1/messages", router.local_base_url))
+            .header("authorization", "Bearer subscription-session-token")
+            .json(&serde_json::json!({ "model": "claude-sonnet-5" }))
+            .send()
+            .await
+            .unwrap();
+        let body: serde_json::Value = resp.json().await.unwrap();
+        assert_eq!(body["authorization"], "Bearer subscription-session-token");
+        assert_eq!(body["x_api_key"], "");
+
+        router.shutdown().await;
+    }
+
+    #[tokio::test]
+    async fn falls_back_to_default_for_non_json_body() {
+        let default_addr = spawn_echo_server().await;
+        let router = ModelRouter::start(
+            target(format!("http://{default_addr}"), UpstreamAuth::Passthrough),
+            HashMap::new(),
+        )
+        .unwrap();
+
+        let client = reqwest::Client::new();
+        let resp = client
+            .post(format!("{}/v1/messages", router.local_base_url))
+            .body("not json")
+            .send()
+            .await
+            .unwrap();
+        assert!(resp.status().is_success());
+
+        router.shutdown().await;
+    }
+
+    #[test]
+    fn model_from_body_reads_top_level_model_field() {
+        assert_eq!(
+            model_from_body(br#"{"model": "granite-4.1-8b", "messages": []}"#),
+            Some("granite-4.1-8b".to_string())
+        );
+    }
+
+    #[test]
+    fn model_from_body_returns_none_for_missing_field() {
+        assert_eq!(model_from_body(br#"{"messages": []}"#), None);
+    }
+
+    #[test]
+    fn model_from_body_returns_none_for_non_json() {
+        assert_eq!(model_from_body(b"not json"), None);
+    }
+
+    #[test]
+    fn hop_by_hop_headers_are_filtered_but_auth_headers_are_not() {
+        assert!(is_hop_by_hop_header("Host"));
+        assert!(is_hop_by_hop_header("Transfer-Encoding"));
+        assert!(!is_hop_by_hop_header("Authorization"));
+        assert!(!is_hop_by_hop_header("Content-Type"));
+        assert!(is_auth_header("X-Api-Key"));
+        assert!(is_auth_header("Authorization"));
+        assert!(!is_auth_header("Content-Type"));
+    }
+}

--- a/src/launchers/shared/model_router.rs
+++ b/src/launchers/shared/model_router.rs
@@ -133,7 +133,9 @@ impl RouterState {
 /// not an error -- so the caller falls through to the default target.
 fn model_from_body(body: &[u8]) -> Option<String> {
     let value: serde_json::Value = serde_json::from_slice(body).ok()?;
-    value.get("model")?.as_str().map(str::to_string)
+    let model = value.get("model")?.as_str().map(str::to_string);
+    alog_channel!(MessageLevel::Debug4, "Found model: {:#?}", model);
+    model
 }
 
 /// Headers that must not be blindly forwarded in either direction:
@@ -200,6 +202,7 @@ async fn forward(
     );
 
     let outbound_method = reqwest::Method::from_bytes(method.as_str().as_bytes())?;
+    alog_channel!(MessageLevel::Debug4, "Routing to {:#?}", &url);
     let mut outbound = target.client.request(outbound_method, &url);
     let strip_client_auth = matches!(target.auth, UpstreamAuth::Inject(_));
     for (name, value) in headers.iter() {

--- a/src/models/base.rs
+++ b/src/models/base.rs
@@ -183,6 +183,119 @@ pub trait Model: crate::registry::Named + Send + Sync {
     }
 }
 
+/*-- ConfiguredModel -----------------------------------------------------------*/
+
+/// Resolves a capability's `model_id` config field into a live model plus
+/// whatever variant the user pinned, and the provider/endpoint checks every
+/// model-backed `Capability::bind()` needs -- shared by `AgentModelCapability`,
+/// `VisionMCPCapability`, and `SubAgentCapability` so each doesn't
+/// reimplement the same `ModelSource`/variant-resolution logic.
+pub struct ConfiguredModel {
+    pub model: std::sync::Arc<dyn Model>,
+    /// The raw `"format/precision"` string from `ModelConfig.variant`, if the
+    /// user configured a specific variant. Used at bind time to resolve the
+    /// provider-specific model alias.
+    configured_variant: Option<String>,
+}
+
+impl ConfiguredModel {
+    /// Resolves `model_id` through `ModelSource::from_config`, which handles
+    /// provider resolution (so `model.provider()` works at bind time) and,
+    /// when a usage-tracking session is active, transparently wraps the
+    /// model in a local tracking proxy. Panics if the model isn't
+    /// found/constructible -- capabilities' `ConfigConstructable::new` is
+    /// infallible by trait signature, so this preserves that contract
+    /// exactly.
+    pub fn resolve(model_id: &str, global_config: &crate::config::Config) -> Self {
+        let mut source = crate::models::ModelSource::from_config(global_config);
+        let model = source.take(model_id).unwrap_or_else(|| {
+            panic!("Configured model '{model_id}' not found or could not be constructed")
+        });
+        let configured_variant = global_config
+            .models
+            .get(model_id)
+            .and_then(|mc| mc.variant.clone());
+        Self {
+            model,
+            configured_variant,
+        }
+    }
+
+    /// Test-only escape hatch so capability unit tests can inject a fake
+    /// model/provider without a real registry lookup.
+    #[cfg(test)]
+    pub(crate) fn for_test(
+        model: std::sync::Arc<dyn Model>,
+        configured_variant: Option<String>,
+    ) -> Self {
+        Self {
+            model,
+            configured_variant,
+        }
+    }
+
+    /// Resolves `configured_variant` (stored as `"format/precision"`) to the
+    /// matching `ModelVariant` in the model's catalog variants, using the
+    /// same case-insensitive lookup as the pull command.
+    pub fn resolve_variant(&self) -> Option<&ModelVariant> {
+        let variant_str = self.configured_variant.as_deref()?;
+        let (format, precision) = variant_str.split_once('/')?;
+        self.model.variants().iter().find(|v| {
+            v.format.eq_ignore_ascii_case(format) && v.precision.eq_ignore_ascii_case(precision)
+        })
+    }
+
+    /// The common core of every model-backed `Capability::bind()`: resolves
+    /// the provider, checks it supports `api_type`, checks the model
+    /// supports `required_function`, finds the `api_type` endpoint for
+    /// `endpoint_function`, and computes the provider-specific model
+    /// name/alias to send. `required_function` and `endpoint_function` are
+    /// separate parameters because a capability's model-support requirement
+    /// and its endpoint lookup can differ (e.g. `VisionMCPCapability` needs
+    /// `ImageUnderstanding` on the model but looks up the endpoint via
+    /// `Chat`, since that's the endpoint that actually serves vision
+    /// requests). `model_id` is used only for error messages.
+    pub fn resolve_provider_endpoint(
+        &self,
+        model_id: &str,
+        api_type: crate::providers::ApiType,
+        required_function: ModelFunction,
+        endpoint_function: ModelFunction,
+    ) -> anyhow::Result<(
+        Box<dyn crate::providers::Provider>,
+        crate::providers::ApiEndpoint,
+        String,
+    )> {
+        let provider = self
+            .model
+            .provider()
+            .map_err(|e| anyhow::anyhow!("model '{model_id}' has no usable provider: {e}"))?;
+        anyhow::ensure!(
+            provider.supported_api_types().contains(&api_type),
+            "provider for model '{model_id}' does not support {api_type}"
+        );
+        anyhow::ensure!(
+            self.model
+                .supported_functions()
+                .contains(&required_function),
+            "model '{model_id}' does not support {required_function}"
+        );
+        let endpoint = provider
+            .endpoints_for_function(&endpoint_function)
+            .into_iter()
+            .find(|e| e.api_type() == api_type)
+            .ok_or_else(|| {
+                anyhow::anyhow!(
+                    "provider for model '{model_id}' has no {api_type} endpoint for {endpoint_function}"
+                )
+            })?;
+        let model_name = provider
+            .model_alias(self.resolve_variant())
+            .unwrap_or_else(|| model_id.to_string());
+        Ok((provider, endpoint, model_name))
+    }
+}
+
 /*-- Metadata Types ----------------------------------------------------------*/
 
 /// Metadata describing a model implementation.
@@ -388,5 +501,305 @@ mod searchable_tests {
         let fields = m.search_fields();
         assert!(fields.contains(&"instruct"));
         assert!(fields.contains(&"chat"));
+    }
+}
+
+#[cfg(test)]
+mod configured_model_tests {
+    use super::*;
+    use crate::providers::{
+        ApiEndpoint, ApiType, HealthStatus, ModelFormat, Provider, ProviderError,
+    };
+    use crate::registry::{ConfigConstructable, Secret};
+    use std::collections::HashMap;
+
+    #[derive(Clone, Default)]
+    struct FakeProvider {
+        instance_id: String,
+        base_url: String,
+        api_key: Option<Secret>,
+        verify_ssl: bool,
+        api_types: Vec<ApiType>,
+        endpoints: HashMap<ModelFunction, Vec<ApiEndpoint>>,
+        alias: Option<String>,
+    }
+
+    impl ConfigConstructable for FakeProvider {
+        type Config = crate::registry::NoConfig;
+        fn new(_: &str, _: &serde_json::Value, _: &crate::config::Config) -> Self {
+            unimplemented!("not used in tests")
+        }
+    }
+
+    impl crate::registry::Named for FakeProvider {
+        fn instance_id(&self) -> &str {
+            &self.instance_id
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl Provider for FakeProvider {
+        fn name(&self) -> &str {
+            "Fake Provider"
+        }
+        fn function_endpoints(&self) -> HashMap<ModelFunction, Vec<ApiEndpoint>> {
+            self.endpoints.clone()
+        }
+        fn supported_api_types(&self) -> Vec<ApiType> {
+            self.api_types.clone()
+        }
+        fn base_url(&self) -> &str {
+            &self.base_url
+        }
+        fn api_key(&self) -> Option<&Secret> {
+            self.api_key.as_ref()
+        }
+        fn verify_ssl(&self) -> bool {
+            self.verify_ssl
+        }
+        fn supported_formats(&self) -> Vec<ModelFormat> {
+            vec![]
+        }
+        fn model_alias(&self, _variant: Option<&ModelVariant>) -> Option<String> {
+            self.alias.clone()
+        }
+        async fn health_check(&self) -> Result<HealthStatus, ProviderError> {
+            unimplemented!("not used in tests")
+        }
+    }
+
+    fn ok_provider() -> FakeProvider {
+        let mut endpoints = HashMap::new();
+        endpoints.insert(ModelFunction::Chat, vec![ApiEndpoint::OpenAIChat]);
+        FakeProvider {
+            instance_id: "my-ollama".to_string(),
+            base_url: "http://localhost:11434".to_string(),
+            api_key: None,
+            verify_ssl: true,
+            api_types: vec![ApiType::OpenAI],
+            endpoints,
+            alias: None,
+        }
+    }
+
+    struct TestModel {
+        supported_functions: Vec<ModelFunction>,
+        provider: FakeProvider,
+        variants: Vec<ModelVariant>,
+    }
+
+    impl crate::registry::Named for TestModel {
+        fn instance_id(&self) -> &str {
+            "test-model"
+        }
+    }
+
+    impl Model for TestModel {
+        fn family(&self) -> &str {
+            "Test"
+        }
+        fn version(&self) -> &str {
+            "1.0"
+        }
+        fn size(&self) -> u64 {
+            1
+        }
+        fn context_length(&self) -> u64 {
+            4096
+        }
+        fn model_type(&self) -> &ModelType {
+            &ModelType::Text
+        }
+        fn huggingface_repo(&self) -> &str {
+            "test/test"
+        }
+        fn native_dtype(&self) -> &str {
+            "bfloat16"
+        }
+        fn architecture(&self) -> &ModelArchitecture {
+            unimplemented!("not used in tests")
+        }
+        fn variants(&self) -> &[ModelVariant] {
+            &self.variants
+        }
+        fn description(&self) -> Option<&str> {
+            None
+        }
+        fn tags(&self) -> &[String] {
+            &[]
+        }
+        fn supported_functions(&self) -> &[ModelFunction] {
+            &self.supported_functions
+        }
+        fn provider(&self) -> anyhow::Result<Box<dyn Provider>> {
+            Ok(Box::new(self.provider.clone()))
+        }
+    }
+
+    fn configured_model(
+        functions: Vec<ModelFunction>,
+        provider: FakeProvider,
+        variant: Option<(&str, Vec<ModelVariant>)>,
+    ) -> ConfiguredModel {
+        let (variant_str, variants) = variant
+            .map(|(s, v)| (Some(s.to_string()), v))
+            .unwrap_or((None, vec![]));
+        ConfiguredModel::for_test(
+            std::sync::Arc::new(TestModel {
+                supported_functions: functions,
+                provider,
+                variants,
+            }),
+            variant_str,
+        )
+    }
+
+    #[test]
+    fn resolve_provider_endpoint_succeeds_for_matching_provider_and_model() {
+        let cm = configured_model(vec![ModelFunction::Chat], ok_provider(), None);
+        let (provider, endpoint, model_name) = cm
+            .resolve_provider_endpoint(
+                "test-model",
+                ApiType::OpenAI,
+                ModelFunction::Chat,
+                ModelFunction::Chat,
+            )
+            .unwrap();
+        assert_eq!(provider.base_url(), "http://localhost:11434");
+        assert_eq!(endpoint, ApiEndpoint::OpenAIChat);
+        assert_eq!(model_name, "test-model");
+    }
+
+    #[test]
+    fn resolve_provider_endpoint_fails_when_provider_lacks_api_type() {
+        let cm = configured_model(
+            vec![ModelFunction::Chat],
+            FakeProvider {
+                api_types: vec![ApiType::Ollama],
+                ..ok_provider()
+            },
+            None,
+        );
+        let err = cm
+            .resolve_provider_endpoint(
+                "test-model",
+                ApiType::OpenAI,
+                ModelFunction::Chat,
+                ModelFunction::Chat,
+            )
+            .err()
+            .unwrap();
+        assert!(err.to_string().contains("does not support OpenAI"));
+    }
+
+    #[test]
+    fn resolve_provider_endpoint_fails_when_model_lacks_required_function() {
+        let cm = configured_model(vec![ModelFunction::Embeddings], ok_provider(), None);
+        let err = cm
+            .resolve_provider_endpoint(
+                "test-model",
+                ApiType::OpenAI,
+                ModelFunction::Chat,
+                ModelFunction::Chat,
+            )
+            .err()
+            .unwrap();
+        assert!(err.to_string().contains("does not support Chat"));
+    }
+
+    #[test]
+    fn resolve_provider_endpoint_fails_when_no_matching_endpoint() {
+        let cm = configured_model(
+            vec![ModelFunction::Chat],
+            FakeProvider {
+                endpoints: HashMap::from([(ModelFunction::Chat, vec![ApiEndpoint::OllamaChat])]),
+                api_types: vec![ApiType::OpenAI, ApiType::Ollama],
+                ..ok_provider()
+            },
+            None,
+        );
+        let err = cm
+            .resolve_provider_endpoint(
+                "test-model",
+                ApiType::OpenAI,
+                ModelFunction::Chat,
+                ModelFunction::Chat,
+            )
+            .err()
+            .unwrap();
+        assert!(err.to_string().contains("has no OpenAI endpoint for Chat"));
+    }
+
+    #[test]
+    fn resolve_provider_endpoint_allows_required_and_endpoint_functions_to_differ() {
+        // Mirrors VisionMCPCapability: model must support ImageUnderstanding,
+        // but the endpoint is looked up via Chat.
+        let cm = configured_model(vec![ModelFunction::ImageUnderstanding], ok_provider(), None);
+        let (_, endpoint, _) = cm
+            .resolve_provider_endpoint(
+                "test-model",
+                ApiType::OpenAI,
+                ModelFunction::ImageUnderstanding,
+                ModelFunction::Chat,
+            )
+            .unwrap();
+        assert_eq!(endpoint, ApiEndpoint::OpenAIChat);
+    }
+
+    #[test]
+    fn resolve_provider_endpoint_uses_provider_alias_when_variant_matches() {
+        let variant = ModelVariant {
+            format: "Ollama".to_string(),
+            precision: "Q4_K_M".to_string(),
+            size_gb: Some(5.3),
+            url: "https://ollama.com/library/granite4.1:8b".to_string(),
+        };
+        let cm = configured_model(
+            vec![ModelFunction::Chat],
+            FakeProvider {
+                alias: Some("granite4.1:8b".to_string()),
+                ..ok_provider()
+            },
+            Some(("Ollama/Q4_K_M", vec![variant])),
+        );
+        let (_, _, model_name) = cm
+            .resolve_provider_endpoint(
+                "test-model",
+                ApiType::OpenAI,
+                ModelFunction::Chat,
+                ModelFunction::Chat,
+            )
+            .unwrap();
+        assert_eq!(model_name, "granite4.1:8b");
+    }
+
+    #[test]
+    fn resolve_provider_endpoint_falls_back_to_catalog_id_when_alias_is_none() {
+        let variant = ModelVariant {
+            format: "Ollama".to_string(),
+            precision: "Q4_K_M".to_string(),
+            size_gb: Some(5.3),
+            url: "https://ollama.com/library/granite4.1:8b".to_string(),
+        };
+        let cm = configured_model(
+            vec![ModelFunction::Chat],
+            ok_provider(),
+            Some(("Ollama/Q4_K_M", vec![variant])),
+        );
+        let (_, _, model_name) = cm
+            .resolve_provider_endpoint(
+                "test-model",
+                ApiType::OpenAI,
+                ModelFunction::Chat,
+                ModelFunction::Chat,
+            )
+            .unwrap();
+        assert_eq!(model_name, "test-model");
+    }
+
+    #[test]
+    fn resolve_variant_returns_none_without_a_configured_variant() {
+        let cm = configured_model(vec![ModelFunction::Chat], ok_provider(), None);
+        assert!(cm.resolve_variant().is_none());
     }
 }

--- a/src/models/mod.rs
+++ b/src/models/mod.rs
@@ -119,8 +119,8 @@ impl crate::dependency::Configured<dyn Model> for ModelSource {
 // Re-export types from base
 mod base;
 pub use base::{
-    LayerKind, LayerTypeCount, MambaShape, Model, ModelArchitecture, ModelFunction, ModelMetadata,
-    ModelType, ModelVariant,
+    ConfiguredModel, LayerKind, LayerTypeCount, MambaShape, Model, ModelArchitecture,
+    ModelFunction, ModelMetadata, ModelType, ModelVariant,
 };
 
 pub(crate) mod context_fit;

--- a/src/utils/ui/prompt.rs
+++ b/src/utils/ui/prompt.rs
@@ -29,6 +29,9 @@ fn prompt_value(
     label: &str,
 ) -> anyhow::Result<Value> {
     let node = resolve_ref(root, node);
+    if let Some(choices) = enum_choices(root, node) {
+        return prompt_enum_scalar(ui, root, &choices, default, indent, label);
+    }
     match get_promptable_type(node).as_deref() {
         Some("object") => prompt_object(ui, root, node, default, indent, label),
         Some("array") => prompt_array(ui, root, node, default, indent, label),
@@ -56,7 +59,9 @@ fn prompt_object(
         let child_indent = format!("{indent}  ");
         for (name, prop_schema) in properties {
             let prop_schema = resolve_ref(root, prop_schema);
-            if get_promptable_type(prop_schema).is_none() {
+            if get_promptable_type(prop_schema).is_none()
+                && enum_choices(root, prop_schema).is_none()
+            {
                 // Untyped / enum-keyed map / unresolved $ref -- no generic UI
                 // for these; leave absent so serde falls back to the config
                 // struct's own defaults.
@@ -82,6 +87,15 @@ fn prompt_array(
         return Ok(Value::Array(vec![]));
     };
 
+    // A `Vec<PureUnitEnum>` -- every choice is a plain literal, none carry
+    // their own fields -- gets a single one-shot Multi-Select instead of the
+    // per-item "Add?" loop below.
+    if let Some(choices) = enum_choices(root, items_schema)
+        && choices.iter().all(|c| matches!(c, EnumChoice::Literal(_)))
+    {
+        return prompt_enum_array(ui, &choices, default, indent, label);
+    }
+
     let default_items: Vec<Value> = default.as_array().cloned().unwrap_or_default();
     let mut defaults_iter = default_items.into_iter();
     let child_indent = format!("{indent}  ");
@@ -94,11 +108,170 @@ fn prompt_array(
             break;
         }
         let item_default = next_default.unwrap_or_else(|| zero_value_for(items_schema));
-        let item = prompt_value(ui, root, items_schema, &item_default, &child_indent, label)?;
+        let item = if let Some(choices) = enum_choices(root, items_schema) {
+            // Mixed enum (some choices carry their own fields, e.g. an
+            // escape-hatch variant) -- one Select per item, recursing into
+            // sub-fields for whichever choice is picked.
+            prompt_enum_scalar(ui, root, &choices, &item_default, &child_indent, label)?
+        } else {
+            prompt_value(ui, root, items_schema, &item_default, &child_indent, label)?
+        };
         items.push(item);
     }
 
     Ok(Value::Array(items))
+}
+
+/*-- Enum prompts ----------------------------------------------------------------*/
+
+/// One selectable option derived from an enum-shaped schema: a literal value
+/// to use as-is (a unit-variant/plain string-enum entry), or a
+/// single-property "tagged" object schema to recurse into when chosen (an
+/// externally-tagged variant carrying its own fields, e.g. schemars' default
+/// representation of a Rust tuple/struct variant).
+enum EnumChoice {
+    Literal(String),
+    Tagged { key: String, schema: Value },
+}
+
+impl EnumChoice {
+    fn label(&self) -> &str {
+        match self {
+            EnumChoice::Literal(s) => s,
+            EnumChoice::Tagged { key, .. } => key,
+        }
+    }
+}
+
+/// Detects an enum-shaped schema node -- either a plain `{"type": "string",
+/// "enum": [...]}` (an all-unit-variant Rust enum) or a `oneOf` mixing that
+/// shape with externally-tagged single-property object alternatives (a
+/// mixed enum with some data-carrying variants -- schemars' default
+/// representation, confirmed against the vendored `schemars_derive` 1.2.1
+/// source). Returns `None` for anything else, so callers fall back to
+/// today's per-type prompting.
+fn enum_choices(root: &Value, node: &Value) -> Option<Vec<EnumChoice>> {
+    if let Some(values) = node.get("enum").and_then(Value::as_array) {
+        let literals: Vec<EnumChoice> = values
+            .iter()
+            .filter_map(Value::as_str)
+            .map(|s| EnumChoice::Literal(s.to_string()))
+            .collect();
+        return (!literals.is_empty() && literals.len() == values.len()).then_some(literals);
+    }
+    if let Some(s) = node.get("const").and_then(Value::as_str) {
+        return Some(vec![EnumChoice::Literal(s.to_string())]);
+    }
+
+    let alternatives = node.get("oneOf").and_then(Value::as_array)?;
+    let mut choices = Vec::new();
+    for alt in alternatives {
+        let alt = resolve_ref(root, alt);
+        if let Some(values) = alt.get("enum").and_then(Value::as_array) {
+            let strs: Vec<&str> = values.iter().filter_map(Value::as_str).collect();
+            if strs.len() != values.len() {
+                return None;
+            }
+            choices.extend(strs.into_iter().map(|s| EnumChoice::Literal(s.to_string())));
+            continue;
+        }
+        // A unit variant carrying its own schemars attributes (most
+        // commonly: a doc comment, which becomes a `"description"`) can't
+        // be grouped into the shared `enum` array above -- JSON Schema's
+        // `enum` keyword has no way to attach a per-value description --
+        // so schemars gives it its own `{"type": "string", "const": "..."}`
+        // alternative instead. Confirmed against the real schema
+        // `ToolName` generates (see `enum_choices_detects_real_tool_name_schema_with_doc_commented_variants`).
+        if let Some(s) = alt.get("const").and_then(Value::as_str) {
+            choices.push(EnumChoice::Literal(s.to_string()));
+            continue;
+        }
+        let props = alt.get("properties").and_then(Value::as_object)?;
+        let required = alt.get("required").and_then(Value::as_array)?;
+        if props.len() != 1 || required.len() != 1 {
+            return None;
+        }
+        let (key, sub_schema) = props.iter().next()?;
+        if required.first().and_then(Value::as_str) != Some(key.as_str()) {
+            return None;
+        }
+        choices.push(EnumChoice::Tagged {
+            key: key.clone(),
+            schema: sub_schema.clone(),
+        });
+    }
+    (!choices.is_empty()).then_some(choices)
+}
+
+/// Selects one choice. `Tagged` recurses into `prompt_value` for its
+/// sub-schema and wraps the result as `{key: value}` -- reuses whatever
+/// object/string/etc. prompting that variant's own fields need.
+fn prompt_enum_scalar(
+    ui: &dyn Ui,
+    root: &Value,
+    choices: &[EnumChoice],
+    default: &Value,
+    indent: &str,
+    label: &str,
+) -> anyhow::Result<Value> {
+    let labels: Vec<String> = choices.iter().map(|c| c.label().to_string()).collect();
+    let default_idx = default_choice_index(choices, default).unwrap_or(0);
+    let chosen = ui.select(&format!("{indent}{label}"), &labels, default_idx)?;
+    match &choices[chosen] {
+        EnumChoice::Literal(s) => Ok(Value::String(s.clone())),
+        EnumChoice::Tagged { key, schema } => {
+            let child_indent = format!("{indent}  ");
+            let sub_default = default.get(key).cloned().unwrap_or(Value::Null);
+            let value = prompt_value(ui, root, schema, &sub_default, &child_indent, key)?;
+            Ok(serde_json::json!({ key: value }))
+        }
+    }
+}
+
+/// One-shot Multi-Select over an array whose items are all `Literal`
+/// choices (a `Vec<PureUnitEnum>` field), replacing the generic per-item
+/// "Add?" loop with a single checklist prompt.
+fn prompt_enum_array(
+    ui: &dyn Ui,
+    choices: &[EnumChoice],
+    default: &Value,
+    indent: &str,
+    label: &str,
+) -> anyhow::Result<Value> {
+    let labels: Vec<String> = choices.iter().map(|c| c.label().to_string()).collect();
+    let default_items: Vec<&str> = default
+        .as_array()
+        .map(|a| a.iter().filter_map(Value::as_str).collect())
+        .unwrap_or_default();
+    let defaults: Vec<bool> = labels
+        .iter()
+        .map(|l| default_items.contains(&l.as_str()))
+        .collect();
+    let chosen = ui.multi_select(&format!("{indent}{label}"), &labels, &defaults)?;
+    Ok(Value::Array(
+        chosen
+            .into_iter()
+            .map(|i| Value::String(labels[i].clone()))
+            .collect(),
+    ))
+}
+
+/// Finds which choice `default` corresponds to, so the Select can pre-select
+/// it: a plain string default matches a `Literal`'s value; a single-key
+/// object default (`{key: ...}`) matches a `Tagged` choice's key.
+fn default_choice_index(choices: &[EnumChoice], default: &Value) -> Option<usize> {
+    if let Some(s) = default.as_str() {
+        return choices
+            .iter()
+            .position(|c| matches!(c, EnumChoice::Literal(l) if l == s));
+    }
+    if let Some(obj) = default.as_object() {
+        let key = obj.keys().next()?;
+        return choices
+            .iter()
+            .position(|c| matches!(c, EnumChoice::Tagged { key: k, .. } if k == key));
+    }
+    None
 }
 
 /*-- Leaf prompts ---------------------------------------------------------------*/
@@ -481,5 +654,230 @@ mod tests {
             zero_value_for(&json!({"type": ["integer", "null"]})),
             json!(0)
         );
+    }
+
+    #[test]
+    fn enum_choices_detects_pure_unit_enum() {
+        let node = json!({"type": "string", "enum": ["FileRead", "FileWrite"]});
+        let choices = enum_choices(&json!({}), &node).unwrap();
+        assert_eq!(choices.len(), 2);
+        assert!(choices.iter().all(|c| matches!(c, EnumChoice::Literal(_))));
+        assert_eq!(choices[0].label(), "FileRead");
+        assert_eq!(choices[1].label(), "FileWrite");
+    }
+
+    #[test]
+    fn enum_choices_detects_mixed_enum_with_tagged_variants() {
+        let node = json!({
+            "oneOf": [
+                {"type": "string", "enum": ["FileRead", "FileWrite"]},
+                {"type": "object", "properties": {"Mcp": {"type": "object"}}, "required": ["Mcp"]},
+                {"type": "object", "properties": {"Other": {"type": "string"}}, "required": ["Other"]},
+            ]
+        });
+        let choices = enum_choices(&json!({}), &node).unwrap();
+        let labels: Vec<&str> = choices.iter().map(EnumChoice::label).collect();
+        assert_eq!(labels, vec!["FileRead", "FileWrite", "Mcp", "Other"]);
+        assert!(matches!(choices[2], EnumChoice::Tagged { .. }));
+        assert!(matches!(choices[3], EnumChoice::Tagged { .. }));
+    }
+
+    #[test]
+    fn enum_choices_returns_none_for_non_enum_schema() {
+        assert!(enum_choices(&json!({}), &json!({"type": "object", "properties": {}})).is_none());
+        assert!(enum_choices(&json!({}), &json!({"type": "string"})).is_none());
+        assert!(enum_choices(&json!({}), &json!({})).is_none());
+    }
+
+    #[test]
+    fn enum_choices_returns_none_for_one_of_alternative_that_is_not_single_tagged_property() {
+        // A oneOf alternative with more than one property isn't a
+        // single-property externally-tagged enum variant.
+        let node = json!({
+            "oneOf": [
+                {"type": "string", "enum": ["FileRead"]},
+                {"type": "object", "properties": {"a": {}, "b": {}}, "required": ["a", "b"]},
+            ]
+        });
+        assert!(enum_choices(&json!({}), &node).is_none());
+    }
+
+    #[test]
+    fn prompt_from_schema_drives_mixed_enum_array_through_select_and_tagged_recursion() {
+        use crate::utils::ui::base::tests::CaptureUi;
+
+        #[derive(Debug, Clone, serde::Serialize, serde::Deserialize, schemars::JsonSchema)]
+        #[allow(dead_code)]
+        enum TestTool {
+            FileRead,
+            FileWrite,
+            Mcp {
+                server: String,
+                tool: Option<String>,
+            },
+            Other(String),
+        }
+
+        #[derive(Debug, Clone, serde::Serialize, serde::Deserialize, schemars::JsonSchema)]
+        struct TestConfig {
+            tools: Vec<TestTool>,
+        }
+
+        let ui = CaptureUi::default();
+        ui.confirm_answers.borrow_mut().push_back(true); // Add tools item? yes
+        ui.select_answers.borrow_mut().push_back(2); // choices[2] == "Mcp"
+        ui.text_answers.borrow_mut().push_back("vision".to_string()); // server
+        ui.text_answers
+            .borrow_mut()
+            .push_back("vlm_compare_images".to_string()); // tool
+        ui.confirm_answers.borrow_mut().push_back(false); // Add tools item? no more
+
+        let schema = schemars::schema_for!(TestConfig);
+        let result = prompt_from_schema(&ui, &schema, &json!({})).unwrap();
+
+        assert_eq!(
+            result,
+            json!({"tools": [{"Mcp": {"server": "vision", "tool": "vlm_compare_images"}}]})
+        );
+    }
+
+    #[test]
+    fn enum_choices_detects_a_one_of_alternative_shaped_as_const_not_enum() {
+        // A unit variant carrying its own schemars attributes (e.g. a doc
+        // comment, which becomes a "description") gets its own
+        // `{"type": "string", "const": "..."}` alternative rather than
+        // being grouped into a shared `enum` array -- JSON Schema's `enum`
+        // keyword can't carry a per-value description. This is exactly
+        // what `ToolName`'s doc-commented variants (`Search`, `FileSearch`,
+        // `Shell`) produce; without this case `enum_choices` bails via `?`
+        // on the very first such alternative and returns `None` for the
+        // *entire* enum.
+        let node = json!({
+            "oneOf": [
+                {"type": "string", "enum": ["FileRead", "FileWrite"]},
+                {"type": "string", "const": "Search", "description": "Content search."},
+                {"type": "object", "properties": {"Other": {"type": "string"}}, "required": ["Other"]},
+            ]
+        });
+        let choices = enum_choices(&json!({}), &node).unwrap();
+        let labels: Vec<&str> = choices.iter().map(EnumChoice::label).collect();
+        assert_eq!(labels, vec!["FileRead", "FileWrite", "Search", "Other"]);
+        assert!(matches!(choices[2], EnumChoice::Literal(_)));
+    }
+
+    #[test]
+    fn enum_choices_detects_the_real_tool_name_schema_end_to_end() {
+        // Regression test: an earlier version of `enum_choices` didn't
+        // recognize the `const`-shaped alternative above, so it returned
+        // `None` for the real `ToolName` type (which has doc comments on
+        // some but not all unit variants) even though it worked for
+        // hand-written schemas and a doc-comment-free test enum. Exercise
+        // the actual production types, not a synthetic schema.
+        let schema = schemars::schema_for!(crate::capabilities::SubAgentCapabilityConfig);
+        let root = serde_json::to_value(&schema).unwrap();
+        let items_schema = root
+            .get("properties")
+            .and_then(|p| p.get("tools"))
+            .map(|v| resolve_ref(&root, v))
+            .and_then(|tools| tools.get("items"))
+            .map(|v| resolve_ref(&root, v))
+            .expect("tools.items present");
+        assert!(enum_choices(&root, items_schema).is_some());
+    }
+
+    #[test]
+    fn prompt_from_schema_drives_the_real_sub_agent_capability_config_end_to_end() {
+        use crate::capabilities::SubAgentCapabilityConfig;
+        use crate::utils::ui::base::tests::CaptureUi;
+
+        let ui = CaptureUi::default();
+        // Fields prompt in alphabetical property order (plain serde_json::Map):
+        // description, model_id, prompt, tools.
+        ui.text_answers
+            .borrow_mut()
+            .push_back("Reviews code".to_string());
+        ui.text_answers
+            .borrow_mut()
+            .push_back("granite-3.1-8b-instruct".to_string());
+        ui.text_answers
+            .borrow_mut()
+            .push_back("You are a meticulous code reviewer.".to_string());
+        ui.confirm_answers.borrow_mut().push_back(true); // Add tools? yes
+        // Flattened choice order: FileRead, FileWrite, FileEdit, WebFetch,
+        // WebSearch (the shared enum group, in that order), then each
+        // doc-commented unit variant's own const alternative -- Search,
+        // FileSearch, Shell -- then Mcp, Other. Index 5 == "Search".
+        ui.select_answers.borrow_mut().push_back(5);
+        ui.confirm_answers.borrow_mut().push_back(false); // Add tools? no more
+
+        let schema = schemars::schema_for!(SubAgentCapabilityConfig);
+        let result = prompt_from_schema(&ui, &schema, &json!({})).unwrap();
+
+        assert_eq!(result["description"], "Reviews code");
+        assert_eq!(result["model_id"], "granite-3.1-8b-instruct");
+        assert_eq!(result["prompt"], "You are a meticulous code reviewer.");
+        assert_eq!(result["tools"], json!(["Search"]));
+
+        // Deserializes back into the real config type.
+        let config: SubAgentCapabilityConfig = serde_json::from_value(result).unwrap();
+        assert_eq!(config.tools, vec![crate::capabilities::ToolName::Search]);
+    }
+
+    #[test]
+    fn prompt_from_schema_drives_mixed_enum_array_through_select_of_a_plain_literal() {
+        use crate::utils::ui::base::tests::CaptureUi;
+
+        #[derive(Debug, Clone, serde::Serialize, serde::Deserialize, schemars::JsonSchema)]
+        #[allow(dead_code)]
+        enum TestTool {
+            FileRead,
+            FileWrite,
+            Other(String),
+        }
+
+        #[derive(Debug, Clone, serde::Serialize, serde::Deserialize, schemars::JsonSchema)]
+        struct TestConfig {
+            tools: Vec<TestTool>,
+        }
+
+        let ui = CaptureUi::default();
+        ui.confirm_answers.borrow_mut().push_back(true); // Add tools item? yes
+        ui.select_answers.borrow_mut().push_back(0); // choices[0] == "FileRead"
+        ui.confirm_answers.borrow_mut().push_back(false); // Add tools item? no more
+
+        let schema = schemars::schema_for!(TestConfig);
+        let result = prompt_from_schema(&ui, &schema, &json!({})).unwrap();
+
+        assert_eq!(result, json!({"tools": ["FileRead"]}));
+    }
+
+    #[test]
+    fn prompt_from_schema_multi_selects_a_pure_unit_enum_array_in_one_shot() {
+        use crate::utils::ui::base::tests::CaptureUi;
+
+        #[derive(Debug, Clone, serde::Serialize, serde::Deserialize, schemars::JsonSchema)]
+        #[allow(dead_code)]
+        enum TestTool {
+            FileRead,
+            FileWrite,
+            Shell,
+        }
+
+        #[derive(Debug, Clone, serde::Serialize, serde::Deserialize, schemars::JsonSchema)]
+        struct TestConfig {
+            tools: Vec<TestTool>,
+        }
+
+        let ui = CaptureUi::default();
+        // A single multi_select call picking FileRead (0) and Shell (2) -- no
+        // "Add another?" confirm loop for a pure (escape-hatch-free) enum.
+        ui.multi_select_answers.borrow_mut().push_back(vec![0, 2]);
+
+        let schema = schemars::schema_for!(TestConfig);
+        let result = prompt_from_schema(&ui, &schema, &json!({})).unwrap();
+
+        assert_eq!(result, json!({"tools": ["FileRead", "Shell"]}));
+        assert_eq!(ui.multi_select_prompts.borrow().len(), 1);
+        assert!(ui.confirm_prompts.borrow().is_empty());
     }
 }


### PR DESCRIPTION
## Description

This PR adds support for a new binding type for `SubAgentBinding` along with a generic implementation as `SubAgentCapability`. It implements support for this binding type in `ClaudeLauncher` as the first proof-of-concept.

## Changes

- Add `SubAgentBinding` type
- Add `SubAgentCapability` implementation for `SubAgentBinding` w/ generic prompt-based agent
- Add `ToolName` enum in `capabilities/base.rs` to support launcher-agnostic tool name mapping. This will allow individual launchers to define their own alias for well-known tools.
- Add support for enums in `prompt_for_schema`
- Add `launchers/shared/model_router.rs` to handle routing between different base URLs for different models when a launcher only supports a single upstream base URL (eg Claude).
- Abstracted out shared model dependency resolution for capabilities into models/base.rs

## Testing

- Unit testing
- End-to-end using `claude`

```sh
GRANITE_CLI_HOME=$PWD/tmp cargo run -q launcher setup claude
# > [x] Configure a new capability...
# > sub-agent
# Name this capability instance: sub-agent-explore
#   description: foobar
#   prompt: You are a codebase exploration agent. Your goal is to investigate the architecture of a given codebase and understand the architecture related to a given prompt. This should include identifying key abstractions related to the prompt (eg base classes / interfaces, config surfaces, etc), identifying areas of the codebase related to the prompt (eg extension module paths, factory registrations, pre-existing files related to the prompt), and summarizing your findings for easy navigation.
#   Add tools? yes
#     tools: FileRead
#   Add tools? yes
#     tools: Search
#   Add tools? yes
#     tools: FileSearch
#   Add tools? yes
#     tools: Shell
#   Add tools? no
# Select a model type to configure:: granite-4.1-3b
# > Ollama / Q4_K_M (2.1 GB)
```

**NOTE:** For non-standard claude upstreams, don't forget to set `ANTHROPIC_BASE_URL` and `ANTHROPIC_AUTH_TOKEN` in the `launch claude` environment below.

```sh
GRANITE_CLI_HOME=$PWD/tmp cargo run -q launch claude -- "Use sub-agent-explorer to figure out the architecture of adding a new Launcher"
```

```sh

▗ ▗   ▖ ▖  Claude Code v2.1.241
           Sonnet 5 with high effort · API Usage Billing
  ▘▘ ▝▝    ~/Projects/github/ibm-granite-community/granite-cli/.claude/worktrees/SubAgentCapability


❯ Use sub-agent-explorer to figure out the architecture of adding a new Launcher

⏺ sub-agent-explore(Explore Launcher architecture in granite-cli)
Backgrounded agent (↓ to manage · ctrl+o to expand)

I've launched the sub-agent-explore agent to map out the Launcher architecture — it's investigating the Launcher trait, ClaudeLauncher's structure, how SubAgentBinding fits in, model_router.rs dispatch logic, and what would need to change to add a new Launcher. I'll report back once it finishes.

✻ Waiting for 1 background agent to finish
```

## Related Issue(s)

Closes #72 

## AI Usage

This PR was primarily built using Claude Code. Commits were made by hand based on subcomponents of implementation.

```sh
╔══════════════════════════════════════════════════════════╗
║           GIT AI USAGE ANALYSIS                          ║
╚══════════════════════════════════════════════════════════╝

📊 COMMITS BY AGENT

--- Aggregate ---
Commits                        |      Count
---------------------------------------------
Claude + Sonnet 5              |         10
none                           |          4
---------------------------------------------
TOTAL                          |         14

📊 COMMITS BY USAGE TYPE

--- Aggregate ---
Commits                        |      Count
---------------------------------------------
none                           |          4
draft                          |          0
full                           |         10
---------------------------------------------
TOTAL                          |         14

📈 LINES OF CODE BY AGENT

--- Aggregate ---
Agent                     |    Commits |  Additions |  Deletions
------------------------------------------------------------
Claude + Sonnet 5         |         10 |       2791 |        165
none                      |          4 |         14 |          5
------------------------------------------------------------
TOTAL                     |         14 |       2805 |        170

📈 LINES OF CODE BY USAGE TYPE

--- Aggregate ---
Usage Type           |    Commits |  Additions |  Deletions
-------------------------------------------------------
none                 |          4 |         14 |          5
draft                |          0 |          0 |          0
full                 |         10 |       2791 |        165
-------------------------------------------------------
TOTAL                |         14 |       2805 |        170
```