### PR TITLE
fix: Skip capabilities whose model was removed

### DIFF
--- a/src/capabilities/agent_model.rs
+++ b/src/capabilities/agent_model.rs
@@ -28,7 +28,11 @@ pub struct AgentModelCapabilityConfig {
 pub struct AgentModelCapability {
     instance_id: String,
     config: AgentModelCapabilityConfig,
-    configured_model: ConfiguredModel,
+    /// `Err` when `config.model_id` doesn't resolve (e.g. the model was
+    /// removed after this capability was configured). Construction stays
+    /// infallible per `ConfigConstructable`; the error is surfaced at
+    /// `bind()` time and via `Capability::is_healthy`.
+    configured_model: Result<ConfiguredModel, String>,
 }
 
 impl ConfigConstructable for AgentModelCapability {
@@ -107,8 +111,12 @@ impl Capability for AgentModelCapability {
             ),
         };
         let model_id = &self.config.model_id;
+        let configured_model = self
+            .configured_model
+            .as_ref()
+            .map_err(|e| anyhow::anyhow!(e.clone()))?;
 
-        let (provider, endpoint, model_name) = self.configured_model.resolve_provider_endpoint(
+        let (provider, endpoint, model_name) = configured_model.resolve_provider_endpoint(
             model_id,
             api_type.clone(),
             ModelFunction::Chat,
@@ -123,8 +131,15 @@ impl Capability for AgentModelCapability {
             endpoint_path: endpoint.path().to_string(),
             api_key: provider.api_key().cloned(),
             verify_ssl: provider.verify_ssl(),
-            context_length: Some(self.configured_model.model.context_length()),
+            context_length: Some(configured_model.model.context_length()),
         }))
+    }
+
+    fn is_healthy(&self) -> Result<(), String> {
+        self.configured_model
+            .as_ref()
+            .map(|_| ())
+            .map_err(Clone::clone)
     }
 }
 
@@ -280,14 +295,14 @@ mod tests {
         AgentModelCapability {
             instance_id: cap.instance_id,
             config: cap.config,
-            configured_model: crate::models::ConfiguredModel::for_test(
+            configured_model: Ok(crate::models::ConfiguredModel::for_test(
                 Arc::new(TestModelWithVariants {
                     supported_functions: functions,
                     provider,
                     variants,
                 }),
                 variant_str,
-            ),
+            )),
         }
     }
 
@@ -595,5 +610,40 @@ mod tests {
             panic!("expected AgentModel binding")
         };
         assert_eq!(binding.model_name, "granite-3.1-8b-instruct");
+    }
+
+    // Regression tests for issue #90: constructing a capability whose
+    // model_id isn't in config.models (e.g. removed via `model remove`)
+    // must not panic. `new()` succeeds either way (infallible per
+    // `ConfigConstructable`); the failure surfaces via `is_healthy()` and,
+    // if reached anyway, via `bind()`'s `Result`.
+
+    #[test]
+    fn new_does_not_panic_when_model_id_is_unconfigured() {
+        let config = Config::default();
+        let cap = AgentModelCapability::new(
+            "my-agent",
+            &serde_json::json!({ "model_id": "granite-4.2-8b" }),
+            &config,
+        );
+        assert!(cap.is_healthy().is_err());
+    }
+
+    #[tokio::test]
+    async fn bind_fails_with_named_error_when_model_id_is_unconfigured() {
+        let config = Config::default();
+        let cap = AgentModelCapability::new(
+            "my-agent",
+            &serde_json::json!({ "model_id": "granite-4.2-8b" }),
+            &config,
+        );
+
+        let err = cap
+            .bind(BindingRequest::AgentModel(AgentModelBindingRequest {
+                api_type: ApiType::OpenAI,
+            }))
+            .await
+            .unwrap_err();
+        assert!(err.to_string().contains("granite-4.2-8b"));
     }
 }

--- a/src/capabilities/agent_model.rs
+++ b/src/capabilities/agent_model.rs
@@ -7,7 +7,7 @@ use crate::capabilities::base::{
     CapabilityMetadata, Dependency, HasCapabilityMetadata,
 };
 use crate::capabilities::requirement::ModelRequirement;
-use crate::models::{ConfiguredModel, ModelFunction};
+use crate::models::{ConfiguredModel, ConfiguredModelResolution, ModelFunction};
 use crate::registry::ConfigConstructable;
 use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
@@ -111,10 +111,7 @@ impl Capability for AgentModelCapability {
             ),
         };
         let model_id = &self.config.model_id;
-        let configured_model = self
-            .configured_model
-            .as_ref()
-            .map_err(|e| anyhow::anyhow!(e.clone()))?;
+        let configured_model = self.configured_model.resolved()?;
 
         let (provider, endpoint, model_name) = configured_model.resolve_provider_endpoint(
             model_id,
@@ -136,10 +133,7 @@ impl Capability for AgentModelCapability {
     }
 
     fn is_healthy(&self) -> Result<(), String> {
-        self.configured_model
-            .as_ref()
-            .map(|_| ())
-            .map_err(Clone::clone)
+        self.configured_model.health()
     }
 }
 

--- a/src/capabilities/base.rs
+++ b/src/capabilities/base.rs
@@ -269,6 +269,19 @@ pub trait Capability: crate::registry::Named + Send + Sync {
     /// Resolve a `BindingRequest` into a concrete `Binding`.
     async fn bind(&self, request: BindingRequest) -> anyhow::Result<Binding>;
 
+    /// Whether this instance's dependencies actually resolved to something
+    /// usable at construction time. `ConfigConstructable::new` is infallible
+    /// by trait signature, so a capability whose config references
+    /// now-missing state (e.g. a `model_id` the user has since removed)
+    /// can't report that by failing construction -- it stores the failure
+    /// and surfaces it here instead. `CapabilitySource::from_config` checks
+    /// this right after constructing each configured entry and skips (with a
+    /// warning) any that report unhealthy, the same way it already skips
+    /// entries with an unrecognized `capability_type`.
+    fn is_healthy(&self) -> Result<(), String> {
+        Ok(())
+    }
+
     // Execution hooks (all optional with NoOp defaults)
     async fn on_setup(&self) -> anyhow::Result<()> {
         Ok(())

--- a/src/capabilities/mod.rs
+++ b/src/capabilities/mod.rs
@@ -46,9 +46,16 @@ impl CapabilitySource {
                         capability_config.capability_type
                     );
                 }
-                result
-                    .ok()
-                    .map(|capability| (capability_config.capability_id.clone(), capability))
+                let capability = result.ok()?;
+                if let Err(e) = capability.is_healthy() {
+                    alog_channel!(
+                        MessageLevel::Warning,
+                        "Skipping capability '{}': {e}",
+                        capability_config.capability_id
+                    );
+                    return None;
+                }
+                Some((capability_config.capability_id.clone(), capability))
             })
             .collect();
         Self { constructed }
@@ -154,6 +161,51 @@ mod tests {
 
         let source = CapabilitySource::from_config(&config);
         assert!(source.instances().is_empty());
+    }
+
+    // Regression test for the panic reported in issue #90: a capability
+    // whose `model_id` no longer exists in `config.models` (e.g. after
+    // `model remove`) must be skipped with a warning, not crash the whole
+    // command -- the same treatment `capability_source_skips_unknown_capability_types`
+    // already gives an unrecognized `capability_type`.
+    #[test]
+    fn capability_source_skips_capability_referencing_a_removed_model() {
+        let mut config = Config::default();
+        // Deliberately do NOT insert "granite-4.2-8b" into config.models --
+        // this reproduces "the model this capability depends on was removed".
+        config.capabilities.insert(
+            "my-agent".to_string(),
+            agent_model_config("my-agent", "granite-4.2-8b"),
+        );
+
+        let source = CapabilitySource::from_config(&config);
+        assert!(source.instances().is_empty());
+    }
+
+    // Alongside a healthy capability, only the broken one should be skipped.
+    #[test]
+    fn capability_source_skips_broken_entries_but_keeps_healthy_ones() {
+        let mut config = Config::default();
+        config.models.insert(
+            "granite-3.1-8b-instruct".to_string(),
+            ModelConfig {
+                model_id: "granite-3.1-8b-instruct".to_string(),
+                provider_id: None,
+                variant: None,
+            },
+        );
+        config.capabilities.insert(
+            "healthy".to_string(),
+            agent_model_config("healthy", "granite-3.1-8b-instruct"),
+        );
+        config.capabilities.insert(
+            "broken".to_string(),
+            agent_model_config("broken", "granite-4.2-8b"),
+        );
+
+        let source = CapabilitySource::from_config(&config);
+        let ids: Vec<String> = source.instances().into_iter().map(|(id, _)| id).collect();
+        assert_eq!(ids, vec!["healthy".to_string()]);
     }
 
     #[test]

--- a/src/capabilities/sub_agent.rs
+++ b/src/capabilities/sub_agent.rs
@@ -41,7 +41,11 @@ pub struct SubAgentCapabilityConfig {
 pub struct SubAgentCapability {
     instance_id: String,
     config: SubAgentCapabilityConfig,
-    configured_model: ConfiguredModel,
+    /// `Err` when `config.model_id` doesn't resolve (e.g. the model was
+    /// removed after this capability was configured). Construction stays
+    /// infallible per `ConfigConstructable`; the error is surfaced at
+    /// `bind()` time and via `Capability::is_healthy`.
+    configured_model: Result<ConfiguredModel, String>,
 }
 
 impl ConfigConstructable for SubAgentCapability {
@@ -108,8 +112,12 @@ impl Capability for SubAgentCapability {
             ),
         };
         let model_id = &self.config.model_id;
+        let configured_model = self
+            .configured_model
+            .as_ref()
+            .map_err(|e| anyhow::anyhow!(e.clone()))?;
 
-        let (provider, endpoint, model_name) = self.configured_model.resolve_provider_endpoint(
+        let (provider, endpoint, model_name) = configured_model.resolve_provider_endpoint(
             model_id,
             api_type.clone(),
             ModelFunction::Chat,
@@ -128,10 +136,17 @@ impl Capability for SubAgentCapability {
                 endpoint_path: endpoint.path().to_string(),
                 api_key: provider.api_key().cloned(),
                 verify_ssl: provider.verify_ssl(),
-                context_length: Some(self.configured_model.model.context_length()),
+                context_length: Some(configured_model.model.context_length()),
             },
             known_type: None,
         }))
+    }
+
+    fn is_healthy(&self) -> Result<(), String> {
+        self.configured_model
+            .as_ref()
+            .map(|_| ())
+            .map_err(Clone::clone)
     }
 }
 
@@ -329,13 +344,13 @@ mod tests {
         SubAgentCapability {
             instance_id: cap.instance_id,
             config: cap.config,
-            configured_model: crate::models::ConfiguredModel::for_test(
+            configured_model: Ok(crate::models::ConfiguredModel::for_test(
                 Arc::new(TestModel {
                     supported_functions: functions,
                     provider,
                 }),
                 None,
-            ),
+            )),
         }
     }
 
@@ -367,13 +382,13 @@ mod tests {
         let cap = SubAgentCapability {
             instance_id: cap.instance_id,
             config: cap.config,
-            configured_model: crate::models::ConfiguredModel::for_test(
+            configured_model: Ok(crate::models::ConfiguredModel::for_test(
                 Arc::new(TestModel {
                     supported_functions: vec![ModelFunction::Chat],
                     provider: ok_provider(),
                 }),
                 None,
-            ),
+            )),
         };
 
         let binding = cap.bind(request(ApiType::Anthropic)).await.unwrap();

--- a/src/capabilities/sub_agent.rs
+++ b/src/capabilities/sub_agent.rs
@@ -8,7 +8,7 @@ use crate::capabilities::base::{
     Dependency, HasCapabilityMetadata, SubAgentBinding, SubAgentBindingRequest, ToolName,
 };
 use crate::capabilities::requirement::ModelRequirement;
-use crate::models::{ConfiguredModel, ModelFunction};
+use crate::models::{ConfiguredModel, ConfiguredModelResolution, ModelFunction};
 use crate::registry::ConfigConstructable;
 use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
@@ -112,10 +112,7 @@ impl Capability for SubAgentCapability {
             ),
         };
         let model_id = &self.config.model_id;
-        let configured_model = self
-            .configured_model
-            .as_ref()
-            .map_err(|e| anyhow::anyhow!(e.clone()))?;
+        let configured_model = self.configured_model.resolved()?;
 
         let (provider, endpoint, model_name) = configured_model.resolve_provider_endpoint(
             model_id,
@@ -143,10 +140,7 @@ impl Capability for SubAgentCapability {
     }
 
     fn is_healthy(&self) -> Result<(), String> {
-        self.configured_model
-            .as_ref()
-            .map(|_| ())
-            .map_err(Clone::clone)
+        self.configured_model.health()
     }
 }
 

--- a/src/capabilities/sub_agent_explore.rs
+++ b/src/capabilities/sub_agent_explore.rs
@@ -17,7 +17,7 @@ use crate::capabilities::base::{
     Dependency, HasCapabilityMetadata, KnownSubAgent, SubAgentBinding, SubAgentBindingRequest,
     ToolName,
 };
-use crate::models::{ConfiguredModel, ModelFunction};
+use crate::models::{ConfiguredModel, ConfiguredModelResolution, ModelFunction};
 use crate::registry::ConfigConstructable;
 
 /*-- ExploreSubAgentCapabilityConfig --------------------------------------------*/
@@ -160,10 +160,7 @@ impl Capability for ExploreSubAgentCapability {
             ),
         };
         let model_id = &self.config.model_id;
-        let configured_model = self
-            .configured_model
-            .as_ref()
-            .map_err(|e| anyhow::anyhow!(e.clone()))?;
+        let configured_model = self.configured_model.resolved()?;
 
         let (provider, endpoint, model_name) = configured_model.resolve_provider_endpoint(
             model_id,
@@ -191,10 +188,7 @@ impl Capability for ExploreSubAgentCapability {
     }
 
     fn is_healthy(&self) -> Result<(), String> {
-        self.configured_model
-            .as_ref()
-            .map(|_| ())
-            .map_err(Clone::clone)
+        self.configured_model.health()
     }
 }
 

--- a/src/capabilities/sub_agent_explore.rs
+++ b/src/capabilities/sub_agent_explore.rs
@@ -75,7 +75,11 @@ Complete the user's search request efficiently and report your findings clearly.
 pub struct ExploreSubAgentCapability {
     instance_id: String,
     config: ExploreSubAgentCapabilityConfig,
-    configured_model: ConfiguredModel,
+    /// `Err` when `config.model_id` doesn't resolve (e.g. the model was
+    /// removed after this capability was configured). Construction stays
+    /// infallible per `ConfigConstructable`; the error is surfaced at
+    /// `bind()` time and via `Capability::is_healthy`.
+    configured_model: Result<ConfiguredModel, String>,
     /// Static prompt for the explore sub-agent (placeholder for now; user can
     /// override by editing this field later).
     pub prompt: String,
@@ -156,8 +160,12 @@ impl Capability for ExploreSubAgentCapability {
             ),
         };
         let model_id = &self.config.model_id;
+        let configured_model = self
+            .configured_model
+            .as_ref()
+            .map_err(|e| anyhow::anyhow!(e.clone()))?;
 
-        let (provider, endpoint, model_name) = self.configured_model.resolve_provider_endpoint(
+        let (provider, endpoint, model_name) = configured_model.resolve_provider_endpoint(
             model_id,
             api_type.clone(),
             ModelFunction::Chat,
@@ -176,10 +184,17 @@ impl Capability for ExploreSubAgentCapability {
                 endpoint_path: endpoint.path().to_string(),
                 api_key: provider.api_key().cloned(),
                 verify_ssl: provider.verify_ssl(),
-                context_length: Some(self.configured_model.model.context_length()),
+                context_length: Some(configured_model.model.context_length()),
             },
             known_type: Some(KnownSubAgent::Explore),
         }))
+    }
+
+    fn is_healthy(&self) -> Result<(), String> {
+        self.configured_model
+            .as_ref()
+            .map(|_| ())
+            .map_err(Clone::clone)
     }
 }
 
@@ -376,13 +391,13 @@ mod tests {
         ExploreSubAgentCapability {
             instance_id: cap.instance_id,
             config: cap.config,
-            configured_model: crate::models::ConfiguredModel::for_test(
+            configured_model: Ok(crate::models::ConfiguredModel::for_test(
                 Arc::new(TestModel {
                     supported_functions: functions,
                     provider,
                 }),
                 None,
-            ),
+            )),
             prompt: cap.prompt,
             tools: cap.tools,
         }
@@ -414,13 +429,13 @@ mod tests {
         let cap = ExploreSubAgentCapability {
             instance_id: cap.instance_id,
             config: cap.config,
-            configured_model: crate::models::ConfiguredModel::for_test(
+            configured_model: Ok(crate::models::ConfiguredModel::for_test(
                 Arc::new(TestModel {
                     supported_functions: vec![ModelFunction::Chat],
                     provider: ok_provider(),
                 }),
                 None,
-            ),
+            )),
             prompt: cap.prompt,
             tools: cap.tools,
         };

--- a/src/capabilities/sub_agent_plan.rs
+++ b/src/capabilities/sub_agent_plan.rs
@@ -18,7 +18,7 @@ use crate::capabilities::base::{
     Dependency, HasCapabilityMetadata, KnownSubAgent, SubAgentBinding, SubAgentBindingRequest,
     ToolName,
 };
-use crate::models::{ConfiguredModel, ModelFunction};
+use crate::models::{ConfiguredModel, ConfiguredModelResolution, ModelFunction};
 use crate::registry::ConfigConstructable;
 
 /*-- PlanSubAgentCapabilityConfig --------------------------------------------*/
@@ -186,10 +186,7 @@ impl Capability for PlanSubAgentCapability {
             ),
         };
         let model_id = &self.config.model_id;
-        let configured_model = self
-            .configured_model
-            .as_ref()
-            .map_err(|e| anyhow::anyhow!(e.clone()))?;
+        let configured_model = self.configured_model.resolved()?;
 
         let (provider, endpoint, model_name) = configured_model.resolve_provider_endpoint(
             model_id,
@@ -217,10 +214,7 @@ impl Capability for PlanSubAgentCapability {
     }
 
     fn is_healthy(&self) -> Result<(), String> {
-        self.configured_model
-            .as_ref()
-            .map(|_| ())
-            .map_err(Clone::clone)
+        self.configured_model.health()
     }
 }
 

--- a/src/capabilities/sub_agent_plan.rs
+++ b/src/capabilities/sub_agent_plan.rs
@@ -94,7 +94,11 @@ REMEMBER: You can ONLY explore and plan. You CANNOT and MUST NOT write, edit, or
 pub struct PlanSubAgentCapability {
     instance_id: String,
     config: PlanSubAgentCapabilityConfig,
-    configured_model: ConfiguredModel,
+    /// `Err` when `config.model_id` doesn't resolve (e.g. the model was
+    /// removed after this capability was configured). Construction stays
+    /// infallible per `ConfigConstructable`; the error is surfaced at
+    /// `bind()` time and via `Capability::is_healthy`.
+    configured_model: Result<ConfiguredModel, String>,
     /// Static prompt for the plan sub-agent (placeholder for now; user can
     /// override by editing this field later).
     pub prompt: String,
@@ -182,8 +186,12 @@ impl Capability for PlanSubAgentCapability {
             ),
         };
         let model_id = &self.config.model_id;
+        let configured_model = self
+            .configured_model
+            .as_ref()
+            .map_err(|e| anyhow::anyhow!(e.clone()))?;
 
-        let (provider, endpoint, model_name) = self.configured_model.resolve_provider_endpoint(
+        let (provider, endpoint, model_name) = configured_model.resolve_provider_endpoint(
             model_id,
             api_type.clone(),
             ModelFunction::Chat,
@@ -202,10 +210,17 @@ impl Capability for PlanSubAgentCapability {
                 endpoint_path: endpoint.path().to_string(),
                 api_key: provider.api_key().cloned(),
                 verify_ssl: provider.verify_ssl(),
-                context_length: Some(self.configured_model.model.context_length()),
+                context_length: Some(configured_model.model.context_length()),
             },
             known_type: Some(KnownSubAgent::Plan),
         }))
+    }
+
+    fn is_healthy(&self) -> Result<(), String> {
+        self.configured_model
+            .as_ref()
+            .map(|_| ())
+            .map_err(Clone::clone)
     }
 }
 
@@ -402,13 +417,13 @@ mod tests {
         PlanSubAgentCapability {
             instance_id: cap.instance_id,
             config: cap.config,
-            configured_model: crate::models::ConfiguredModel::for_test(
+            configured_model: Ok(crate::models::ConfiguredModel::for_test(
                 Arc::new(TestModel {
                     supported_functions: functions,
                     provider,
                 }),
                 None,
-            ),
+            )),
             prompt: cap.prompt,
             tools: cap.tools,
         }
@@ -440,13 +455,13 @@ mod tests {
         let cap = PlanSubAgentCapability {
             instance_id: cap.instance_id,
             config: cap.config,
-            configured_model: crate::models::ConfiguredModel::for_test(
+            configured_model: Ok(crate::models::ConfiguredModel::for_test(
                 Arc::new(TestModel {
                     supported_functions: vec![ModelFunction::Chat],
                     provider: ok_provider(),
                 }),
                 None,
-            ),
+            )),
             prompt: cap.prompt,
             tools: cap.tools,
         };

--- a/src/capabilities/vision_mcp/mod.rs
+++ b/src/capabilities/vision_mcp/mod.rs
@@ -80,7 +80,11 @@ impl Default for VisionMCPCapabilityConfig {
 pub struct VisionMCPCapability {
     instance_id: String,
     config: VisionMCPCapabilityConfig,
-    configured_model: ConfiguredModel,
+    /// `Err` when `config.model_id` doesn't resolve (e.g. the model was
+    /// removed after this capability was configured). Construction stays
+    /// infallible per `ConfigConstructable`; the error is surfaced at
+    /// `bind()` time and via `Capability::is_healthy`.
+    configured_model: Result<ConfiguredModel, String>,
     /// The in-process Streamable HTTP server started by `bind()`. `None`
     /// before `bind()` runs.
     http_server: Mutex<Option<SubServer>>,
@@ -160,13 +164,17 @@ impl Capability for VisionMCPCapability {
         );
 
         let model_id = &self.config.model_id;
+        let configured_model = self
+            .configured_model
+            .as_ref()
+            .map_err(|e| anyhow::anyhow!(e.clone()))?;
         // The vision backend speaks the OpenAI-compatible chat/vision
         // dialect, the one every granite-cli provider can serve -- same
         // rationale as `pi`/`opencode`'s AgentModel binding. The model must
         // support ImageUnderstanding, but the endpoint is looked up via
         // Chat, since that's the endpoint that actually serves vision
         // requests.
-        let (provider, endpoint, model_name) = self.configured_model.resolve_provider_endpoint(
+        let (provider, endpoint, model_name) = configured_model.resolve_provider_endpoint(
             model_id,
             ApiType::OpenAI,
             ModelFunction::ImageUnderstanding,
@@ -204,6 +212,13 @@ impl Capability for VisionMCPCapability {
             server.shutdown().await;
         }
         Ok(())
+    }
+
+    fn is_healthy(&self) -> Result<(), String> {
+        self.configured_model
+            .as_ref()
+            .map(|_| ())
+            .map_err(Clone::clone)
     }
 }
 
@@ -404,13 +419,13 @@ mod tests {
         VisionMCPCapability {
             instance_id: cap.instance_id,
             config: cap.config,
-            configured_model: ConfiguredModel::for_test(
+            configured_model: Ok(ConfiguredModel::for_test(
                 Arc::new(TestVisionModel {
                     supported_functions: functions,
                     provider,
                 }),
                 None,
-            ),
+            )),
             http_server: Mutex::new(None),
         }
     }

--- a/src/capabilities/vision_mcp/mod.rs
+++ b/src/capabilities/vision_mcp/mod.rs
@@ -22,7 +22,7 @@ use crate::capabilities::base::{
     HasCapabilityMetadata, LaunchContext, McpBinding, McpBindingRequest, McpTransportKind,
 };
 use crate::capabilities::requirement::ModelRequirement;
-use crate::models::{ConfiguredModel, ModelFunction, ModelType};
+use crate::models::{ConfiguredModel, ConfiguredModelResolution, ModelFunction, ModelType};
 use crate::providers::ApiType;
 use crate::registry::ConfigConstructable;
 use crate::utils::subserver::SubServer;
@@ -164,10 +164,7 @@ impl Capability for VisionMCPCapability {
         );
 
         let model_id = &self.config.model_id;
-        let configured_model = self
-            .configured_model
-            .as_ref()
-            .map_err(|e| anyhow::anyhow!(e.clone()))?;
+        let configured_model = self.configured_model.resolved()?;
         // The vision backend speaks the OpenAI-compatible chat/vision
         // dialect, the one every granite-cli provider can serve -- same
         // rationale as `pi`/`opencode`'s AgentModel binding. The model must
@@ -215,10 +212,7 @@ impl Capability for VisionMCPCapability {
     }
 
     fn is_healthy(&self) -> Result<(), String> {
-        self.configured_model
-            .as_ref()
-            .map(|_| ())
-            .map_err(Clone::clone)
+        self.configured_model.health()
     }
 }
 

--- a/src/commands/launcher.rs
+++ b/src/commands/launcher.rs
@@ -704,6 +704,34 @@ mod tests {
         );
     }
 
+    // Regression test for issue #90: `select_capabilities` used to panic when
+    // a configured capability's model_id no longer resolves (e.g. after
+    // `model remove granite-4.2-8b` while `capability setup agent-model` still
+    // references it). It must instead silently omit the broken capability
+    // from the multi-select, the same way an unknown capability_type is
+    // already omitted.
+    #[tokio::test]
+    async fn select_capabilities_omits_capability_whose_model_was_removed() {
+        let mut ctx = test_ctx();
+        add_capability(&mut ctx, "my-agent", "granite-4.2-8b");
+        // Simulate `model remove granite-4.2-8b`: the capability config still
+        // references it, but it's gone from config.models.
+        ctx.config.models.remove("granite-4.2-8b");
+
+        let launcher_def = claude_launcher_def();
+        let result = select_capabilities(&mut ctx, &launcher_def, &[]).await;
+
+        assert!(result.is_ok(), "must not panic or error: {result:?}");
+        let ui = capture_ui!(ctx);
+        let prompts = ui.multi_select_prompts.borrow();
+        if let Some((_, items, _)) = prompts.first() {
+            assert!(
+                !items.contains(&"my-agent".to_string()),
+                "broken capability must not be offered as a choice"
+            );
+        }
+    }
+
     // Previously-enabled capability IDs are pre-checked (defaults = true).
     #[tokio::test]
     async fn select_capabilities_pre_checks_previously_enabled_ids() {

--- a/src/models/base.rs
+++ b/src/models/base.rs
@@ -319,6 +319,35 @@ impl ConfiguredModel {
     }
 }
 
+/*-- ConfiguredModelResolution -------------------------------------------------*/
+
+/// What every model-backed `Capability` does with the `Result<ConfiguredModel,
+/// String>` it stores from `ConfiguredModel::resolve`: report the failure
+/// from `Capability::is_healthy`, or bail out of `Capability::bind` with a
+/// named error. Centralized here so the 5 capabilities that store this
+/// `Result` (`AgentModelCapability`, `VisionMCPCapability`,
+/// `SubAgentCapability`, `ExploreSubAgentCapability`, `PlanSubAgentCapability`)
+/// each reduce to one call instead of repeating the same
+/// `as_ref().map_err(...)`.
+pub trait ConfiguredModelResolution {
+    /// For `Capability::is_healthy`.
+    fn health(&self) -> Result<(), String>;
+
+    /// For `Capability::bind` prologues: `Ok(&ConfiguredModel)` when
+    /// resolved, or a named `anyhow::Error` otherwise.
+    fn resolved(&self) -> anyhow::Result<&ConfiguredModel>;
+}
+
+impl ConfiguredModelResolution for Result<ConfiguredModel, String> {
+    fn health(&self) -> Result<(), String> {
+        self.as_ref().map(|_| ()).map_err(Clone::clone)
+    }
+
+    fn resolved(&self) -> anyhow::Result<&ConfiguredModel> {
+        self.as_ref().map_err(|e| anyhow::anyhow!(e.clone()))
+    }
+}
+
 /*-- Metadata Types ----------------------------------------------------------*/
 
 /// Metadata describing a model implementation.
@@ -836,5 +865,23 @@ mod configured_model_tests {
             panic!("expected resolve to fail for an unconfigured model_id")
         };
         assert!(err.contains("granite-4.2-8b"));
+    }
+
+    #[test]
+    fn configured_model_resolution_health_and_resolved_agree_with_the_result() {
+        let ok: Result<ConfiguredModel, String> = Ok(configured_model(
+            vec![ModelFunction::Chat],
+            ok_provider(),
+            None,
+        ));
+        assert!(ok.health().is_ok());
+        assert!(ok.resolved().is_ok());
+
+        let broken: Result<ConfiguredModel, String> = Err("granite-4.2-8b missing".to_string());
+        assert_eq!(broken.health(), Err("granite-4.2-8b missing".to_string()));
+        let Err(err) = broken.resolved() else {
+            panic!("expected resolved() to fail when the stored Result is Err")
+        };
+        assert!(err.to_string().contains("granite-4.2-8b missing"));
     }
 }

--- a/src/models/base.rs
+++ b/src/models/base.rs
@@ -223,10 +223,15 @@ impl ConfiguredModel {
     /// computed first (rather than after, as it used to be) so it can be
     /// passed into `take`, which needs it to compute the same provider alias
     /// `resolve_provider_endpoint` will use later as the route's dispatch
-    /// key. Panics if the model isn't found/constructible -- capabilities'
-    /// `ConfigConstructable::new` is infallible by trait signature, so this
-    /// preserves that contract exactly.
-    pub fn resolve(model_id: &str, global_config: &crate::config::Config) -> Self {
+    /// key.
+    ///
+    /// Returns `Err` (naming `model_id`) rather than panicking when the model
+    /// isn't found/constructible -- e.g. a capability's `model_id` still
+    /// points at a model the user has since removed. Capabilities'
+    /// `ConfigConstructable::new` is infallible by trait signature, so
+    /// callers store this `Result` and surface the error at `bind()` time
+    /// instead of at construction time.
+    pub fn resolve(model_id: &str, global_config: &crate::config::Config) -> Result<Self, String> {
         let configured_variant = global_config
             .models
             .get(model_id)
@@ -234,13 +239,13 @@ impl ConfiguredModel {
         let mut source = crate::models::ModelSource::from_config(global_config);
         let model = source
             .take(model_id, configured_variant.as_deref())
-            .unwrap_or_else(|| {
-                panic!("Configured model '{model_id}' not found or could not be constructed")
-            });
-        Self {
+            .ok_or_else(|| {
+                format!("Configured model '{model_id}' not found or could not be constructed")
+            })?;
+        Ok(Self {
             model,
             configured_variant,
-        }
+        })
     }
 
     /// Test-only escape hatch so capability unit tests can inject a fake
@@ -819,5 +824,17 @@ mod configured_model_tests {
     fn resolve_variant_returns_none_without_a_configured_variant() {
         let cm = configured_model(vec![ModelFunction::Chat], ok_provider(), None);
         assert!(cm.resolve_variant().is_none());
+    }
+
+    // Regression test for issue #90: resolving a model_id that isn't in
+    // config.models (e.g. it was removed via `model remove`) must return a
+    // named `Err`, not panic.
+    #[test]
+    fn resolve_returns_named_err_for_unconfigured_model_id() {
+        let global_config = crate::config::Config::default();
+        let Err(err) = ConfiguredModel::resolve("granite-4.2-8b", &global_config) else {
+            panic!("expected resolve to fail for an unconfigured model_id")
+        };
+        assert!(err.contains("granite-4.2-8b"));
     }
 }

--- a/src/models/mod.rs
+++ b/src/models/mod.rs
@@ -146,8 +146,8 @@ impl crate::dependency::Configured<dyn Model> for ModelSource {
 // Re-export types from base
 mod base;
 pub use base::{
-    ConfiguredModel, LayerKind, LayerTypeCount, MambaShape, Model, ModelArchitecture,
-    ModelFunction, ModelMetadata, ModelType, ModelVariant,
+    ConfiguredModel, ConfiguredModelResolution, LayerKind, LayerTypeCount, MambaShape, Model,
+    ModelArchitecture, ModelFunction, ModelMetadata, ModelType, ModelVariant,
 };
 
 pub(crate) mod context_fit;


### PR DESCRIPTION
## Description

When building a launcher, if any capability had a dangling reference, panic was triggered so no new launcher could be created until the dangling reference was fixed. This is not a good user experience and not in line with the behavior of the CLI in other parts of the user experience.

This PR fixes this by removing the panic, replacing with an error which is stored and used to filter our unhealthy capabilities in the UI.

## Changes

`ConfiguredModel::resolve()`panicked when a capability's model_id no longer existed in config (e.g. after `model remove`), crashing any command that eagerly constructs capabilities.
Since `ConfigConstructable::new` is infallible by trait signature, the panic bypassed `CapabilitySource::from_config's existing skip-and-warn handling for construction failures.

`resolve()` now returns a Result instead of panicking; the five model-backed capabilities store it and surface the failure through a new `Capability::is_healthy()` check (used by
`CapabilitySource::from_config` to skip and warn, matching how an unknown capability_type is already handled) and through bind()'s existing Result.

## Testing

1. Root-cause level (src/models/base.rs)
- resolve_returns_named_err_for_unconfigured_model_id — asserts ConfiguredModel::resolve() returns Err naming the model id instead of panicking, for a model that isn't in config.

2. Capability level (src/capabilities/agent_model.rs)
- new_does_not_panic_when_model_id_is_unconfigured — constructs a real AgentModelCapability (via ConfigConstructable::new, not the test double) with a dangling model_id and checks is_healthy() reports the error.
- bind_fails_with_named_error_when_model_id_is_unconfigured — same setup, but calls bind() and asserts it returns a proper anyhow::Result error naming the model, not a panic.

3. Source/registry level (src/capabilities/mod.rs)
- capability_source_skips_capability_referencing_a_removed_model — CapabilitySource::from_config() with one capability pointing at a missing model → instances() comes back empty (skipped, not crashed).
- capability_source_skips_broken_entries_but_keeps_healthy_ones — same, but alongy, to confirm only the broken one gets dropped, not everything.
## Related Issue(s)

Fixes: #90 

## AI Usage

AI-Usage: draft (Claude Sonnet 5)
