### PR TITLE
Plan sub-agent / OpenCode sub-agents

### DIFF
--- a/docs/specs/0021-sub-agent-capability.md
+++ b/docs/specs/0021-sub-agent-capability.md
@@ -102,12 +102,14 @@ mode doesn't care which credential scheme it's carrying, but genuinely
 cloud-provider-specific request signing is not something this proxy
 attempts.
 
-**Any launcher other than `claude`.** `pi`, `bob`, and `opencode` are
-unaffected — they simply don't declare `BindingType::SubAgent` in their
+**Any launcher other than `claude`.** `pi` and `bob` are unaffected — they
+simply don't declare `BindingType::SubAgent` in their
 `supported_capabilities`, so the existing subset check in
 `bind_capability`/`select_capabilities` rejects enabling a `SubAgentCapability`
 for them, the same way it already rejects any other unsupported binding
-type.
+type. (`opencode` gained `BindingType::SubAgent` support later, since its
+config's native multi-provider support means it needs none of this spec's
+mini-router -- see `src/launchers/opencode.rs`.)
 
 **Cost/pricing accounting for subscription vs. API-key billing** — per the
 issue's own caveat.

--- a/src/capabilities/base.rs
+++ b/src/capabilities/base.rs
@@ -147,6 +147,7 @@ pub enum ToolName {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, schemars::JsonSchema)]
 pub enum KnownSubAgent {
     Explore,
+    Plan,
 }
 
 /// Result payload for `BindingType::SubAgent`: a named sub-agent's prompt,

--- a/src/capabilities/mod.rs
+++ b/src/capabilities/mod.rs
@@ -13,6 +13,7 @@ pub static CAPABILITY_REGISTRY: LazyLock<base::CapabilityFactory> = LazyLock::ne
     factory.register::<vision_mcp::VisionMCPCapability>("vision-mcp");
     factory.register::<sub_agent::SubAgentCapability>("sub-agent");
     factory.register::<sub_agent_explore::ExploreSubAgentCapability>("sub-agent-explore");
+    factory.register::<sub_agent_plan::PlanSubAgentCapability>("sub-agent-plan");
     factory
 });
 
@@ -96,6 +97,9 @@ pub use sub_agent::{SubAgentCapability, SubAgentCapabilityConfig};
 mod sub_agent_explore;
 pub use sub_agent_explore::{ExploreSubAgentCapability, ExploreSubAgentCapabilityConfig};
 
+mod sub_agent_plan;
+pub use sub_agent_plan::{PlanSubAgentCapability, PlanSubAgentCapabilityConfig};
+
 /*-- tests ---------------------------------------------------------------------*/
 
 #[cfg(test)]
@@ -160,5 +164,10 @@ mod tests {
     #[test]
     fn capability_registry_has_sub_agent() {
         assert!(CAPABILITY_REGISTRY.get("sub-agent").is_some());
+    }
+
+    #[test]
+    fn capability_registry_has_sub_agent_plan() {
+        assert!(CAPABILITY_REGISTRY.get("sub-agent-plan").is_some());
     }
 }

--- a/src/capabilities/sub_agent_plan.rs
+++ b/src/capabilities/sub_agent_plan.rs
@@ -1,0 +1,508 @@
+//! `PlanSubAgentCapability`: defines a named planning sub-agent with a static
+//! prompt and fixed tool allow-list (FileRead, Search, FileSearch, Shell,
+//! WebFetch, WebSearch -- everything read-only, no FileWrite/FileEdit), and a
+//! `Model`/`Provider` of its own. Mirrors `ExploreSubAgentCapability`.
+
+// Standard
+use serde_valid::Validate;
+use std::collections::HashSet;
+
+// Third Party
+use async_trait::async_trait;
+use serde::{Deserialize, Serialize};
+
+// Local
+use crate::capabilities::ModelRequirement;
+use crate::capabilities::base::{
+    AgentModelBinding, Binding, BindingRequest, BindingType, Capability, CapabilityMetadata,
+    Dependency, HasCapabilityMetadata, KnownSubAgent, SubAgentBinding, SubAgentBindingRequest,
+    ToolName,
+};
+use crate::models::{ConfiguredModel, ModelFunction};
+use crate::registry::ConfigConstructable;
+
+/*-- PlanSubAgentCapabilityConfig --------------------------------------------*/
+
+/// Configuration for the plan sub-agent capability. Unlike `SubAgentCapability`,
+/// the prompt and tools are static (not configurable via JSON), leaving only the
+/// description (what the sub-agent does) and model_id as configurable.
+#[derive(Debug, Clone, Serialize, Deserialize, Default, schemars::JsonSchema, Validate)]
+pub struct PlanSubAgentCapabilityConfig {
+    /// Shown to the main agent so it can decide when to delegate to this
+    /// plan sub-agent.
+    #[validate(min_length = 1)]
+    pub description: String,
+    /// Key into the configured models map (the user-chosen instance ID) for
+    /// the model this sub-agent runs on.
+    #[validate(min_length = 1)]
+    pub model_id: String,
+}
+
+/*-- PlanSubAgentCapability -----------------------------------------------*/
+
+const PLAN_PROMPT: &str = "You are a software architect and planning specialist. Your role is to explore the codebase and design implementation plans.
+
+=== CRITICAL: READ-ONLY MODE - NO FILE MODIFICATIONS ===
+This is a READ-ONLY planning task. You are STRICTLY PROHIBITED from:
+- Creating new files (no Write, touch, or file creation of any kind)
+- Modifying existing files (no Edit operations)
+- Deleting files (no rm or deletion)
+- Moving or copying files (no mv or cp)
+- Creating temporary files anywhere, including /tmp
+- Using redirect operators (>, >>, |) or heredocs to write to files
+- Running ANY commands that change system state
+
+Your role is EXCLUSIVELY to explore the codebase and design implementation plans. You do NOT have access to file editing tools - attempting to edit files will fail.
+
+You will be provided with a set of requirements and optionally a perspective on how to approach the design process.
+
+## Your Process
+
+1. **Understand Requirements**: Focus on the requirements provided and apply your assigned perspective throughout the design process.
+
+2. **Explore Thoroughly**:
+   - Read any files provided to you in the initial prompt
+   - Find existing patterns and conventions using `find`, `grep`, file search / glob, and search
+   - Understand the current architecture
+   - Identify similar features as reference
+   - Trace through relevant code paths
+   - Use the shell tool ONLY for read-only operations (`ls, git status, git log, git diff, find, grep, cat, head, tail, git status, git log, git diff`
+   - NEVER use the shell tool for: `mkdir, touch, rm, cp, mv, git add, git commit, npm install, pip install, git add, git commit, npm install, pip install`, or any file creation/modification
+
+3. **Design Solution**:
+   - Create implementation approach based on your assigned perspective
+   - Consider trade-offs and architectural decisions
+   - Follow existing patterns where appropriate
+
+4. **Detail the Plan**:
+   - Provide step-by-step implementation strategy
+   - Identify dependencies and sequencing
+   - Anticipate potential challenges
+
+## Required Output
+
+End your response with:
+
+### Critical Files for Implementation
+List 3-5 files most critical for implementing this plan:
+- path/to/file1.ts
+- path/to/file2.ts
+- path/to/file3.ts
+
+REMEMBER: You can ONLY explore and plan. You CANNOT and MUST NOT write, edit, or modify any files. You do NOT have access to file editing tools.";
+
+pub struct PlanSubAgentCapability {
+    instance_id: String,
+    config: PlanSubAgentCapabilityConfig,
+    configured_model: ConfiguredModel,
+    /// Static prompt for the plan sub-agent (placeholder for now; user can
+    /// override by editing this field later).
+    pub prompt: String,
+    /// Static tool allow-list for the plan sub-agent.
+    pub tools: Vec<ToolName>,
+}
+
+impl ConfigConstructable for PlanSubAgentCapability {
+    type Config = PlanSubAgentCapabilityConfig;
+
+    /// Constructs the capability by resolving its model through
+    /// `ConfiguredModel`, exactly like `AgentModelCapability::new` -- so
+    /// `model.provider()` works at bind time and, when a usage-tracking
+    /// session is active, the model is transparently tracked.
+    fn new(
+        instance_id: &str,
+        cfg: &serde_json::Value,
+        global_config: &crate::config::Config,
+    ) -> Self {
+        let config: PlanSubAgentCapabilityConfig =
+            serde_json::from_value(cfg.clone()).unwrap_or_default();
+        let configured_model = ConfiguredModel::resolve(&config.model_id, global_config);
+
+        // Static prompt
+        // TODO: Make prompt a template that should be expanded by the launcher
+        let prompt = PLAN_PROMPT.to_string();
+        // Static tools: everything read-only (no FileWrite/FileEdit)
+        let tools = vec![
+            ToolName::FileRead,
+            ToolName::Search,
+            ToolName::FileSearch,
+            ToolName::Shell,
+            ToolName::WebFetch,
+            ToolName::WebSearch,
+        ];
+
+        Self {
+            instance_id: instance_id.to_string(),
+            config,
+            configured_model,
+            prompt,
+            tools,
+        }
+    }
+}
+
+impl crate::registry::Named for PlanSubAgentCapability {
+    fn instance_id(&self) -> &str {
+        &self.instance_id
+    }
+}
+
+#[async_trait]
+impl Capability for PlanSubAgentCapability {
+    fn name(&self) -> &str {
+        "Plan Sub-Agent"
+    }
+
+    fn description(&self) -> &str {
+        "Defines a named planning sub-agent (static prompt, fixed read-only tools, and model) that a launched coding agent can delegate implementation-plan design to."
+    }
+
+    fn dependencies(&self) -> Vec<Dependency> {
+        vec![Dependency::Model {
+            config_key: "model_id".to_string(),
+            requirement: ModelRequirement {
+                supported_functions: vec![ModelFunction::Chat, ModelFunction::ToolCalling],
+                ..Default::default()
+            },
+            resolved_id: Some(self.config.model_id.clone()),
+            required: true,
+        }]
+    }
+
+    fn binding_types(&self) -> HashSet<BindingType> {
+        HashSet::from([BindingType::SubAgent])
+    }
+
+    async fn bind(&self, request: BindingRequest) -> anyhow::Result<Binding> {
+        let api_type = match request {
+            BindingRequest::SubAgent(SubAgentBindingRequest { api_type }) => api_type,
+            other => anyhow::bail!(
+                "PlanSubAgentCapability does not handle {:?} binding requests",
+                other.binding_type()
+            ),
+        };
+        let model_id = &self.config.model_id;
+
+        let (provider, endpoint, model_name) = self.configured_model.resolve_provider_endpoint(
+            model_id,
+            api_type.clone(),
+            ModelFunction::Chat,
+            ModelFunction::Chat,
+        )?;
+
+        Ok(Binding::SubAgent(SubAgentBinding {
+            description: self.config.description.clone(),
+            prompt: self.prompt.clone(),
+            tools: self.tools.clone(),
+            model: AgentModelBinding {
+                api_type,
+                provider_name: provider.instance_id().to_string(),
+                base_url: provider.base_url().to_string(),
+                model_name,
+                endpoint_path: endpoint.path().to_string(),
+                api_key: provider.api_key().cloned(),
+                verify_ssl: provider.verify_ssl(),
+                context_length: Some(self.configured_model.model.context_length()),
+            },
+            known_type: Some(KnownSubAgent::Plan),
+        }))
+    }
+}
+
+impl HasCapabilityMetadata for PlanSubAgentCapability {
+    fn metadata() -> CapabilityMetadata {
+        CapabilityMetadata {
+            name: "Plan Sub-Agent".to_string(),
+            description: "Defines a named planning sub-agent (static prompt, fixed read-only tools, and model) that a launched coding agent can delegate implementation-plan design to.".to_string(),
+            dependencies: vec![Dependency::Model {
+                config_key: "model_id".to_string(),
+                requirement: ModelRequirement {
+                    supported_functions: vec![ModelFunction::Chat, ModelFunction::ToolCalling],
+                    ..Default::default()
+                },
+                resolved_id: None,
+                required: true,
+            }],
+            tags: vec!["agent".to_string(), "plan".to_string()],
+            supported_binding_types: HashSet::from([BindingType::SubAgent]),
+        }
+    }
+}
+
+/*-- tests -------------------------------------------------------------------*/
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::{Config, ModelConfig};
+    use crate::models::Model;
+    use crate::providers::{
+        ApiEndpoint, ApiType, HealthStatus, ModelFormat, Provider, ProviderError,
+    };
+    use crate::registry::Secret;
+    use std::collections::HashMap;
+    use std::sync::Arc;
+
+    #[derive(Clone, Default)]
+    struct FakeProvider {
+        instance_id: String,
+        base_url: String,
+        api_key: Option<Secret>,
+        verify_ssl: bool,
+        api_types: Vec<ApiType>,
+        endpoints: HashMap<ModelFunction, Vec<ApiEndpoint>>,
+        alias: Option<String>,
+    }
+
+    impl ConfigConstructable for FakeProvider {
+        type Config = crate::registry::NoConfig;
+        fn new(_: &str, _: &serde_json::Value, _: &crate::config::Config) -> Self {
+            unimplemented!("not used in tests")
+        }
+    }
+
+    impl crate::registry::Named for FakeProvider {
+        fn instance_id(&self) -> &str {
+            &self.instance_id
+        }
+    }
+
+    #[async_trait]
+    impl Provider for FakeProvider {
+        fn name(&self) -> &str {
+            "Fake Provider"
+        }
+        fn function_endpoints(&self) -> HashMap<ModelFunction, Vec<ApiEndpoint>> {
+            self.endpoints.clone()
+        }
+        fn supported_api_types(&self) -> Vec<ApiType> {
+            self.api_types.clone()
+        }
+        fn base_url(&self) -> &str {
+            &self.base_url
+        }
+        fn api_key(&self) -> Option<&Secret> {
+            self.api_key.as_ref()
+        }
+        fn verify_ssl(&self) -> bool {
+            self.verify_ssl
+        }
+        fn supported_formats(&self) -> Vec<ModelFormat> {
+            vec![]
+        }
+        fn model_alias(&self, _variant: Option<&crate::models::ModelVariant>) -> Option<String> {
+            self.alias.clone()
+        }
+        async fn health_check(&self) -> Result<HealthStatus, ProviderError> {
+            unimplemented!("not used in tests")
+        }
+    }
+
+    fn ok_provider() -> FakeProvider {
+        let mut endpoints = HashMap::new();
+        endpoints.insert(
+            ModelFunction::Chat,
+            vec![ApiEndpoint::OpenAIChat, ApiEndpoint::AnthropicMessages],
+        );
+        FakeProvider {
+            instance_id: "my-ollama".to_string(),
+            base_url: "http://localhost:11434".to_string(),
+            api_key: None,
+            verify_ssl: true,
+            api_types: vec![ApiType::OpenAI, ApiType::Anthropic],
+            endpoints,
+            alias: None,
+        }
+    }
+
+    struct TestModel {
+        supported_functions: Vec<ModelFunction>,
+        provider: FakeProvider,
+    }
+
+    impl ConfigConstructable for TestModel {
+        type Config = crate::registry::NoConfig;
+        fn new(_: &str, _: &serde_json::Value, _: &crate::config::Config) -> Self {
+            unimplemented!("not used in tests")
+        }
+    }
+
+    impl crate::registry::Named for TestModel {
+        fn instance_id(&self) -> &str {
+            "granite-3.1-8b-instruct"
+        }
+    }
+
+    impl Model for TestModel {
+        fn family(&self) -> &str {
+            "Test"
+        }
+        fn version(&self) -> &str {
+            "1.0"
+        }
+        fn size(&self) -> u64 {
+            1
+        }
+        fn context_length(&self) -> u64 {
+            4096
+        }
+        fn model_type(&self) -> &crate::models::ModelType {
+            &crate::models::ModelType::Text
+        }
+        fn huggingface_repo(&self) -> &str {
+            "test/test"
+        }
+        fn native_dtype(&self) -> &str {
+            "bfloat16"
+        }
+        fn architecture(&self) -> &crate::models::ModelArchitecture {
+            unimplemented!("not used in tests")
+        }
+        fn variants(&self) -> &[crate::models::ModelVariant] {
+            &[]
+        }
+        fn description(&self) -> Option<&str> {
+            None
+        }
+        fn tags(&self) -> &[String] {
+            &[]
+        }
+        fn supported_functions(&self) -> &[ModelFunction] {
+            &self.supported_functions
+        }
+        fn provider(&self) -> anyhow::Result<Box<dyn Provider>> {
+            Ok(Box::new(self.provider.clone()))
+        }
+    }
+
+    /// Builds a `PlanSubAgentCapability` with a real registry model id (so
+    /// construction succeeds) and then swaps in a test double model/provider,
+    /// mirroring the test pattern from `sub_agent_explore.rs`.
+    fn plan_capability_with_test_model(
+        functions: Vec<ModelFunction>,
+        provider: FakeProvider,
+    ) -> PlanSubAgentCapability {
+        let mut config = Config::default();
+        config.models.insert(
+            "granite-3.1-8b-instruct".to_string(),
+            ModelConfig {
+                model_id: "granite-3.1-8b-instruct".to_string(),
+                provider_id: None,
+                variant: None,
+            },
+        );
+        let cap = PlanSubAgentCapability::new(
+            "planner",
+            &serde_json::json!({
+                "description": "Plans changes",
+                "model_id": "granite-3.1-8b-instruct",
+            }),
+            &config,
+        );
+        PlanSubAgentCapability {
+            instance_id: cap.instance_id,
+            config: cap.config,
+            configured_model: crate::models::ConfiguredModel::for_test(
+                Arc::new(TestModel {
+                    supported_functions: functions,
+                    provider,
+                }),
+                None,
+            ),
+            prompt: cap.prompt,
+            tools: cap.tools,
+        }
+    }
+
+    fn request(api_type: ApiType) -> BindingRequest {
+        BindingRequest::SubAgent(SubAgentBindingRequest { api_type })
+    }
+
+    #[tokio::test]
+    async fn bind_succeeds_and_carries_description_prompt_and_tools() {
+        let mut config = Config::default();
+        config.models.insert(
+            "granite-3.1-8b-instruct".to_string(),
+            ModelConfig {
+                model_id: "granite-3.1-8b-instruct".to_string(),
+                provider_id: None,
+                variant: None,
+            },
+        );
+        let cap = PlanSubAgentCapability::new(
+            "planner",
+            &serde_json::json!({
+                "description": "Plans changes",
+                "model_id": "granite-3.1-8b-instruct",
+            }),
+            &config,
+        );
+        let cap = PlanSubAgentCapability {
+            instance_id: cap.instance_id,
+            config: cap.config,
+            configured_model: crate::models::ConfiguredModel::for_test(
+                Arc::new(TestModel {
+                    supported_functions: vec![ModelFunction::Chat],
+                    provider: ok_provider(),
+                }),
+                None,
+            ),
+            prompt: cap.prompt,
+            tools: cap.tools,
+        };
+
+        let binding = cap.bind(request(ApiType::Anthropic)).await.unwrap();
+        let Binding::SubAgent(binding) = binding else {
+            panic!("expected SubAgent binding")
+        };
+        assert_eq!(binding.description, "Plans changes");
+        assert_eq!(binding.prompt, PLAN_PROMPT.to_string());
+        assert_eq!(
+            binding.tools,
+            vec![
+                ToolName::FileRead,
+                ToolName::Search,
+                ToolName::FileSearch,
+                ToolName::Shell,
+                ToolName::WebFetch,
+                ToolName::WebSearch,
+            ]
+        );
+        assert_eq!(binding.model.base_url, "http://localhost:11434");
+        assert_eq!(binding.model.model_name, "granite-3.1-8b-instruct");
+        assert_eq!(binding.model.api_type, ApiType::Anthropic);
+    }
+
+    #[test]
+    fn binding_types_reports_sub_agent() {
+        let cap = plan_capability_with_test_model(vec![ModelFunction::Chat], ok_provider());
+        assert_eq!(cap.binding_types(), HashSet::from([BindingType::SubAgent]));
+    }
+
+    #[test]
+    fn dependencies_carry_resolved_model_id() {
+        let cap = plan_capability_with_test_model(vec![ModelFunction::Chat], ok_provider());
+        let deps = cap.dependencies();
+        assert_eq!(deps.len(), 1);
+        assert!(deps.iter().any(|d| matches!(
+            d,
+            Dependency::Model { resolved_id: Some(id), .. } if id == "granite-3.1-8b-instruct"
+        )));
+    }
+
+    #[test]
+    fn metadata_reports_supported_binding_types_and_wildcard_dependency() {
+        let meta = PlanSubAgentCapability::metadata();
+        assert_eq!(
+            meta.supported_binding_types,
+            HashSet::from([BindingType::SubAgent])
+        );
+        assert!(meta.dependencies.iter().any(|d| matches!(
+            d,
+            Dependency::Model {
+                resolved_id: None,
+                ..
+            }
+        )));
+    }
+}

--- a/src/commands/capability.rs
+++ b/src/commands/capability.rs
@@ -664,6 +664,7 @@ mod tests {
 
     #[tokio::test]
     async fn setup_agent_model_persists_config() {
+        let _home = crate::config::TestConfigHome::new();
         let mut ctx = ctx_with_chat_capable_model();
         // CaptureUi's text() echoes back the default when prompted; here we
         // pass an explicit instance id so no prompt is needed. Exactly one
@@ -815,6 +816,7 @@ mod tests {
 
     #[test]
     fn remove_existing_capability_succeeds_and_disappears_from_list() {
+        let _home = crate::config::TestConfigHome::new();
         let mut ctx = ctx_with_capability("my-cap", "agent-model");
         assert!(ctx.config.get_capability("my-cap").is_some());
 
@@ -844,6 +846,7 @@ mod tests {
 
     #[test]
     fn list_does_not_show_removed_capability() {
+        let _home = crate::config::TestConfigHome::new();
         let mut ctx = ctx_with_capability("my-cap", "agent-model");
         CapabilityCommands::remove(&mut ctx, "my-cap").unwrap();
         CapabilityCommands::list(&ctx).unwrap();

--- a/src/commands/launcher.rs
+++ b/src/commands/launcher.rs
@@ -1,4 +1,5 @@
 // Third Party
+use alog::{MessageLevel, alog_channel, use_channel};
 use anyhow::Result;
 
 // Local
@@ -6,6 +7,8 @@ use crate::capabilities::{CAPABILITY_REGISTRY, CapabilitySource};
 use crate::dependency::Configured;
 use crate::launchers::LAUNCHER_REGISTRY;
 use crate::utils::prompt_from_schema;
+
+use_channel!("LNCHR");
 
 /*-- public --*/
 
@@ -173,10 +176,11 @@ impl LauncherCommands {
             .map(|lc| lc.config.clone())
             .or_else(|| LAUNCHER_REGISTRY.default_config(launcher_type))
             .unwrap_or_else(|| serde_json::json!({}));
+        alog_channel!(MessageLevel::Debug3, "Defaults: {:#?}", defaults);
 
         let mut config = prompt_from_schema(&*ctx.ui, &schema, &defaults)?;
 
-        // Normalise: an empty string for command_path means "use PATH" — treat
+        // Normalize: an empty string for command_path means "use PATH" — treat
         // it the same as absent so validate_command does a PATH lookup.
         if config.get("command_path").and_then(|v| v.as_str()) == Some("") {
             config

--- a/src/commands/launcher.rs
+++ b/src/commands/launcher.rs
@@ -502,10 +502,7 @@ mod tests {
 
     #[tokio::test]
     async fn setup_warns_on_same_type_existing_instance() {
-        let tmp = tempfile::TempDir::new().unwrap();
-        let home = tmp.path().join("granite-cli-test-launcher-setup");
-        // SAFETY: single-threaded test; no other thread reads this var.
-        unsafe { std::env::set_var("GRANITE_CLI_HOME", &home) };
+        let _home = crate::config::TestConfigHome::new();
 
         // Pre-populate a "claude" instance named "claude-old"
         let mut ctx = ctx_with_launcher("claude-old", "claude");
@@ -519,8 +516,6 @@ mod tests {
             infos.iter().any(|m| m.contains("claude-old")),
             "expected clash warning to mention the existing instance"
         );
-
-        unsafe { std::env::remove_var("GRANITE_CLI_HOME") };
     }
 
     #[tokio::test]
@@ -534,6 +529,7 @@ mod tests {
 
     #[test]
     fn remove_existing_launcher_succeeds_and_disappears_from_list() {
+        let _home = crate::config::TestConfigHome::new();
         let mut ctx = ctx_with_launcher("my-claude", "claude");
         assert!(ctx.config.get_launcher("my-claude").is_some());
 
@@ -563,6 +559,7 @@ mod tests {
 
     #[test]
     fn list_does_not_show_removed_launcher() {
+        let _home = crate::config::TestConfigHome::new();
         let mut ctx = ctx_with_launcher("my-claude", "claude");
         LauncherCommands::remove(&mut ctx, "my-claude").unwrap();
         LauncherCommands::list(&ctx).unwrap();

--- a/src/commands/model.rs
+++ b/src/commands/model.rs
@@ -1532,6 +1532,7 @@ mod tests {
 
     #[test]
     fn list_does_not_show_removed_model() {
+        let _home = crate::config::TestConfigHome::new();
         let mut ctx = ctx_with_model("granite-3.1-8b-instruct", Some("my-ollama"));
         ModelCommands::remove(&mut ctx, "granite-3.1-8b-instruct").unwrap();
         ModelCommands::list(&ctx, None).unwrap();

--- a/src/commands/model.rs
+++ b/src/commands/model.rs
@@ -1502,6 +1502,7 @@ mod tests {
 
     #[test]
     fn remove_existing_model_succeeds_and_disappears_from_list() {
+        let _home = crate::config::TestConfigHome::new();
         let mut ctx = ctx_with_model("granite-3.1-8b-instruct", Some("my-ollama"));
         assert!(ctx.config.get_model("granite-3.1-8b-instruct").is_some());
 

--- a/src/commands/provider.rs
+++ b/src/commands/provider.rs
@@ -483,6 +483,7 @@ mod tests {
 
     #[test]
     fn remove_existing_provider_succeeds_and_disappears_from_list() {
+        let _home = crate::config::TestConfigHome::new();
         let mut ctx = ctx_with_provider("my-ollama", "http://localhost:11434");
         assert!(ctx.config.get_provider("my-ollama").is_some());
 
@@ -512,6 +513,7 @@ mod tests {
 
     #[test]
     fn list_does_not_show_removed_provider() {
+        let _home = crate::config::TestConfigHome::new();
         let mut ctx = ctx_with_provider("my-ollama", "http://localhost:11434");
         ProviderCommands::remove(&mut ctx, "my-ollama").unwrap();
         ProviderCommands::list(&ctx).unwrap();

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -115,6 +115,21 @@ impl Config {
         Ok(default_dir.join("granite-cli"))
     }
 
+    /// Backstop against a test writing into the user's real global config:
+    /// panics unless `GRANITE_CLI_HOME` has been pointed at an isolated
+    /// directory (see `TestConfigHome`). Called at the top of every
+    /// disk-mutating operation, never on the read-only path-resolution path.
+    #[cfg(test)]
+    fn assert_test_isolated() {
+        let home = std::env::var("GRANITE_CLI_HOME").unwrap_or_default();
+        assert!(
+            !home.is_empty(),
+            "Config write attempted during tests without GRANITE_CLI_HOME set -- \
+             wrap the test body in `let _home = crate::config::TestConfigHome::new();` \
+             so it never touches the real global config."
+        );
+    }
+
     fn models_dir() -> Result<PathBuf> {
         Ok(Self::config_dir()?.join("models"))
     }
@@ -142,6 +157,9 @@ impl Config {
     }
 
     fn ensure_directories() -> Result<()> {
+        #[cfg(test)]
+        Self::assert_test_isolated();
+
         let config_dir = Self::config_dir()?;
         if !config_dir.exists() {
             fs::create_dir_all(&config_dir)?;
@@ -231,6 +249,9 @@ impl Config {
     }
 
     fn save(&self) -> Result<()> {
+        #[cfg(test)]
+        Self::assert_test_isolated();
+
         // Save individual model files
         for (id, model) in &self.models {
             let path = Self::models_dir()?.join(format!("{id}.yaml"));
@@ -427,10 +448,48 @@ impl Default for LauncherConfig {
     }
 }
 
+/// Serializes access to `GRANITE_CLI_HOME`, which every `TestConfigHome`
+/// mutates -- it's process-global env state shared across concurrently
+/// running tests.
+#[cfg(test)]
+static CONFIG_HOME_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+/// Points `GRANITE_CLI_HOME` at a fresh temp directory for the guard's
+/// lifetime and restores it on drop -- including on panic or early return --
+/// so `Config` mutations in tests can never land in the user's real global
+/// config. Holds `CONFIG_HOME_LOCK` the whole time so concurrent tests using
+/// this guard never race each other over the shared env var.
+#[cfg(test)]
+pub(crate) struct TestConfigHome {
+    _tmp: tempfile::TempDir,
+    _guard: std::sync::MutexGuard<'static, ()>,
+}
+
+#[cfg(test)]
+impl TestConfigHome {
+    pub(crate) fn new() -> Self {
+        let guard = CONFIG_HOME_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let tmp = tempfile::TempDir::new().unwrap();
+        // SAFETY: serialized by CONFIG_HOME_LOCK, held for the guard's lifetime.
+        unsafe { std::env::set_var("GRANITE_CLI_HOME", tmp.path()) };
+        Self {
+            _tmp: tmp,
+            _guard: guard,
+        }
+    }
+}
+
+#[cfg(test)]
+impl Drop for TestConfigHome {
+    fn drop(&mut self) {
+        // SAFETY: still holding CONFIG_HOME_LOCK.
+        unsafe { std::env::remove_var("GRANITE_CLI_HOME") };
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
-    use tempfile::TempDir;
 
     #[test]
     fn launcher_config_default_round_trips() {
@@ -444,10 +503,7 @@ mod tests {
 
     #[test]
     fn insert_and_remove_launcher() {
-        let tmp = TempDir::new().unwrap();
-        let home = tmp.path().join("granite-cli-test-2");
-        // SAFETY: single-threaded test; no other thread reads this var.
-        unsafe { std::env::set_var("GRANITE_CLI_HOME", &home) };
+        let _home = TestConfigHome::new();
 
         let mut config = Config::new().unwrap();
         let lc = LauncherConfig {
@@ -461,7 +517,5 @@ mod tests {
 
         config.remove_launcher("claude").unwrap();
         assert!(config.get_launcher("claude").is_none());
-
-        unsafe { std::env::remove_var("GRANITE_CLI_HOME") };
     }
 }

--- a/src/launchers/claude.rs
+++ b/src/launchers/claude.rs
@@ -369,6 +369,7 @@ impl ClaudeLauncher {
                 // so the override sticks.
                 let mapped_name = match binding.known_type {
                     Some(KnownSubAgent::Explore) => "Explore".to_string(),
+                    Some(KnownSubAgent::Plan) => "Plan".to_string(),
                     _ => name.clone(),
                 };
                 alog_channel!(MessageLevel::Debug2, "Using agent name {} for {}", &mapped_name, &name);

--- a/src/launchers/opencode.rs
+++ b/src/launchers/opencode.rs
@@ -19,7 +19,10 @@ use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
 
 // Local
-use crate::capabilities::{AgentModelBinding, Binding, BindingType, Capability, McpBinding};
+use crate::capabilities::{
+    AgentModelBinding, Binding, BindingType, Capability, KnownSubAgent, McpBinding,
+    SubAgentBinding, ToolName,
+};
 use crate::launchers::base::{EnvBinding, LaunchContext, Launcher, LauncherMetadata, run_command};
 use crate::launchers::shared::mcp_cli::mcp_binding_request;
 use crate::providers::ApiType;
@@ -38,9 +41,13 @@ pub struct OpenCodeLauncherConfig {
     #[serde(default)]
     pub command_path: Option<String>,
 
-    /// Extra keys merged (shallow, last-write-wins) into the generated
+    /// Extra keys merged (shallow, last-write-wins) into every generated
     /// provider entry -- e.g. `headers` a particular server needs. Necessary
-    /// because the entry is regenerated on every launch.
+    /// because the entries are regenerated on every launch. Applied
+    /// uniformly to the main model's provider entry *and* every bound
+    /// sub-agent's, since there is no per-sub-agent override knob yet -- an
+    /// override meant for one provider (e.g. a dialect-specific `npm`
+    /// package) will also land on any other bound provider.
     #[serde(default)]
     pub provider_overrides: Option<serde_json::Value>,
 }
@@ -52,6 +59,14 @@ pub struct OpenCodeLauncher {
     /// `(server_name, binding)` for every MCP-capable capability bound to
     /// this launcher, written into the generated config's `mcp` block.
     bound_mcp_bindings: Vec<(String, McpBinding)>,
+    /// `(name, binding)` for every `SubAgentCapability` bound to this
+    /// launcher -- `name` is the capability's own `instance_id`, used as the
+    /// key in the generated config's `agent` block. Unlike Claude Code (one
+    /// `ANTHROPIC_BASE_URL` for the whole session), OpenCode's config natively
+    /// supports any number of named providers, so each sub-agent's model gets
+    /// its own `provider.<name>` entry and is referenced directly as
+    /// `<provider>/<model>` in `agent.<name>.model` -- no mini-router needed.
+    bound_sub_agents: Vec<(String, SubAgentBinding)>,
 }
 
 impl ConfigConstructable for OpenCodeLauncher {
@@ -69,6 +84,7 @@ impl ConfigConstructable for OpenCodeLauncher {
             config,
             bound_agent_model: None,
             bound_mcp_bindings: vec![],
+            bound_sub_agents: vec![],
         }
     }
 }
@@ -111,6 +127,28 @@ impl Launcher for OpenCodeLauncher {
             return Ok(());
         }
 
+        if capability_types.contains(&BindingType::SubAgent) {
+            // Same dialect choice as the main-model request below: every
+            // granite-cli provider can serve `@ai-sdk/openai-compatible`.
+            let request = crate::capabilities::BindingRequest::SubAgent(
+                crate::capabilities::SubAgentBindingRequest {
+                    api_type: ApiType::OpenAI,
+                },
+            );
+            let binding = capability.bind(request).await?;
+            match binding {
+                Binding::SubAgent(binding) => {
+                    self.bound_sub_agents
+                        .push((capability.instance_id().to_string(), binding));
+                }
+                other => anyhow::bail!(
+                    "expected a SubAgent binding, got {:?}",
+                    other.binding_type()
+                ),
+            }
+            return Ok(());
+        }
+
         // OpenCode's custom-provider config speaks whatever dialect its `npm`
         // SDK package implements. `@ai-sdk/openai-compatible` is the one every
         // granite-cli provider can serve, so that is what we ask for.
@@ -137,6 +175,34 @@ impl Launcher for OpenCodeLauncher {
         resolve_shell_command(&self.config.command_path, "opencode")
     }
 
+    /// Maps a canonical `ToolName` onto the tool-id strings OpenCode's own
+    /// (legacy, but still supported) `tools` boolean map uses -- confirmed
+    /// against current official docs (<https://opencode.ai/docs/agents/>,
+    /// <https://opencode.ai/docs/permissions/>). `edit`/`write` are two
+    /// distinct tool ids at this granularity even though OpenCode's newer
+    /// `permission` config consolidates both under one `edit` category. MCP
+    /// tools are named `<server>_<tool>`, with `<server>_*` disabling/enabling
+    /// every tool from that server (confirmed via the docs' own example for
+    /// disabling a whole MCP server's tools).
+    fn map_tool_name(&self, tool: &ToolName) -> Option<String> {
+        Some(match tool {
+            ToolName::FileRead => "read".to_string(),
+            ToolName::FileWrite => "write".to_string(),
+            ToolName::FileEdit => "edit".to_string(),
+            ToolName::Search => "grep".to_string(),
+            ToolName::FileSearch => "glob".to_string(),
+            ToolName::Shell => "bash".to_string(),
+            ToolName::WebFetch => "webfetch".to_string(),
+            ToolName::WebSearch => "websearch".to_string(),
+            ToolName::Mcp { server, tool: None } => format!("{server}_*"),
+            ToolName::Mcp {
+                server,
+                tool: Some(t),
+            } => format!("{server}_{t}"),
+            ToolName::Other(raw) => raw.clone(),
+        })
+    }
+
     /// Points OpenCode at the granite-cli-generated config file and supplies
     /// the credential the file interpolates.
     ///
@@ -147,23 +213,27 @@ impl Launcher for OpenCodeLauncher {
     /// custom-provider config does not require one.
     async fn env_overlay(&self, ctx: &LaunchContext) -> anyhow::Result<Vec<EnvBinding>> {
         let mut overlay = vec![];
-        if self.bound_agent_model.is_some() || !self.bound_mcp_bindings.is_empty() {
+        if self.bound_agent_model.is_some()
+            || !self.bound_mcp_bindings.is_empty()
+            || !self.bound_sub_agents.is_empty()
+        {
             overlay.push(EnvBinding {
                 key: CONFIG_ENV.to_string(),
                 value: opencode_config_path(ctx)?.to_string_lossy().to_string(),
             });
 
-            if let Some(binding) = &self.bound_agent_model
-                && let Some(api_key) = binding
+            for (index, (binding, _)) in self.provider_groups().iter().enumerate() {
+                if let Some(api_key) = binding
                     .api_key
                     .as_ref()
                     .map(|api_key| api_key.0.clone())
                     .filter(|key| !key.is_empty())
-            {
-                overlay.push(EnvBinding {
-                    key: API_KEY_ENV.to_string(),
-                    value: api_key,
-                });
+                {
+                    overlay.push(EnvBinding {
+                        key: provider_api_key_env(index),
+                        value: api_key,
+                    });
+                }
             }
         }
         Ok(overlay)
@@ -184,15 +254,21 @@ impl Launcher for OpenCodeLauncher {
         ctx: &LaunchContext,
         ui: &dyn Ui,
     ) -> anyhow::Result<std::process::ExitStatus> {
-        if self.bound_agent_model.is_some() || !self.bound_mcp_bindings.is_empty() {
-            let provider_entry = self
-                .bound_agent_model
-                .as_ref()
-                .map(|binding| self.provider_entry(binding))
-                .transpose()?;
+        if self.bound_agent_model.is_some()
+            || !self.bound_mcp_bindings.is_empty()
+            || !self.bound_sub_agents.is_empty()
+        {
+            let mut providers = serde_json::Map::new();
+            for (index, (binding, model_names)) in self.provider_groups().iter().enumerate() {
+                let entry =
+                    self.provider_entry(binding, model_names, &provider_api_key_env(index))?;
+                providers.insert(binding.provider_name.clone(), entry);
+            }
+            let agent = self.build_agent_config(ui);
             let config = generate_config(
                 self.bound_agent_model.as_ref(),
-                provider_entry,
+                providers,
+                agent,
                 &self.bound_mcp_bindings,
             );
             let config_path = opencode_config_path(ctx)?;
@@ -226,7 +302,11 @@ impl HasOpenCodeLauncherMetadata for OpenCodeLauncher {
             name: "OpenCode CLI".to_string(),
             description: "OpenCode terminal coding agent".to_string(),
             default_command: "opencode".to_string(),
-            supported_capabilities: HashSet::from([BindingType::AgentModel, BindingType::Mcp]),
+            supported_capabilities: HashSet::from([
+                BindingType::AgentModel,
+                BindingType::Mcp,
+                BindingType::SubAgent,
+            ]),
             tags: vec!["opencode".to_string(), "coding-agent".to_string()],
         }
     }
@@ -248,15 +328,24 @@ const API_KEY_ENV: &str = "GRANITE_CLI_OPENCODE_API_KEY";
 const CONFIG_FILE: &str = "opencode.json";
 
 impl OpenCodeLauncher {
-    /// Builds the `provider.<name>` entry describing the bound model.
-    fn provider_entry(&self, binding: &AgentModelBinding) -> anyhow::Result<serde_json::Value> {
+    /// Builds the `provider.<name>` entry describing `binding`'s provider,
+    /// with one `models` entry per name in `model_names` -- plural because a
+    /// single provider instance may back both the main model and one or more
+    /// sub-agents' models, all of which must land in the same generated
+    /// `provider.<name>` entry rather than clobbering each other.
+    fn provider_entry(
+        &self,
+        binding: &AgentModelBinding,
+        model_names: &[&str],
+        api_key_env: &str,
+    ) -> anyhow::Result<serde_json::Value> {
         let mut options = serde_json::json!({ "baseURL": opencode_base_url(binding) });
         if binding
             .api_key
             .as_ref()
             .is_some_and(|key| !key.0.is_empty())
         {
-            options["apiKey"] = serde_json::Value::String(format!("{{env:{API_KEY_ENV}}}"));
+            options["apiKey"] = serde_json::Value::String(format!("{{env:{api_key_env}}}"));
         }
 
         // `limit` is all-or-nothing in OpenCode's schema: if present, both
@@ -264,12 +353,14 @@ impl OpenCodeLauncher {
         // context length, so `limit` is left out entirely rather than
         // guessing an output cap.
         let mut models = serde_json::Map::new();
-        models.insert(
-            binding.model_name.clone(),
-            serde_json::json!({
-                "name": binding.model_name,
-            }),
-        );
+        for name in model_names {
+            models.insert(
+                (*name).to_string(),
+                serde_json::json!({
+                    "name": name,
+                }),
+            );
+        }
 
         let mut entry = serde_json::json!({
             "npm": "@ai-sdk/openai-compatible",
@@ -279,7 +370,10 @@ impl OpenCodeLauncher {
         });
 
         // Shallow merge so a user override of e.g. `headers` doesn't clobber
-        // the generated `options`/`models`, and vice versa.
+        // the generated `options`/`models`, and vice versa. Applied uniformly
+        // to every generated provider entry (main model's and every
+        // sub-agent's) -- there is deliberately no per-sub-agent override
+        // knob yet.
         if let (Some(overrides), Some(target)) = (
             self.config
                 .provider_overrides
@@ -292,6 +386,109 @@ impl OpenCodeLauncher {
             }
         }
         Ok(entry)
+    }
+
+    /// Groups the main model binding (if any) and every bound sub-agent's
+    /// model binding by `provider_name`, collecting each group's distinct
+    /// model names -- so two sub-agents (or a sub-agent and the main model)
+    /// that happen to share the same underlying granite-cli provider instance
+    /// land in one `provider.<name>` entry with multiple `models`, instead of
+    /// one overwriting the other. Order is main-model-first, then
+    /// `bound_sub_agents` order, which is also the order `env_overlay` and
+    /// `launch` use to number each group's API-key env var
+    /// (`provider_api_key_env`) -- the two must stay in lock-step.
+    fn provider_groups(&self) -> Vec<(&AgentModelBinding, Vec<&str>)> {
+        fn add<'a>(
+            groups: &mut Vec<(&'a AgentModelBinding, Vec<&'a str>)>,
+            binding: &'a AgentModelBinding,
+        ) {
+            if let Some((_, model_names)) = groups
+                .iter_mut()
+                .find(|(b, _)| b.provider_name == binding.provider_name)
+            {
+                if !model_names.contains(&binding.model_name.as_str()) {
+                    model_names.push(&binding.model_name);
+                }
+            } else {
+                groups.push((binding, vec![binding.model_name.as_str()]));
+            }
+        }
+
+        let mut groups = Vec::new();
+        if let Some(binding) = &self.bound_agent_model {
+            add(&mut groups, binding);
+        }
+        for (_, sub_agent) in &self.bound_sub_agents {
+            add(&mut groups, &sub_agent.model);
+        }
+        groups
+    }
+
+    /// Builds the `agent.<name>` entries for every bound sub-agent:
+    /// `description`, `prompt`, `model` (as `<provider>/<model>`, per
+    /// <https://opencode.ai/docs/agents/>), and `tools` when a tool
+    /// allow-list was given. `tools` is OpenCode's legacy-but-still-supported
+    /// boolean map (<https://opencode.ai/docs/agents/>,
+    /// <https://opencode.ai/docs/permissions/>) rather than the newer
+    /// `permission` config: `permission`'s named categories default to
+    /// "allow" for anything not mentioned, which can't express "only these
+    /// tools, everything else off" the way `{"*": false, ...}` can -- the
+    /// same allow-list semantics `SubAgentBinding.tools` already has for the
+    /// `claude` launcher. A tool with no mapping is dropped with a warning
+    /// (per sub-agent), matching `ClaudeLauncher::build_agents_json`.
+    ///
+    /// `known_type` maps onto OpenCode's own built-in agent names (`explore`,
+    /// `plan` -- see <https://opencode.ai/docs/agents/>) the same way
+    /// `ClaudeLauncher` overrides Claude Code's built-in `Explore`/`Plan`
+    /// sub-agents.
+    fn build_agent_config(&self, ui: &dyn Ui) -> serde_json::Map<String, serde_json::Value> {
+        self.bound_sub_agents
+            .iter()
+            .map(|(name, binding)| {
+                let mut entry = serde_json::json!({
+                    "description": binding.description,
+                    "prompt": binding.prompt,
+                    "mode": "subagent",
+                    "model": format!("{}/{}", binding.model.provider_name, binding.model.model_name),
+                });
+                if !binding.tools.is_empty() {
+                    let mut tools = serde_json::Map::new();
+                    tools.insert("*".to_string(), serde_json::Value::Bool(false));
+                    for tool in &binding.tools {
+                        match self.map_tool_name(tool) {
+                            Some(mapped) => {
+                                tools.insert(mapped, serde_json::Value::Bool(true));
+                            }
+                            None => ui.warn(&format!(
+                                "sub-agent '{name}': tool {tool:?} has no mapping for the opencode launcher, skipping"
+                            )),
+                        }
+                    }
+                    entry["tools"] = serde_json::Value::Object(tools);
+                }
+                let mapped_name = match binding.known_type {
+                    Some(KnownSubAgent::Explore) => "explore".to_string(),
+                    Some(KnownSubAgent::Plan) => "plan".to_string(),
+                    None => name.clone(),
+                };
+                (mapped_name, entry)
+            })
+            .collect()
+    }
+}
+
+/// The env var an OpenCode provider entry's `apiKey` interpolates from, for
+/// the `index`-th distinct provider in `provider_groups()` order. Index `0`
+/// (conventionally the main model's provider, when bound) keeps the original
+/// unsuffixed name for backwards compatibility; every additional distinct
+/// provider (a sub-agent's, when it differs from the main model's) gets its
+/// own suffixed var so multiple secrets can be injected into one launch
+/// without colliding.
+fn provider_api_key_env(index: usize) -> String {
+    if index == 0 {
+        API_KEY_ENV.to_string()
+    } else {
+        format!("{API_KEY_ENV}_{index}")
     }
 }
 
@@ -314,24 +511,31 @@ fn opencode_config_path(ctx: &LaunchContext) -> anyhow::Result<PathBuf> {
     Ok(crate::config::Config::launcher_state_dir(&ctx.launcher_id)?.join(CONFIG_FILE))
 }
 
-/// Builds the top-level `opencode.json` shape: a provider entry (if bound)
+/// Builds the top-level `opencode.json` shape: the main model (if bound)
 /// selected via the top-level `model` key (`provider/model`) so it applies
-/// uniformly across the TUI, `run`, `attach`, and GitHub Action; plus an
-/// `mcp` block (if any MCP servers are bound), using opencode's
-/// `McpLocalConfig`/`McpRemoteConfig` shape (see
+/// uniformly across the TUI, `run`, `attach`, and GitHub Action; a `provider`
+/// block with one entry per distinct provider (main model's and/or each
+/// sub-agent's, pre-built by the caller via `provider_groups`/
+/// `provider_entry`); an `agent` block (if any sub-agents are bound, pre-built
+/// via `build_agent_config`); and an `mcp` block (if any MCP servers are
+/// bound), using opencode's `McpLocalConfig`/`McpRemoteConfig` shape (see
 /// <https://opencode.ai/config.json>).
 fn generate_config(
     binding: Option<&AgentModelBinding>,
-    provider_entry: Option<serde_json::Value>,
+    providers: serde_json::Map<String, serde_json::Value>,
+    agent: serde_json::Map<String, serde_json::Value>,
     mcp_bindings: &[(String, McpBinding)],
 ) -> serde_json::Value {
     let mut config = serde_json::json!({ "$schema": "https://opencode.ai/config.json" });
-    if let (Some(binding), Some(entry)) = (binding, provider_entry) {
-        let mut providers = serde_json::Map::new();
-        providers.insert(binding.provider_name.clone(), entry);
+    if let Some(binding) = binding {
         config["model"] =
             serde_json::Value::String(format!("{}/{}", binding.provider_name, binding.model_name));
+    }
+    if !providers.is_empty() {
         config["provider"] = serde_json::Value::Object(providers);
+    }
+    if !agent.is_empty() {
+        config["agent"] = serde_json::Value::Object(agent);
     }
     if !mcp_bindings.is_empty() {
         let mut mcp = serde_json::Map::new();
@@ -451,6 +655,12 @@ mod tests {
     }
 
     #[test]
+    fn metadata_supports_sub_agent_binding() {
+        let meta = OpenCodeLauncher::metadata();
+        assert!(meta.supported_capabilities.contains(&BindingType::SubAgent));
+    }
+
+    #[test]
     fn instance_id_round_trips_from_construction() {
         let l = OpenCodeLauncher::new(
             "opencode-local",
@@ -481,8 +691,9 @@ mod tests {
 
     #[test]
     fn provider_entry_describes_bound_model() {
+        let b = binding();
         let entry = launcher(serde_json::json!({}))
-            .provider_entry(&binding())
+            .provider_entry(&b, &[b.model_name.as_str()], API_KEY_ENV)
             .unwrap();
         assert_eq!(entry["npm"], "@ai-sdk/openai-compatible");
         assert_eq!(entry["options"]["baseURL"], "http://localhost:11434/v1");
@@ -495,15 +706,46 @@ mod tests {
     }
 
     #[test]
+    fn provider_entry_describes_multiple_models_for_one_provider() {
+        let b = binding();
+        let entry = launcher(serde_json::json!({}))
+            .provider_entry(&b, &["granite4.1:8b", "granite4.1:3b"], API_KEY_ENV)
+            .unwrap();
+        assert_eq!(entry["models"]["granite4.1:8b"]["name"], "granite4.1:8b");
+        assert_eq!(entry["models"]["granite4.1:3b"]["name"], "granite4.1:3b");
+    }
+
+    #[test]
     fn provider_entry_interpolates_env_when_key_present() {
         let b = AgentModelBinding {
             api_key: Some(Secret::from("sk-test")),
             ..binding()
         };
-        let entry = launcher(serde_json::json!({})).provider_entry(&b).unwrap();
+        let entry = launcher(serde_json::json!({}))
+            .provider_entry(&b, &[b.model_name.as_str()], API_KEY_ENV)
+            .unwrap();
         assert_eq!(
             entry["options"]["apiKey"],
             "{env:GRANITE_CLI_OPENCODE_API_KEY}"
+        );
+    }
+
+    #[test]
+    fn provider_entry_uses_the_given_api_key_env_name() {
+        let b = AgentModelBinding {
+            api_key: Some(Secret::from("sk-test")),
+            ..binding()
+        };
+        let entry = launcher(serde_json::json!({}))
+            .provider_entry(
+                &b,
+                &[b.model_name.as_str()],
+                "GRANITE_CLI_OPENCODE_API_KEY_1",
+            )
+            .unwrap();
+        assert_eq!(
+            entry["options"]["apiKey"],
+            "{env:GRANITE_CLI_OPENCODE_API_KEY_1}"
         );
     }
 
@@ -513,7 +755,9 @@ mod tests {
             api_key: Some(Secret::from("")),
             ..binding()
         };
-        let entry = launcher(serde_json::json!({})).provider_entry(&b).unwrap();
+        let entry = launcher(serde_json::json!({}))
+            .provider_entry(&b, &[b.model_name.as_str()], API_KEY_ENV)
+            .unwrap();
         assert!(entry["options"].get("apiKey").is_none());
     }
 
@@ -522,7 +766,10 @@ mod tests {
         let l = launcher(serde_json::json!({
             "provider_overrides": { "headers": { "X-Custom": "1" } }
         }));
-        let entry = l.provider_entry(&binding()).unwrap();
+        let b = binding();
+        let entry = l
+            .provider_entry(&b, &[b.model_name.as_str()], API_KEY_ENV)
+            .unwrap();
         assert_eq!(entry["headers"]["X-Custom"], "1");
         // Generated keys survive the merge.
         assert_eq!(entry["options"]["baseURL"], "http://localhost:11434/v1");
@@ -533,8 +780,226 @@ mod tests {
         let l = launcher(serde_json::json!({
             "provider_overrides": { "npm": "@ai-sdk/openai" }
         }));
-        let entry = l.provider_entry(&binding()).unwrap();
+        let b = binding();
+        let entry = l
+            .provider_entry(&b, &[b.model_name.as_str()], API_KEY_ENV)
+            .unwrap();
         assert_eq!(entry["npm"], "@ai-sdk/openai");
+    }
+
+    // -- provider_api_key_env ---------------------------------------------------
+
+    #[test]
+    fn provider_api_key_env_keeps_unsuffixed_name_at_index_zero() {
+        assert_eq!(provider_api_key_env(0), "GRANITE_CLI_OPENCODE_API_KEY");
+    }
+
+    #[test]
+    fn provider_api_key_env_suffixes_by_index_beyond_zero() {
+        assert_eq!(provider_api_key_env(1), "GRANITE_CLI_OPENCODE_API_KEY_1");
+        assert_eq!(provider_api_key_env(2), "GRANITE_CLI_OPENCODE_API_KEY_2");
+    }
+
+    // -- provider_groups ---------------------------------------------------------
+
+    fn sub_agent_binding(
+        description: &str,
+        provider_name: &str,
+        model_name: &str,
+        tools: Vec<ToolName>,
+    ) -> SubAgentBinding {
+        SubAgentBinding {
+            description: description.to_string(),
+            prompt: "You are a helpful sub-agent.".to_string(),
+            tools,
+            model: AgentModelBinding {
+                provider_name: provider_name.to_string(),
+                model_name: model_name.to_string(),
+                ..binding()
+            },
+            known_type: None,
+        }
+    }
+
+    #[test]
+    fn provider_groups_is_empty_with_nothing_bound() {
+        let l = launcher(serde_json::json!({}));
+        assert!(l.provider_groups().is_empty());
+    }
+
+    #[test]
+    fn provider_groups_includes_main_model_first() {
+        let mut l = launcher(serde_json::json!({}));
+        l.bound_agent_model = Some(binding());
+        let groups = l.provider_groups();
+        assert_eq!(groups.len(), 1);
+        assert_eq!(groups[0].0.provider_name, "my-ollama");
+        assert_eq!(groups[0].1, vec!["granite4.1:8b"]);
+    }
+
+    #[test]
+    fn provider_groups_gives_a_distinct_provider_its_own_group() {
+        let mut l = launcher(serde_json::json!({}));
+        l.bound_agent_model = Some(binding());
+        l.bound_sub_agents = vec![(
+            "reviewer".to_string(),
+            sub_agent_binding("Reviews code", "other-provider", "other-model", vec![]),
+        )];
+        let groups = l.provider_groups();
+        assert_eq!(groups.len(), 2);
+        assert_eq!(groups[1].0.provider_name, "other-provider");
+        assert_eq!(groups[1].1, vec!["other-model"]);
+    }
+
+    #[test]
+    fn provider_groups_merges_model_names_sharing_a_provider() {
+        let mut l = launcher(serde_json::json!({}));
+        l.bound_agent_model = Some(binding());
+        l.bound_sub_agents = vec![(
+            "reviewer".to_string(),
+            sub_agent_binding("Reviews code", "my-ollama", "granite4.1:3b", vec![]),
+        )];
+        let groups = l.provider_groups();
+        assert_eq!(groups.len(), 1);
+        assert_eq!(groups[0].1, vec!["granite4.1:8b", "granite4.1:3b"]);
+    }
+
+    #[test]
+    fn provider_groups_dedupes_identical_model_name_for_shared_provider() {
+        let mut l = launcher(serde_json::json!({}));
+        l.bound_agent_model = Some(binding());
+        l.bound_sub_agents = vec![(
+            "reviewer".to_string(),
+            sub_agent_binding("Reviews code", "my-ollama", "granite4.1:8b", vec![]),
+        )];
+        let groups = l.provider_groups();
+        assert_eq!(groups.len(), 1);
+        assert_eq!(groups[0].1, vec!["granite4.1:8b"]);
+    }
+
+    // -- map_tool_name -----------------------------------------------------------
+
+    #[test]
+    fn map_tool_name_covers_every_canonical_variant_and_formats_mcp_references() {
+        let l = launcher(serde_json::json!({}));
+        assert_eq!(
+            l.map_tool_name(&ToolName::FileRead),
+            Some("read".to_string())
+        );
+        assert_eq!(
+            l.map_tool_name(&ToolName::FileWrite),
+            Some("write".to_string())
+        );
+        assert_eq!(
+            l.map_tool_name(&ToolName::FileEdit),
+            Some("edit".to_string())
+        );
+        assert_eq!(l.map_tool_name(&ToolName::Search), Some("grep".to_string()));
+        assert_eq!(
+            l.map_tool_name(&ToolName::FileSearch),
+            Some("glob".to_string())
+        );
+        assert_eq!(l.map_tool_name(&ToolName::Shell), Some("bash".to_string()));
+        assert_eq!(
+            l.map_tool_name(&ToolName::WebFetch),
+            Some("webfetch".to_string())
+        );
+        assert_eq!(
+            l.map_tool_name(&ToolName::WebSearch),
+            Some("websearch".to_string())
+        );
+        assert_eq!(
+            l.map_tool_name(&ToolName::Mcp {
+                server: "vision".to_string(),
+                tool: None,
+            }),
+            Some("vision_*".to_string())
+        );
+        assert_eq!(
+            l.map_tool_name(&ToolName::Mcp {
+                server: "vision".to_string(),
+                tool: Some("vlm_compare_images".to_string()),
+            }),
+            Some("vision_vlm_compare_images".to_string())
+        );
+        assert_eq!(
+            l.map_tool_name(&ToolName::Other("SomeRawTool".to_string())),
+            Some("SomeRawTool".to_string())
+        );
+    }
+
+    // -- build_agent_config -------------------------------------------------------
+
+    #[test]
+    fn build_agent_config_includes_description_prompt_and_model_but_omits_empty_tools() {
+        let mut l = launcher(serde_json::json!({}));
+        l.bound_sub_agents = vec![(
+            "reviewer".to_string(),
+            sub_agent_binding("Reviews code", "my-ollama", "granite4.1:8b", vec![]),
+        )];
+        let ui = CaptureUi::default();
+        let agent = l.build_agent_config(&ui);
+        let entry = &agent["reviewer"];
+        assert_eq!(entry["description"], "Reviews code");
+        assert_eq!(entry["prompt"], "You are a helpful sub-agent.");
+        assert_eq!(entry["model"], "my-ollama/granite4.1:8b");
+        assert!(entry.get("tools").is_none());
+    }
+
+    #[test]
+    fn build_agent_config_denies_by_default_and_allows_only_listed_tools() {
+        let mut l = launcher(serde_json::json!({}));
+        l.bound_sub_agents = vec![(
+            "reviewer".to_string(),
+            sub_agent_binding(
+                "Reviews code",
+                "my-ollama",
+                "granite4.1:8b",
+                vec![ToolName::FileRead, ToolName::Search],
+            ),
+        )];
+        let ui = CaptureUi::default();
+        let agent = l.build_agent_config(&ui);
+        assert_eq!(
+            agent["reviewer"]["tools"],
+            serde_json::json!({ "*": false, "read": true, "grep": true })
+        );
+    }
+
+    #[test]
+    fn build_agent_config_covers_every_bound_sub_agent_by_instance_id() {
+        let mut l = launcher(serde_json::json!({}));
+        l.bound_sub_agents = vec![
+            (
+                "reviewer".to_string(),
+                sub_agent_binding("Reviews code", "my-ollama", "model-a", vec![]),
+            ),
+            (
+                "summarizer".to_string(),
+                sub_agent_binding("Summarizes text", "my-ollama", "model-b", vec![]),
+            ),
+        ];
+        let ui = CaptureUi::default();
+        let agent = l.build_agent_config(&ui);
+        assert_eq!(agent.len(), 2);
+        assert_eq!(agent["reviewer"]["model"], "my-ollama/model-a");
+        assert_eq!(agent["summarizer"]["model"], "my-ollama/model-b");
+    }
+
+    #[test]
+    fn build_agent_config_maps_known_types_onto_opencodes_own_builtin_agent_names() {
+        let mut l = launcher(serde_json::json!({}));
+        l.bound_sub_agents = vec![(
+            "my-explorer".to_string(),
+            SubAgentBinding {
+                known_type: Some(KnownSubAgent::Explore),
+                ..sub_agent_binding("Explores code", "my-ollama", "granite4.1:8b", vec![])
+            },
+        )];
+        let ui = CaptureUi::default();
+        let agent = l.build_agent_config(&ui);
+        assert!(agent.contains_key("explore"));
+        assert!(!agent.contains_key("my-explorer"));
     }
 
     // -- base url ----------------------------------------------------------
@@ -557,8 +1022,12 @@ mod tests {
 
     #[test]
     fn generate_config_nests_entry_under_provider_name_and_sets_default_model() {
-        let entry = serde_json::json!({ "npm": "@ai-sdk/openai-compatible" });
-        let config = generate_config(Some(&binding()), Some(entry), &[]);
+        let mut providers = serde_json::Map::new();
+        providers.insert(
+            "my-ollama".to_string(),
+            serde_json::json!({ "npm": "@ai-sdk/openai-compatible" }),
+        );
+        let config = generate_config(Some(&binding()), providers, serde_json::Map::new(), &[]);
         assert_eq!(config["$schema"], "https://opencode.ai/config.json");
         assert_eq!(config["model"], "my-ollama/granite4.1:8b");
         assert_eq!(
@@ -573,10 +1042,39 @@ mod tests {
             url: "http://127.0.0.1:9999".to_string(),
             headers: Default::default(),
         };
-        let config = generate_config(None, None, &[("vision".to_string(), mcp_binding)]);
+        let config = generate_config(
+            None,
+            serde_json::Map::new(),
+            serde_json::Map::new(),
+            &[("vision".to_string(), mcp_binding)],
+        );
         assert!(config.get("model").is_none());
+        assert!(config.get("provider").is_none());
         assert_eq!(config["mcp"]["vision"]["type"], "remote");
         assert_eq!(config["mcp"]["vision"]["url"], "http://127.0.0.1:9999");
+    }
+
+    #[test]
+    fn generate_config_writes_agent_block_when_sub_agents_present() {
+        let mut agent = serde_json::Map::new();
+        agent.insert(
+            "reviewer".to_string(),
+            serde_json::json!({ "description": "Reviews code" }),
+        );
+        let config = generate_config(None, serde_json::Map::new(), agent, &[]);
+        assert!(config.get("model").is_none());
+        assert_eq!(config["agent"]["reviewer"]["description"], "Reviews code");
+    }
+
+    #[test]
+    fn generate_config_omits_agent_key_when_no_sub_agents_bound() {
+        let config = generate_config(
+            Some(&binding()),
+            serde_json::Map::new(),
+            serde_json::Map::new(),
+            &[],
+        );
+        assert!(config.get("agent").is_none());
     }
 
     // -- env overlay -----------------------------------------------------------
@@ -630,6 +1128,55 @@ mod tests {
             !overlay
                 .iter()
                 .any(|b| b.key == "GRANITE_CLI_OPENCODE_API_KEY")
+        );
+    }
+
+    #[tokio::test]
+    async fn env_overlay_exports_one_api_key_per_distinct_provider_when_sub_agents_present() {
+        let main = AgentModelBinding {
+            api_key: Some(Secret::from("main-key")),
+            ..binding()
+        };
+        let mut l = bound(serde_json::json!({}), main);
+        l.bound_sub_agents = vec![(
+            "reviewer".to_string(),
+            SubAgentBinding {
+                model: AgentModelBinding {
+                    provider_name: "other-provider".to_string(),
+                    model_name: "other-model".to_string(),
+                    api_key: Some(Secret::from("sub-key")),
+                    ..binding()
+                },
+                ..sub_agent_binding("Reviews code", "other-provider", "other-model", vec![])
+            },
+        )];
+
+        let overlay = l.env_overlay(&ctx(false)).await.unwrap();
+
+        let main_key = overlay
+            .iter()
+            .find(|b| b.key == "GRANITE_CLI_OPENCODE_API_KEY")
+            .expect("main model's api key");
+        assert_eq!(main_key.value, "main-key");
+
+        let sub_key = overlay
+            .iter()
+            .find(|b| b.key == "GRANITE_CLI_OPENCODE_API_KEY_1")
+            .expect("sub-agent's own api key, on its own suffixed env var");
+        assert_eq!(sub_key.value, "sub-key");
+    }
+
+    #[tokio::test]
+    async fn env_overlay_redirects_config_when_only_a_sub_agent_is_bound() {
+        let mut l = launcher(serde_json::json!({}));
+        l.bound_sub_agents = vec![(
+            "reviewer".to_string(),
+            sub_agent_binding("Reviews code", "my-ollama", "granite4.1:8b", vec![]),
+        )];
+        let overlay = l.env_overlay(&ctx(false)).await.unwrap();
+        assert!(
+            overlay.iter().any(|b| b.key == "OPENCODE_CONFIG"),
+            "a sub-agent alone (no main model, no MCP) must still redirect OPENCODE_CONFIG"
         );
     }
 
@@ -694,5 +1241,97 @@ mod tests {
         // Without a binding there is no generated config, so OpenCode keeps
         // using its own config chain.
         assert!(!infos.iter().any(|m| m.contains(CONFIG_ENV)));
+    }
+
+    #[tokio::test]
+    async fn dry_run_launch_with_sub_agents_writes_agent_and_provider_blocks() {
+        let mut l = bound(serde_json::json!({ "command_path": "ls" }), binding());
+        l.bound_sub_agents = vec![(
+            "reviewer".to_string(),
+            sub_agent_binding(
+                "Reviews code",
+                "other-provider",
+                "other-model",
+                vec![ToolName::FileRead],
+            ),
+        )];
+        let ui = CaptureUi::default();
+        l.launch(&[], &ctx(true), &ui).await.unwrap();
+
+        let infos = ui.infos.borrow();
+        let dump = infos.join("\n");
+        assert!(dump.contains(r#""reviewer""#), "{dump}");
+        assert!(dump.contains(r#""my-ollama/granite4.1:8b""#), "{dump}");
+        assert!(dump.contains(r#""other-provider""#), "{dump}");
+        // Both providers get their own entry, keyed by provider name.
+        assert!(dump.contains(r#""my-ollama": {"#), "{dump}");
+        assert!(dump.contains(r#""other-provider": {"#), "{dump}");
+    }
+
+    #[tokio::test]
+    async fn dry_run_launch_with_only_a_sub_agent_still_writes_a_config() {
+        let mut l = launcher(serde_json::json!({ "command_path": "ls" }));
+        l.bound_sub_agents = vec![(
+            "reviewer".to_string(),
+            sub_agent_binding("Reviews code", "my-ollama", "granite4.1:8b", vec![]),
+        )];
+        let ui = CaptureUi::default();
+        l.launch(&[], &ctx(true), &ui).await.unwrap();
+
+        let infos = ui.infos.borrow();
+        assert!(
+            infos
+                .iter()
+                .any(|m| m.contains("Would write OpenCode config")),
+            "a sub-agent alone (no main model, no MCP) must still trigger config generation, got {infos:?}"
+        );
+    }
+
+    /// Minimal `Capability` double that always resolves to a fixed
+    /// `SubAgentBinding`, mirroring `ClaudeLauncher`'s test of the same name.
+    struct FakeSubAgentCapability {
+        instance_id: String,
+        binding: SubAgentBinding,
+    }
+
+    impl crate::registry::Named for FakeSubAgentCapability {
+        fn instance_id(&self) -> &str {
+            &self.instance_id
+        }
+    }
+
+    #[async_trait]
+    impl Capability for FakeSubAgentCapability {
+        fn name(&self) -> &str {
+            "Fake Sub-Agent"
+        }
+        fn description(&self) -> &str {
+            "test double"
+        }
+        fn dependencies(&self) -> Vec<crate::capabilities::Dependency> {
+            vec![]
+        }
+        fn binding_types(&self) -> HashSet<BindingType> {
+            HashSet::from([BindingType::SubAgent])
+        }
+        async fn bind(
+            &self,
+            _request: crate::capabilities::BindingRequest,
+        ) -> anyhow::Result<Binding> {
+            Ok(Binding::SubAgent(self.binding.clone()))
+        }
+    }
+
+    #[tokio::test]
+    async fn bind_capability_pushes_sub_agent_binding() {
+        let mut l = launcher(serde_json::json!({}));
+        let cap = FakeSubAgentCapability {
+            instance_id: "reviewer".to_string(),
+            binding: sub_agent_binding("Reviews code", "my-ollama", "granite4.1:8b", vec![]),
+        };
+        l.bind_capability(&cap).await.unwrap();
+        assert_eq!(l.bound_sub_agents.len(), 1);
+        assert_eq!(l.bound_sub_agents[0].0, "reviewer");
+        assert_eq!(l.bound_sub_agents[0].1.model.model_name, "granite4.1:8b");
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -656,7 +656,7 @@ async fn run_launch(
     dry_run: bool,
     usage_tracking: bool,
 ) -> anyhow::Result<()> {
-    use crate::capabilities::CAPABILITY_REGISTRY;
+    use crate::capabilities::{BindingType, CAPABILITY_REGISTRY};
     use crate::launchers::LAUNCHER_REGISTRY;
     use crate::launchers::LaunchContext;
     use crate::proxy::ProxyServer;
@@ -674,23 +674,34 @@ async fn run_launch(
         })?
         .clone();
 
-    // The session proxy boots whenever usage tracking was requested OR a
-    // bound capability needs sub-agent routing (that routing is structurally
-    // required for sub-agents to reach their own providers through Claude
-    // Code's single base-URL env var, independent of whether `-u` was
-    // passed). Skipped entirely under `dry_run`: there's no subprocess to
-    // point a proxy at, and showing the real upstream URL in the overlay is
-    // more useful than a not-yet-running one. When booted, it's threaded
-    // through `config.model_proxy` so that any capability which resolves its
-    // model through `ModelSource` (see `AgentModelCapability::new`) is
+    // The session proxy boots whenever usage tracking was requested OR the
+    // `claude` launcher has a sub-agent capability bound (any of
+    // `SubAgentCapability`/`ExploreSubAgentCapability`/`PlanSubAgentCapability`
+    // -- checked via `BindingType::SubAgent` rather than a specific
+    // capability-type string, so it covers all of them). That routing is
+    // structurally required only for Claude Code: it has exactly one
+    // `ANTHROPIC_BASE_URL` for the whole session, so every sub-agent's model
+    // must be multiplexed through the mini-router regardless of whether `-u`
+    // was passed. `opencode` (and any other launcher that later gains
+    // `BindingType::SubAgent` support) configures each sub-agent's own
+    // provider directly in its multi-provider config, so it never needs this.
+    // Skipped entirely under `dry_run`: there's no subprocess to point a
+    // proxy at, and showing the real upstream URL in the overlay is more
+    // useful than a not-yet-running one. When booted, it's threaded through
+    // `config.model_proxy` so that any capability which resolves its model
+    // through `ModelSource` (see `AgentModelCapability::new`) is
     // transparently routed through it (and tracked, if a tracker is active)
     // -- no per-capability wrapping needed here.
-    let needs_sub_agent_routing = lc.enabled_capabilities.iter().any(|id| {
-        config
-            .get_capability(id)
-            .map(|c| c.capability_type == "sub-agent")
-            .unwrap_or(false)
-    });
+    let needs_sub_agent_routing = lc.launcher_type == "claude"
+        && lc.enabled_capabilities.iter().any(|id| {
+            config
+                .get_capability(id)
+                .and_then(|c| CAPABILITY_REGISTRY.get(&c.capability_type))
+                .is_some_and(|meta| {
+                    meta.supported_binding_types
+                        .contains(&BindingType::SubAgent)
+                })
+        });
     let boot_proxy = (usage_tracking || needs_sub_agent_routing) && !dry_run;
     let proxy_server = if boot_proxy {
         Some(ProxyServer::start()?)

--- a/src/utils/ui/prompt.rs
+++ b/src/utils/ui/prompt.rs
@@ -1,6 +1,11 @@
+// Third Party
+use alog::{MessageLevel, alog_channel, use_channel};
 use serde_json::Value;
 
+// Local
 use crate::utils::ui::Ui;
+
+use_channel!("PRMPT");
 
 /*-- Public entry point --------------------------------------------------------*/
 
@@ -32,6 +37,7 @@ fn prompt_value(
     if let Some(choices) = enum_choices(root, node) {
         return prompt_enum_scalar(ui, root, &choices, default, indent, label);
     }
+    alog_channel!(MessageLevel::Debug3, "Prompting for {:#?}", node);
     match get_promptable_type(node).as_deref() {
         Some("object") => prompt_object(ui, root, node, default, indent, label),
         Some("array") => prompt_array(ui, root, node, default, indent, label),


### PR DESCRIPTION
## Description

This PR adds a second scripted sub-agent for planning and extends sub-agent support to the `opencode` launcher.

## Changes

- Add new sub-agent for planning (`PlanSubAgentCapability`)
- Support `SubAgentBinding` in `OpenCodeLauncher`
- Fix unit test bugs that were touching global config

## Testing

- Unit tests
- Ran with both `claude` and `opencode` and enabled sub-agents

## Related Issue(s)

Closes #81 

## AI Usage

AI was used in the standard way: planning/implementation with manual commits and review.

**NOTE**: Several of the commits, particularly the addition of sub-agent support for OpenCode actively used `granite-cli` with sub-agents delegated to `granite4.2:3b` running locally.

```sh
╔══════════════════════════════════════════════════════════╗
║           GIT AI USAGE ANALYSIS                          ║
╚══════════════════════════════════════════════════════════╝

📊 COMMITS BY AGENT

--- Aggregate ---
Commits                        |      Count
---------------------------------------------
Claude + Sonnet 5 + granite4.2:3b |          2
Claude + Sonnet 5              |          2
none                           |          1
---------------------------------------------
TOTAL                          |          5

📊 COMMITS BY USAGE TYPE

--- Aggregate ---
Commits                        |      Count
---------------------------------------------
none                           |          1
draft                          |          2
full                           |          2
---------------------------------------------
TOTAL                          |          5

📈 LINES OF CODE BY AGENT

--- Aggregate ---
Agent                     |    Commits |  Additions |  Deletions
------------------------------------------------------------
Claude + Sonnet 5 + granite4.2:3b |          2 |        786 |         77
Claude + Sonnet 5         |          2 |        519 |          0
none                      |          1 |         11 |          1
------------------------------------------------------------
TOTAL                     |          5 |       1316 |         78

📈 LINES OF CODE BY USAGE TYPE

--- Aggregate ---
Usage Type           |    Commits |  Additions |  Deletions
-------------------------------------------------------
none                 |          1 |         11 |          1
draft                |          2 |       1224 |         64
full                 |          2 |         81 |         13
-------------------------------------------------------
TOTAL                |          5 |       1316 |         78
```