### PR TITLE
Auto setup

### DIFF
--- a/docs/specs/0023-setup-wizard.md
+++ b/docs/specs/0023-setup-wizard.md
@@ -1,0 +1,436 @@
+# Spec 0023: `granite-cli setup` — Unified Auto Setup Wizard
+
+## Overview
+
+This spec introduces a new top-level `granite-cli setup` command that orchestrates the automatic discovery and configuration of providers, models, launchers, and capabilities in a single guided flow. It combines the existing per-component `setup` wizards with an extended recommendation engine that surfaces the full dependency graph — not just models, but every layer needed to make a capable setup work.
+
+The wizard works **backwards from capabilities**: the user first selects which capabilities they want, then which launchers support those capabilities, then which providers serve the launchers, and finally which models satisfy the capability requirements. Each section's selections inform the next section's recommendations.
+
+Two execution modes are supported:
+
+- **Interactive** (default): Step through each section with prompts.
+- **`--auto`**: Non-interactive — detect, recommend, and configure everything that can be auto-configured with default settings. Consent is implied.
+
+## Goals
+
+1. Add a `setup` top-level subcommand (`granite-cli setup`) with `--auto` and `--skip-pull` flags
+2. Implement a `Discover` engine that scans all four layers (providers, models, launchers, capabilities) and produces structured recommendations
+3. Build an interactive wizard that presents sections **in dependency order**: Capabilities → Launchers → Providers → Models
+4. Auto-configure detected items in `--auto` mode using registry defaults
+5. Never auto-pull model weights — pull is always explicit
+6. Use each component's default health check for availability detection (no impl-specific logic)
+7. Filter model recommendations to only those models that would be used by at least one selected capability
+
+## Non-Goals
+
+- Provider binary installation (e.g., "ollama not installed, run `brew install ollama`") — outside granite-cli's scope
+- Model weight auto-pulling in `--auto` mode (always requires explicit `model pull`)
+- Provider failover or retry logic — deferred to a future spec
+- TUI implementation — wizard uses the existing `dialoguer`-based UI layer
+- Shell export integration — out of scope for the wizard; users export separately
+
+---
+
+## 1. Command Interface
+
+### Top-level command
+
+```
+granite-cli setup              # Interactive full wizard
+granite-cli setup --auto       # Non-interactive: detect + configure automatically
+granite-cli setup --skip-pull  # Interactive, but never prompt to pull weights
+granite-cli setup --auto --skip-pull  # Both flags combined
+```
+
+### CLI definition (Rust)
+
+Add to `src/main.rs`:
+
+```rust
+#[derive(Subcommand, Debug)]
+enum SetupSubcommands {
+    /// Run the full setup wizard to configure providers, models, launchers,
+    /// and capabilities. Works backwards from capabilities — selecting a
+    /// capability determines which launchers, providers, and models are
+    /// recommended.
+    Setup {
+        /// Auto-detect and configure everything that can be auto-configured.
+        /// Consent is implied. Uses registry defaults for all config fields.
+        #[arg(long)]
+        auto: bool,
+
+        /// Skip the model weight pull prompt at the end of the wizard.
+        /// Model weights are never auto-pulled in --auto mode regardless.
+        #[arg(long)]
+        skip_pull: bool,
+    },
+}
+```
+
+Wire `Setup(SetupSubcommands)` into the `Commands` enum and route it in `main()`.
+
+---
+
+## 2. Discovery Engine
+
+All discovery happens in a new `src/commands/setup.rs` module, in a `Discover` struct that produces a `DiscoveryResult`. The `Discover::run()` method is async and runs all four discovery phases sequentially.
+
+### 2.1 Result Types
+
+```rust
+/// One recommendation produced during the discovery phase.
+enum Recommendation {
+    Provider {
+        provider_type: &'static str,
+        provider_name: String,
+        health_healthy: bool,
+        health_error: Option<String>,
+        suggested_instance_id: String,
+    },
+    Model {
+        model_id: String,
+        family: String,
+        version: String,
+        size: String,
+        model_type: ModelType,
+        best_variant: ModelVariant,   // largest size fitting hardware, latest in family
+        context_fit: ContextFit,
+        can_run_by: Vec<String>,      // provider ids that can run it
+    },
+    Launcher {
+        launcher_type: String,
+        launcher_name: String,
+        binary_path: Option<PathBuf>,
+        suggested_instance_id: String,
+    },
+    Capability {
+        capability_type: String,
+        capability_name: String,
+        // Resolved at recommendation time; may be empty if user hasn't
+        // selected launchers/models yet.
+        satisfied_by_launchers: Vec<String>,
+        satisfied_by_models: Vec<String>,
+    },
+}
+
+/// The complete output of the discovery engine.
+struct DiscoveryResult {
+    recommendations: Vec<Recommendation>,
+    /// Provider ids that are already configured (not recommended, just existing).
+    configured_providers: Vec<String>,
+    /// Model ids that are already configured.
+    configured_models: Vec<String>,
+    /// Launcher ids that are already configured.
+    configured_launchers: Vec<String>,
+    /// Capability ids that are already configured.
+    configured_capabilities: Vec<String>,
+}
+```
+
+### 2.2 Provider Discovery — `Discover::discover_providers()`
+
+For each provider type in `PROVIDER_REGISTRY.entries()`:
+
+1. Check `ctx.config.providers` — skip if already configured, record in `configured_providers`
+2. For unconfigured providers:
+   a. Construct a transient instance using registry default config (`LAUNCHER_REGISTRY.default_config()` / `PROVIDER_REGISTRY.default_config()`)
+   b. Run the provider's default `health_check()` method
+   c. If the health check succeeds, emit a `Recommendation::Provider` with `health_healthy: true`
+   d. If the health check fails, still emit a recommendation with `health_healthy: false` and the error message — the user may want to configure it anyway
+3. Use the provider type as the `suggested_instance_id`
+
+**Key rule: No impl-specific detection logic.** Every provider is discovered the same way — construct with defaults, run health check. The health check itself may be provider-specific (ollama checks `/tags`, llama-cpp checks `/models`, etc.) but the discovery engine does not contain any such logic.
+
+### 2.3 Model Discovery — `Discover::discover_models()`
+
+1. Group `MODEL_REGISTRY.entries()` by family (e.g., "Granite Language", "Granite Vision")
+2. For each family:
+   a. Find the latest version using `compare_versions_desc()` (existing utility)
+   b. For the latest version, find the strongest/largest size that fits current hardware:
+      - Call `detect_hardware()` to get the `HardwareProfile`
+      - For each variant, call `context_fit::estimate()` to compute `ContextFit`
+      - Prefer variants with `ContextFit::Full` over `ContextFit::Partial`
+      - Among equally-fit variants, prefer the largest by `size_gb`
+   c. For the winning variant, check which configured providers (from `ctx.config` or from discovered healthy providers) can run it via `can_run_model(format, precision)`
+   d. Skip if the model is already in `ctx.config.models`
+   e. Emit `Recommendation::Model`
+
+**Key rule: At discovery time, ALL families produce recommendations.** No filtering by capability occurs yet. Filtering by capability happens in the wizard selection phase.
+
+### 2.4 Launcher Discovery — `Discover::discover_launchers()`
+
+For each launcher type in `LAUNCHER_REGISTRY.entries()`:
+
+1. Check `ctx.config.launchers` — skip if already configured, record in `configured_launchers`
+2. For unconfigured launchers:
+   a. Construct a transient instance using registry default config
+   b. Call `launcher.validate_command()` to check if the binary is resolvable
+   c. Record the resolved path (or `None` if not found)
+   d. Emit `Recommendation::Launcher` with the binary path
+
+### 2.5 Capability Discovery — `Discover::discover_capabilities()`
+
+For each capability type in `CAPABILITY_REGISTRY.entries()`:
+
+1. Check `ctx.config.capabilities` — skip if already configured, record in `configured_capabilities`
+2. For unconfigured capabilities:
+   a. Check which configured/recommended launchers support this capability's binding types:
+      - Iterate `LAUNCHER_REGISTRY.entries()` and check `LauncherMetadata.supported_capabilities` against `CapabilityMetadata.supported_binding_types`
+   b. For capabilities with model requirements (e.g., `agent-model`), check which recommended models satisfy the `ModelRequirement`:
+      - Use `ModelRequirement` to filter `MODEL_REGISTRY.entries()`
+      - A model satisfies the requirement if all non-empty fields match
+   c. Emit `Recommendation::Capability` with the lists of satisfying launchers and models
+
+**These lists are populated from the full discovery result.** When the wizard filters launchers/models, the capability satisfaction lists are re-evaluated.
+
+---
+
+## 3. Wizard Flow
+
+The wizard is implemented in `SetupCommands::run(ctx, auto, skip_pull)`.
+
+### 3.1 Phase 0 — Discovery
+
+Run `Discover::run(ctx)` to produce `DiscoveryResult`. This is the single source of truth for all recommendations.
+
+### 3.2 Phase 1 — Capabilities Selection
+
+Present all capability recommendations (and already-configured capabilities) as a multi-select list:
+
+```
+== Capabilities ==
+  [x] agent-model        — Provides agent model bindings for AI tools
+  [x] vision-mcp         — Provides vision analysis via MCP
+  [ ] sub-agent          — Provides sub-agent delegation
+  [x] sub-agent-explore  — Provides explore sub-agent capability
+```
+
+In `--auto` mode, all capabilities with at least one satisfying launcher and model are auto-selected.
+
+The user's selections are recorded as `selected_capabilities: HashSet<String>`.
+
+### 3.3 Phase 2 — Launchers Selection
+
+Re-evaluate launcher recommendations based on selected capabilities. A launcher is recommended if it supports at least one selected capability's binding types:
+
+```
+== Launchers ==
+  [x] claude     — Claude Code, binary found: /opt/claude/claude
+  [ ] bob        — Bob, binary not found on PATH
+  [x] opencode   — OpenCode, binary found: /usr/local/bin/opencode
+```
+
+In `--auto` mode, all auto-selected capabilities require certain launchers — those launchers are auto-selected. If a launcher's binary is not found, it is still recommended but flagged.
+
+The user's selections are recorded as `selected_launchers: HashSet<String>`.
+
+### 3.4 Phase 3 — Providers Selection
+
+Re-evaluate provider recommendations based on selected launchers. A provider is recommended if at least one selected launcher needs it (i.e., the launcher's configured capabilities need models that the provider can serve). Show all detected+healthy providers, plus any configured providers:
+
+```
+== Providers ==
+  [x] ollama       — Local, healthy ✓
+  [ ] openrouter   — Hosted, health check failed: timeout
+  [x] llama-cpp    — Local, healthy ✓
+```
+
+In `--auto` mode, all healthy detected providers are auto-selected.
+
+The user's selections are recorded as `selected_providers: HashSet<String>`.
+
+### 3.5 Phase 4 — Models Selection
+
+Re-evaluate model recommendations based on selected capabilities. A model is recommended **only if it would be used by at least one selected capability**. This is the key filtering step that answers requirement 3 from the spec:
+
+```
+== Models ==
+  [x] granite-3.3-8b-instruct    — Granite Language 3.3, 8B, gguf/fp16 (4.7 GB), Full fit
+  [x] granite-vision-3.3-2b      — Granite Vision 3.3, 2B, gguf/fp16 (1.3 GB), Full fit
+```
+
+In `--auto` mode, models that satisfy the requirements of all auto-selected capabilities are auto-selected.
+
+The user's selections are recorded as `selected_models: HashSet<String>`.
+
+### 3.6 Phase 5 — Configuration
+
+Iterate through all four sections in forward order and configure selected items:
+
+1. **Providers**: For each selected provider, call `ProviderCommands::setup()` with the registry default config
+2. **Launchers**: For each selected launcher, call `LauncherCommands::setup()` with the registry default config
+3. **Models**: For each selected model, call `ModelCommands::setup()` — this resolves a provider for the model
+4. **Capabilities**: For each selected capability, call `CapabilityCommands::setup()` — this resolves models/providers as needed
+
+In `--auto` mode, all steps use defaults without prompting.
+
+### 3.7 Phase 6 — Pull (if not skipped)
+
+For each configured model backed by a local provider, ask whether to pull model weights:
+
+```
+== Pull Weights ==
+  [x] ollama → granite-3.3-8b-instruct (gguf/fp16)
+  [x] ollama → granite-vision-3.3-2b (gguf/fp16)
+  → Pull now? (y/N)
+```
+
+In `--auto` mode, this phase is always skipped (never auto-pull).
+
+### 3.8 Phase 7 — Summary
+
+Display a final summary of everything that was configured:
+
+```
+== Setup Complete ==
+  Providers:  ollama, llama-cpp
+  Models:     granite-3.3-8b-instruct, granite-vision-3.3-2b
+  Launchers:  claude, opencode
+  Capabilities: agent-model, vision-mcp, sub-agent-explore
+
+Run `granite-cli launcher list` to see configured launchers.
+Run `granite-cli launch claude` to launch Claude Code with Granite overlay.
+```
+
+---
+
+## 4. Re-evaluation Logic
+
+After each selection phase, the wizard re-evaluates subsequent sections. This is implemented by a `Revaluator` that takes the current selections and the full `DiscoveryResult`, and returns filtered recommendations for the next section.
+
+```rust
+struct Revaluator;
+
+impl Revaluator {
+    /// Filter launcher recommendations to only those that support
+    /// at least one of the selected capability types.
+    fn for_launchers(
+        discovery: &DiscoveryResult,
+        selected_caps: &HashSet<String>,
+    ) -> Vec<Recommendation>;
+
+    /// Filter provider recommendations to only those that can serve
+    /// at least one of the selected model variants.
+    fn for_providers(
+        discovery: &DiscoveryResult,
+        selected_models: &HashSet<String>,
+        selected_launchers: &HashSet<String>,
+    ) -> Vec<Recommendation>;
+
+    /// Filter model recommendations to only those that satisfy at least
+    /// one of the selected capability's model requirements.
+    fn for_models(
+        discovery: &DiscoveryResult,
+        selected_caps: &HashSet<String>,
+    ) -> Vec<Recommendation>;
+}
+```
+
+**Provider filtering logic:** A provider is recommended if it can run at least one variant of at least one selected model. Additionally, if a selected launcher has capabilities that require specific provider types (e.g., MCP capabilities need OpenAI-compatible API), those providers are prioritized.
+
+---
+
+## 5. File Changes
+
+| File | Action | Description |
+|------|--------|-------------|
+| `src/main.rs` | Extend | Add `Setup` subcommand, `--auto`/`--skip-pull` flags, routing |
+| `src/commands/mod.rs` | Extend | Add `pub mod setup;` |
+| `src/commands/setup.rs` | **Create** | Full implementation: `Discover`, `Revaluator`, `SetupCommands::run()` |
+
+---
+
+## 6. Commit Plan
+
+### Commit 1 — `src/commands/setup.rs`: Discovery engine + types
+
+Add the `Discover` struct, `Recommendation` enum, and `DiscoveryResult` struct. Implement all four discovery methods:
+
+- `discover_providers()` — construct with defaults, run health check
+- `discover_models()` — group by family, find latest + best variant, check provider compatibility
+- `discover_launchers()` — construct with defaults, validate command
+- `discover_capabilities()` — check launcher compatibility + model requirement satisfaction
+
+**Tests:**
+- `discover_providers_detects_healthy_ollama` — configure a mock ollama with a responding health check; assert it appears as a healthy recommendation
+- `discover_providers_skips_configured` — pre-configure ollama; assert it appears in `configured_providers`, not `recommendations`
+- `discover_models_groups_by_family` — assert that the result contains one recommendation per family, not per variant
+- `discover_models_picks_largest_fitting_variant` — assert that for a family with multiple sizes, the largest variant fitting the hardware is selected
+- `discover_launchers_validates_binary` — assert that a launcher with an existing binary has `binary_path` set
+- `discover_launchers_skips_configured` — pre-configure a launcher; assert it appears in `configured_launchers`
+- `discover_capabilities_checks_launcher_compatibility` — assert that a capability appears with the correct list of supporting launchers
+
+### Commit 2 — `src/commands/setup.rs`: Revaluator + Wizard
+
+Add the `Revaluator` struct and implement the wizard flow:
+
+- `run_wizard()` — interactive step-through of all 7 phases
+- `run_auto()` — non-interactive mode with `--auto`
+
+**Tests:**
+- `wizard_filters_launchers_by_capabilities` — select a capability that only supports claude; assert bob is not offered in launcher selection
+- `wizard_filters_models_by_capabilities` — select only agent-model (which needs text models); assert vision-only models are not offered
+- `auto_mode_selects_all_detectable` — in auto mode, all detected+healthy providers and all binary-found launchers are auto-selected
+
+### Commit 3 — `src/main.rs`: CLI wiring
+
+Add the `Setup` subcommand to `Commands`, the `--auto`/`--skip-pull` flags, and routing in `main()`.
+
+**Tests:**
+- `setup_subcommand_exists` — parse `granite-cli setup`; assert subcommand is `Setup(SetupSubcommands::Setup { auto: false, skip_pull: false })`
+- `setup_subcommand_with_auto` — parse `granite-cli setup --auto`; assert `auto: true`
+- `setup_subcommand_with_skip_pull` — parse `granite-cli setup --skip-pull`; assert `skip_pull: true`
+
+---
+
+## 7. Success Criteria
+
+- [ ] `granite-cli setup` runs the interactive wizard with all four sections in order (Capabilities → Launchers → Providers → Models)
+- [ ] Deselecting a launcher in the Launchers section removes capabilities that the launcher was the only support for
+- [ ] Deselecting a capability in the Capabilities section removes models that the capability was the only consumer for
+- [ ] `granite-cli setup --auto` configures all detectable providers, all binary-found launchers, and all capability-recommended models without any prompts
+- [ ] Model weights are never auto-pulled in any mode
+- [ ] `granite-cli setup --skip-pull` suppresses the pull prompt at the end of the wizard
+- [ ] Provider detection uses only the default health check — no impl-specific detection logic in the discovery engine
+- [ ] All new unit tests pass under `cargo test`
+- [ ] `cargo clippy -- -D warnings` passes with no new warnings
+
+---
+
+## 8. Appendix: Section Dependency Flow Diagram
+
+```
+                    ┌─────────────┐
+                    │  Discovery  │  ← runs once, collects everything
+                    └──────┬──────┘
+                           │
+              ┌────────────▼────────────┐
+              │  Phase 1: Capabilities  │  ← user multi-selects
+              └────────────┬────────────┘
+                           │ selected capabilities
+              ┌────────────▼────────────┐
+              │   Phase 2: Launchers    │  ← filtered by selected caps
+              └────────────┬────────────┘
+                           │ selected launchers
+              ┌────────────▼────────────┐
+              │    Phase 3: Providers   │  ← filtered by selected launchers
+              └────────────┬────────────┘
+                           │ selected providers
+              ┌────────────▼────────────┐
+              │    Phase 4: Models      │  ← filtered by selected caps
+              └────────────┬────────────┘
+                           │ selected models
+              ┌────────────▼────────────┐
+              │  Phase 5: Configure     │  ← write configs
+              └────────────┬────────────┘
+                           │
+              ┌────────────▼────────────┐
+              │  Phase 6: Pull (opt)    │  ← optional, never auto
+              └────────────┬────────────┘
+                           │
+              ┌────────────▼────────────┐
+              │  Phase 7: Summary       │  ← display result
+              └─────────────────────────┘
+```
+
+Each arrow represents a re-evaluation: the selections from the upstream phase filter the recommendations in the downstream phase. This ensures the user never sees an option that would be useless given their upstream choices.

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -3,9 +3,11 @@ pub mod hardware;
 pub mod launcher;
 pub mod model;
 pub mod provider;
+pub mod setup;
 
 pub use capability::CapabilityCommands;
 pub use hardware::HardwareCommands;
 pub use launcher::LauncherCommands;
 pub use model::ModelCommands;
 pub use provider::ProviderCommands;
+pub use setup::SetupCommands;

--- a/src/commands/setup.rs
+++ b/src/commands/setup.rs
@@ -1,0 +1,1642 @@
+// Third Party
+use anyhow::Result;
+use std::collections::{HashMap, HashSet};
+
+// Local
+use crate::capabilities::{BindingType, CAPABILITY_REGISTRY, Dependency, ModelRequirement};
+use crate::dependency::Requirement;
+use crate::launchers::LAUNCHER_REGISTRY;
+use crate::models::{ContextFit, MODEL_REGISTRY, ModelMetadata, ModelType, ModelVariant};
+use crate::providers::{HealthStatus, PROVIDER_REGISTRY, Provider};
+use crate::utils::hardware::detect_hardware;
+
+/*-- public --*/
+
+/// A single recommendation produced during discovery.
+pub enum Recommendation {
+    Provider {
+        provider_type: &'static str,
+        provider_name: String,
+        health_healthy: bool,
+        health_error: Option<String>,
+    },
+    Model {
+        model_id: String,
+        family: String,
+        version: String,
+        size: String,
+        model_type: ModelType,
+        best_variant: ModelVariant,
+        context_fit: ContextFit,
+        can_run_by: Vec<String>,
+    },
+    Launcher {
+        launcher_type: String,
+        launcher_name: String,
+        binary_path: Option<String>,
+    },
+    Capability {
+        capability_type: String,
+        capability_name: String,
+    },
+}
+
+/// The complete output of the discovery engine.
+pub struct DiscoveryResult {
+    pub recommendations: Vec<Recommendation>,
+    pub configured_provider_ids: Vec<String>,
+    pub configured_model_ids: Vec<String>,
+    pub configured_launcher_ids: Vec<String>,
+    pub configured_capability_ids: Vec<String>,
+}
+
+/*-- private --*/
+
+/// Discovers all available providers, models, launchers, and capabilities,
+/// returning structured recommendations and a list of already-configured items.
+struct Discover;
+
+impl Discover {
+    /// Run the full discovery pipeline.
+    pub async fn run(ctx: &crate::AppContext) -> DiscoveryResult {
+        let (provider_recs, configured_providers) = Self::discover_providers(ctx).await;
+        let model_recs = Self::discover_models(ctx, &configured_providers);
+        let (launcher_recs, configured_launchers) = Self::discover_launchers(ctx).await;
+        let (capability_recs, configured_capabilities) = Self::discover_capabilities(
+            ctx,
+            &provider_recs,
+            &model_recs,
+            &configured_providers,
+        );
+
+        let mut recommendations: Vec<Recommendation> = Vec::new();
+        recommendations.extend(provider_recs);
+        recommendations.extend(model_recs);
+        recommendations.extend(launcher_recs);
+        recommendations.extend(capability_recs);
+
+        // Sort for deterministic output
+        recommendations.sort_by_key(display_name);
+
+        DiscoveryResult {
+            recommendations,
+            configured_provider_ids: configured_providers,
+            configured_model_ids: ctx.config.models.keys().cloned().collect(),
+            configured_launcher_ids: configured_launchers,
+            configured_capability_ids: configured_capabilities,
+        }
+    }
+
+    // -- Provider discovery --------------------------------------------------
+
+    async fn discover_providers(
+        ctx: &crate::AppContext,
+    ) -> (Vec<Recommendation>, Vec<String>) {
+        let configured_ids: HashSet<&str> = ctx.config.providers.keys().map(|s| s.as_str()).collect();
+        let mut configured: Vec<String> = Vec::new();
+        let mut recommendations: Vec<Recommendation> = Vec::new();
+
+        for (provider_type, metadata) in PROVIDER_REGISTRY.entries() {
+            if configured_ids.contains(provider_type) {
+                configured.push(provider_type.to_string());
+                continue;
+            }
+
+            // Construct a transient instance with default config and run health check
+            let default_config = PROVIDER_REGISTRY.default_config(provider_type).unwrap_or_default();
+            let result = PROVIDER_REGISTRY.construct(
+                provider_type,
+                provider_type,
+                &default_config,
+                &ctx.config,
+            );
+
+            match result {
+                Ok(provider) => match Self::run_health_check(&*provider).await {
+                    Ok(status) => recommendations.push(Recommendation::Provider {
+                        provider_type,
+                        provider_name: metadata.name.clone(),
+                        health_healthy: status.healthy,
+                        health_error: status.error,
+                    }),
+                    Err(e) => recommendations.push(Recommendation::Provider {
+                        provider_type,
+                        provider_name: metadata.name.clone(),
+                        health_healthy: false,
+                        health_error: Some(format!("Health check failed: {e}")),
+                    }),
+                },
+                Err(_) => {
+                    // Provider could not be constructed (e.g., missing schema).
+                    // Still recommend it — user may need to configure it manually.
+                    recommendations.push(Recommendation::Provider {
+                        provider_type,
+                        provider_name: metadata.name.clone(),
+                        health_healthy: false,
+                        health_error: Some("Could not construct provider with default config".to_string()),
+                    });
+                }
+            }
+        }
+
+        configured.sort();
+        recommendations.sort_by_key(display_name);
+        (recommendations, configured)
+    }
+
+    async fn run_health_check(provider: &dyn Provider) -> Result<HealthStatus, crate::providers::ProviderError> {
+        provider.health_check().await
+    }
+
+    // -- Model discovery -----------------------------------------------------
+
+    fn discover_models(
+        ctx: &crate::AppContext,
+        configured_provider_ids: &[String],
+    ) -> Vec<Recommendation> {
+        let profile = detect_hardware();
+        let configured_ids: HashSet<&str> = ctx.config.models.keys().map(|s| s.as_str()).collect();
+
+        // Group models by family, keeping each model's real catalog id
+        // alongside its metadata.
+        let mut family_groups: HashMap<String, Vec<(String, ModelMetadata)>> = HashMap::new();
+        for (model_id, model_md) in MODEL_REGISTRY.entries() {
+            if configured_ids.contains(model_id) {
+                continue;
+            }
+            let family = model_md.family.clone();
+            family_groups
+                .entry(family)
+                .or_default()
+                .push((model_id.to_string(), model_md));
+        }
+
+        let mut recommendations: Vec<Recommendation> = Vec::new();
+
+        for models in family_groups.values() {
+            // Find latest version in this family
+            let latest = find_latest_version(models);
+
+            if let Some((model_id, latest_model)) = latest {
+                // Find best variant for this model
+                if let Some((best_variant, best_fit)) = best_variant(latest_model, &profile) {
+                    // Check which configured providers can run this variant
+                    let can_run_by = Self::find_can_run_providers(
+                        &best_variant,
+                        configured_provider_ids,
+                        ctx,
+                    );
+
+                    recommendations.push(Recommendation::Model {
+                        model_id: model_id.clone(),
+                        family: latest_model.family.clone(),
+                        version: latest_model.version.clone(),
+                        size: format_size(latest_model.size),
+                        model_type: latest_model.model_type.clone(),
+                        best_variant,
+                        context_fit: best_fit,
+                        can_run_by,
+                    });
+                }
+            }
+        }
+
+        // Sort by family, then version desc, then size desc
+        recommendations.sort_by(|a, b| {
+            let (a_family, a_version, a_size) = model_sort_key(a);
+            let (b_family, b_version, b_size) = model_sort_key(b);
+            a_family
+                .cmp(b_family)
+                .then_with(|| compare_versions_desc(a_version, b_version))
+                .then_with(|| b_size.cmp(&a_size))
+        });
+
+        recommendations
+    }
+
+    fn find_can_run_providers(
+        variant: &ModelVariant,
+        configured_provider_ids: &[String],
+        ctx: &crate::AppContext,
+    ) -> Vec<String> {
+        configured_provider_ids
+            .iter()
+            .filter_map(|pid| ctx.config.get_provider(pid))
+            .filter_map(|pc| {
+                PROVIDER_REGISTRY
+                    .construct(
+                        &pc.provider_type,
+                        &pc.provider_id,
+                        &pc.config,
+                        &ctx.config,
+                    )
+                    .ok()
+                    .filter(|p| p.can_run_model(&variant.format, &variant.precision))
+            })
+            .map(|p| p.instance_id().to_string())
+            .collect()
+    }
+
+    // -- Launcher discovery --------------------------------------------------
+
+    async fn discover_launchers(
+        ctx: &crate::AppContext,
+    ) -> (Vec<Recommendation>, Vec<String>) {
+        let configured_ids: HashSet<&str> = ctx.config.launchers.keys().map(|s| s.as_str()).collect();
+        let mut configured: Vec<String> = Vec::new();
+        let mut recommendations: Vec<Recommendation> = Vec::new();
+
+        for (launcher_type, metadata) in LAUNCHER_REGISTRY.entries() {
+            if configured_ids.contains(launcher_type) {
+                configured.push(launcher_type.to_string());
+                continue;
+            }
+
+            // Construct a transient instance with default config
+            let default_config = LAUNCHER_REGISTRY.default_config(launcher_type).unwrap_or_default();
+            match LAUNCHER_REGISTRY.construct(
+                launcher_type,
+                launcher_type,
+                &default_config,
+                &ctx.config,
+            ) {
+                Ok(launcher) => match launcher.validate_command() {
+                    Ok(path) => recommendations.push(Recommendation::Launcher {
+                        launcher_type: launcher_type.to_string(),
+                        launcher_name: metadata.name.clone(),
+                        binary_path: Some(path.to_string_lossy().to_string()),
+                    }),
+                    Err(_) => recommendations.push(Recommendation::Launcher {
+                        launcher_type: launcher_type.to_string(),
+                        launcher_name: metadata.name.clone(),
+                        binary_path: None,
+                    }),
+                },
+                Err(_) => {
+                    // Could not construct — still recommend but without binary info
+                    recommendations.push(Recommendation::Launcher {
+                        launcher_type: launcher_type.to_string(),
+                        launcher_name: metadata.name.clone(),
+                        binary_path: None,
+                    });
+                }
+            }
+        }
+
+        configured.sort();
+        recommendations.sort_by_key(display_name);
+        (recommendations, configured)
+    }
+
+    // -- Capability discovery ------------------------------------------------
+
+    fn discover_capabilities(
+        ctx: &crate::AppContext,
+        _provider_recs: &[Recommendation],
+        _model_recs: &[Recommendation],
+        _configured_provider_ids: &[String],
+    ) -> (Vec<Recommendation>, Vec<String>) {
+        let configured_ids: Vec<&str> = ctx
+            .config
+            .capabilities
+            .keys()
+            .map(|s| s.as_str())
+            .collect();
+        let configured: Vec<String> = configured_ids.iter().copied().map(String::from).collect();
+
+        let mut recommendations: Vec<Recommendation> = Vec::new();
+
+        for (capability_type, metadata) in CAPABILITY_REGISTRY.entries() {
+            if configured_ids.contains(&capability_type) {
+                continue;
+            }
+
+            recommendations.push(Recommendation::Capability {
+                capability_type: capability_type.to_string(),
+                capability_name: metadata.name.clone(),
+            });
+        }
+
+        recommendations.sort_by_key(display_name);
+        (recommendations, configured)
+    }
+}
+
+/// A re-evaluator that filters recommendations based on user selections from
+/// earlier wizard sections. This implements the backward-from-capabilities
+/// dependency flow.
+struct Revaluator;
+
+impl Revaluator {
+    /// Filter launcher recommendations to only those that support at least one
+    /// of the selected capability binding types.
+    fn for_launchers<'a>(
+        discovery: &'a DiscoveryResult,
+        selected_cap_types: &HashSet<String>,
+    ) -> Vec<&'a Recommendation> {
+        // Determine which binding types are needed by selected capabilities
+        let needed_types: HashSet<BindingType> = selected_cap_types
+            .iter()
+            .filter_map(|cap_type| CAPABILITY_REGISTRY.get(cap_type))
+            .flat_map(|m| m.supported_binding_types.clone().into_iter())
+            .collect();
+
+        if needed_types.is_empty() {
+            // No binding types needed — any launcher is fine
+            return discovery
+                .recommendations
+                .iter()
+                .filter(|r| matches!(r, Recommendation::Launcher { .. }))
+                .collect();
+        }
+
+        discovery
+            .recommendations
+            .iter()
+            .filter(move |r| {
+                if let Recommendation::Launcher { launcher_type, .. } = r {
+                    if let Some(launcher_meta) = LAUNCHER_REGISTRY.get(launcher_type) {
+                        return launcher_meta
+                            .supported_capabilities
+                            .iter()
+                            .any(|bt| needed_types.contains(bt));
+                    }
+                    // If we can't look up the launcher, include it anyway
+                    return true;
+                }
+                false
+            })
+            .collect()
+    }
+
+    /// Filter provider recommendations to only those that can run at least one
+    /// of the selected model variants.
+    fn for_providers<'a>(
+        discovery: &'a DiscoveryResult,
+        selected_model_ids: &HashSet<String>,
+        _ctx: &crate::AppContext,
+    ) -> Vec<&'a Recommendation> {
+        let provider_recs: Vec<_> = discovery
+            .recommendations
+            .iter()
+            .filter(|r| matches!(r, Recommendation::Provider { .. }))
+            .collect();
+
+        // If no models selected, return all provider recommendations
+        if selected_model_ids.is_empty() {
+            return provider_recs;
+        }
+
+        // Build a set of selected model IDs for quick lookup
+        let selected_ids: HashSet<&str> = selected_model_ids.iter().map(|s| s.as_str()).collect();
+
+        // Check which providers can run the selected models by looking at the
+        // can_run_by field in the model recommendations
+        let providers_that_can_run: HashSet<String> = discovery
+            .recommendations
+            .iter()
+            .filter_map(|r| match r {
+                Recommendation::Model {
+                    model_id,
+                    can_run_by,
+                    ..
+                } => {
+                    if selected_ids.contains(model_id.as_str()) {
+                        Some(can_run_by.clone())
+                    } else {
+                        None
+                    }
+                }
+                _ => None,
+            })
+            .flatten()
+            .collect();
+
+        if providers_that_can_run.is_empty() {
+            // If no provider info available, show all providers
+            return provider_recs;
+        }
+
+        provider_recs
+            .into_iter()
+            .filter(move |r| {
+                if let Recommendation::Provider { provider_type, .. } = r {
+                    providers_that_can_run.contains(*provider_type)
+                } else {
+                    false
+                }
+            })
+            .collect()
+    }
+
+    /// Filter model recommendations to only those that would be used by at least
+    /// one selected capability (i.e., satisfy the capability's `ModelRequirement`).
+    fn for_models<'a>(
+        discovery: &'a DiscoveryResult,
+        selected_cap_types: &HashSet<String>,
+    ) -> Vec<&'a Recommendation> {
+        // Collect all model requirements from selected capabilities
+        let all_requirements: Vec<ModelRequirement> = selected_cap_types
+            .iter()
+            .filter_map(|cap_type| CAPABILITY_REGISTRY.get(cap_type))
+            .flat_map(|m| {
+                m.dependencies
+                    .iter()
+                    .filter_map(|d| match d {
+                        Dependency::Model {
+                            requirement,
+                            resolved_id: None,
+                            ..
+                        } => Some(requirement.clone()),
+                        _ => None,
+                    })
+                    .collect::<Vec<_>>()
+            })
+            .collect();
+
+        if all_requirements.is_empty() {
+            // No model requirements — show all model recommendations
+            return discovery
+                .recommendations
+                .iter()
+                .filter(|r| matches!(r, Recommendation::Model { .. }))
+                .collect();
+        }
+
+        discovery
+            .recommendations
+            .iter()
+            .filter(move |r| {
+                if let Recommendation::Model { model_id, .. } = r {
+                    // Look up the real catalog metadata (family/version/size
+                    // alone can't tell us `supported_functions`, which most
+                    // capability requirements actually key on).
+                    match MODEL_REGISTRY.get(model_id) {
+                        Some(md) => all_requirements.iter().any(|req| req.admits_type(&md)),
+                        None => false,
+                    }
+                } else {
+                    false
+                }
+            })
+            .collect()
+    }
+
+    /// Filter capability recommendations to only those that could actually be
+    /// used by at least one selected launcher (i.e., the launcher supports
+    /// one of the capability's declared binding types). With no launchers
+    /// selected, no capability has anywhere to bind, so none are shown.
+    fn for_capabilities<'a>(
+        discovery: &'a DiscoveryResult,
+        selected_launcher_types: &HashSet<String>,
+    ) -> Vec<&'a Recommendation> {
+        if selected_launcher_types.is_empty() {
+            return Vec::new();
+        }
+
+        let supported_types: HashSet<BindingType> = selected_launcher_types
+            .iter()
+            .filter_map(|lt| LAUNCHER_REGISTRY.get(lt))
+            .flat_map(|m| m.supported_capabilities.clone().into_iter())
+            .collect();
+
+        discovery
+            .recommendations
+            .iter()
+            .filter(move |r| {
+                if let Recommendation::Capability { capability_type, .. } = r {
+                    if let Some(cap_meta) = CAPABILITY_REGISTRY.get(capability_type) {
+                        return cap_meta
+                            .supported_binding_types
+                            .iter()
+                            .any(|bt| supported_types.contains(bt));
+                    }
+                    // If we can't look up the capability, include it anyway
+                    true
+                } else {
+                    false
+                }
+            })
+            .collect()
+    }
+}
+
+/*-- helpers -----------------------------------------------------------------*/
+
+/// Compare semantic versions in descending order (higher versions first).
+fn compare_versions_desc(a: &str, b: &str) -> std::cmp::Ordering {
+    let parse_version =
+        |v: &str| -> Vec<u32> { v.split('.').filter_map(|s| s.parse::<u32>().ok()).collect() };
+
+    let va = parse_version(a);
+    let vb = parse_version(b);
+
+    for (a_part, b_part) in va.iter().zip(vb.iter()) {
+        match b_part.cmp(a_part) {
+            std::cmp::Ordering::Equal => continue,
+            other => return other,
+        }
+    }
+
+    vb.len().cmp(&va.len())
+}
+
+fn find_latest_version(models: &[(String, ModelMetadata)]) -> Option<&(String, ModelMetadata)> {
+    models
+        .iter()
+        .max_by(|(_, a), (_, b)| compare_versions_desc(&a.version, &b.version))
+}
+
+fn format_size(size: u64) -> String {
+    match size {
+        1_000_000_000.. => format!("{}B", size / 1_000_000_000),
+        1_000_000.. => format!("{}M", size / 1_000_000),
+        _ => size.to_string(),
+    }
+}
+
+fn parse_size(size_str: &str) -> u64 {
+    let size_str = size_str.trim();
+    if let Some(num) = size_str.strip_suffix('B') {
+        num.parse::<u64>().unwrap_or(0) * 1_000_000_000
+    } else if let Some(num) = size_str.strip_suffix('M') {
+        num.parse::<u64>().unwrap_or(0) * 1_000_000
+    } else {
+        size_str.parse::<u64>().unwrap_or(0)
+    }
+}
+
+fn best_variant(
+    model: &ModelMetadata,
+    profile: &crate::utils::hardware::HardwareProfile,
+) -> Option<(ModelVariant, ContextFit)> {
+    let fit_rank = |fit: &ContextFit| match fit {
+        ContextFit::Full => 1,
+        ContextFit::Partial(_) => 0,
+        ContextFit::None => -1,
+    };
+
+    model
+        .variants
+        .iter()
+        .map(|v| {
+            let fit = crate::models::context_fit::estimate(
+                model.context_length,
+                &model.architecture,
+                &model.native_dtype,
+                v,
+                profile,
+            );
+            (fit, v)
+        })
+        .filter(|(fit, _)| *fit != ContextFit::None)
+        .max_by(|(fit_a, a), (fit_b, b)| {
+            fit_rank(fit_a).cmp(&fit_rank(fit_b)).then_with(|| {
+                a.size_gb
+                    .partial_cmp(&b.size_gb)
+                    .unwrap_or(std::cmp::Ordering::Equal)
+            })
+        })
+        .map(|(fit, v)| (v.clone(), fit))
+}
+
+fn display_name(rec: &Recommendation) -> String {
+    match rec {
+        Recommendation::Provider { provider_name, .. } => provider_name.clone(),
+        Recommendation::Model {
+            family,
+            version,
+            size,
+            ..
+        } => format!("{family} {version} {size}"),
+        Recommendation::Launcher {
+            launcher_name, ..
+        } => launcher_name.clone(),
+        Recommendation::Capability {
+            capability_name, ..
+        } => capability_name.clone(),
+    }
+}
+
+/// Extracts `(family, version, size)` from a model recommendation for
+/// sorting purposes, without needing a full `ModelMetadata`.
+fn model_sort_key(rec: &Recommendation) -> (&str, &str, u64) {
+    match rec {
+        Recommendation::Model {
+            family,
+            version,
+            size,
+            ..
+        } => (family.as_str(), version.as_str(), parse_size(size)),
+        _ => ("", "", 0),
+    }
+}
+
+/*-- SetupCommands -----------------------------------------------------------*/
+
+pub struct SetupCommands;
+
+impl SetupCommands {
+    /// Entry point for `granite-cli setup`.
+    pub async fn run(
+        ctx: &mut crate::AppContext,
+        auto: bool,
+        skip_pull: bool,
+    ) -> Result<()> {
+        if auto {
+            Self::run_auto(ctx).await
+        } else {
+            Self::run_wizard(ctx, skip_pull).await
+        }
+    }
+
+    /// Run the interactive wizard.
+    async fn run_wizard(
+        ctx: &mut crate::AppContext,
+        skip_pull: bool,
+    ) -> Result<()> {
+        let ui = &*ctx.ui;
+        ui.info("=== granite-cli Setup Wizard ===\n");
+        ui.info("Discovering available components...\n");
+
+        let discovery = Discover::run(ctx).await;
+
+        if discovery.recommendations.is_empty()
+            && discovery.configured_provider_ids.is_empty()
+            && discovery.configured_model_ids.is_empty()
+            && discovery.configured_launcher_ids.is_empty()
+            && discovery.configured_capability_ids.is_empty()
+        {
+            ui.info("Nothing to configure. All components are either not available or already set up.");
+            return Ok(());
+        }
+
+        // Phase 1: Launchers selection (show all detected launchers)
+        let selected_launchers = Self::select_launchers(ctx, &discovery).await?;
+
+        // Phase 2: Capabilities selection (filtered by what the selected
+        // launchers can actually bind)
+        let selected_caps = Self::select_capabilities(ctx, &discovery, &selected_launchers).await?;
+
+        // Phase 3: Models selection (filtered by capability requirements)
+        let selected_models = Self::select_models(ctx, &discovery, &selected_caps).await?;
+
+        // Phase 4: Providers selection (only healthy, filtered by model compatibility)
+        let selected_providers =
+            Self::select_providers(ctx, &discovery, &selected_models).await?;
+
+        // Phase 5: Configuration
+        Self::configure_all(
+            ctx,
+            &discovery,
+            &selected_caps,
+            &selected_launchers,
+            &selected_providers,
+            &selected_models,
+        )
+        .await?;
+
+        // Phase 6: Pull (optional)
+        if !skip_pull {
+            Self::prompt_pull(ctx, &selected_models).await?;
+        }
+
+        // Phase 7: Summary
+        Self::print_summary(
+            ctx,
+            &selected_caps,
+            &selected_launchers,
+            &selected_providers,
+            &selected_models,
+        );
+
+        Ok(())
+    }
+
+    /// Run auto mode — detect, configure everything with defaults.
+    async fn run_auto(ctx: &mut crate::AppContext) -> Result<()> {
+        let ui = &*ctx.ui;
+        ui.info("=== granite-cli Auto Setup ===\n");
+        ui.info("Auto-detecting and configuring all available components...\n");
+
+        let discovery = Discover::run(ctx).await;
+
+        if discovery.recommendations.is_empty() {
+            ui.info("No components available to configure.");
+            return Ok(());
+        }
+
+        // Auto-select everything that's recommended, following the same
+        // Launchers → Capabilities → Models → Providers dependency chain as
+        // the interactive wizard.
+        let selected_launchers: HashSet<String> = discovery
+            .recommendations
+            .iter()
+            .filter_map(|r| match r {
+                Recommendation::Launcher {
+                    launcher_type,
+                    binary_path: Some(_),
+                    ..
+                } => Some(launcher_type.clone()),
+                _ => None,
+            })
+            .collect();
+
+        let selected_caps: HashSet<String> = Revaluator::for_capabilities(&discovery, &selected_launchers)
+            .into_iter()
+            .filter_map(|r| match r {
+                Recommendation::Capability {
+                    capability_type, ..
+                } => Some(capability_type.clone()),
+                _ => None,
+            })
+            .collect();
+
+        let selected_models: HashSet<String> = Revaluator::for_models(&discovery, &selected_caps)
+            .into_iter()
+            .filter_map(|r| match r {
+                Recommendation::Model { model_id, .. } => Some(model_id.clone()),
+                _ => None,
+            })
+            .collect();
+
+        let selected_providers: HashSet<String> = Revaluator::for_providers(&discovery, &selected_models, ctx)
+            .into_iter()
+            .filter_map(|r| match r {
+                Recommendation::Provider {
+                    provider_type,
+                    health_healthy,
+                    ..
+                } if *health_healthy => Some(provider_type.to_string()),
+                _ => None,
+            })
+            .collect();
+
+        Self::configure_all(
+            ctx,
+            &discovery,
+            &selected_caps,
+            &selected_launchers,
+            &selected_providers,
+            &selected_models,
+        )
+        .await?;
+
+        // Never auto-pull in --auto mode
+        Self::print_summary(
+            ctx,
+            &selected_caps,
+            &selected_launchers,
+            &selected_providers,
+            &selected_models,
+        );
+
+        Ok(())
+    }
+
+    /*-- Selection phases ----------------------------------------------------*/
+
+    async fn select_capabilities(
+        ctx: &mut crate::AppContext,
+        discovery: &DiscoveryResult,
+        selected_launchers: &HashSet<String>,
+    ) -> Result<HashSet<String>> {
+        let ui = &*ctx.ui;
+
+        let caps: Vec<_> = Revaluator::for_capabilities(discovery, selected_launchers)
+            .into_iter()
+            .filter_map(|r| match r {
+                Recommendation::Capability {
+                    capability_type,
+                    capability_name,
+                } => Some((capability_type.clone(), capability_name.clone())),
+                _ => None,
+            })
+            .collect();
+
+        if caps.is_empty() {
+            ui.info("No capabilities available for the selected launchers.");
+            return Ok(HashSet::new());
+        }
+
+        let items: Vec<String> = caps
+            .iter()
+            .map(|(id, name)| format!("{} — {}", id, name))
+            .collect();
+        let defaults = vec![true; items.len()];
+
+        let selected = ui.multi_select(
+            "Select capabilities to configure",
+            &items,
+            &defaults,
+        )?;
+
+        Ok(selected
+            .into_iter()
+            .map(|i| caps[i].0.clone())
+            .collect())
+    }
+
+    async fn select_launchers(
+        ctx: &mut crate::AppContext,
+        discovery: &DiscoveryResult,
+    ) -> Result<HashSet<String>> {
+        let ui = &*ctx.ui;
+
+        let filtered: Vec<_> = Revaluator::for_launchers(discovery, &HashSet::new())
+            .into_iter()
+            .filter_map(|r| match r {
+                Recommendation::Launcher {
+                    launcher_type,
+                    launcher_name,
+                    binary_path: Some(binary_path),
+                } => Some((launcher_type.clone(), launcher_name, binary_path.clone())),
+                _ => None,
+            })
+            .collect();
+
+        if filtered.is_empty() {
+            ui.info("No launchers detected on this system.");
+            return Ok(HashSet::new());
+        }
+
+        let items: Vec<String> = filtered
+            .iter()
+            .map(|(id, name, path)| format!("{} — {} ({})", id, name, path))
+            .collect();
+        let defaults = vec![true; items.len()];
+
+        let selected = ui.multi_select(
+            "Select launchers to configure",
+            &items,
+            &defaults,
+        )?;
+
+        Ok(selected
+            .into_iter()
+            .map(|i| filtered[i].0.clone())
+            .collect())
+    }
+
+    async fn select_providers(
+        ctx: &mut crate::AppContext,
+        discovery: &DiscoveryResult,
+        selected_models: &HashSet<String>,
+    ) -> Result<HashSet<String>> {
+        let ui = &*ctx.ui;
+
+        let filtered: Vec<_> = Revaluator::for_providers(
+            discovery,
+            selected_models,
+            ctx,
+        )
+        .into_iter()
+            .filter_map(|r| match r {
+                Recommendation::Provider {
+                    provider_type,
+                    provider_name,
+                    health_healthy,
+                    health_error,
+                } if *health_healthy => Some((
+                    provider_type.to_string(),
+                    provider_name,
+                    health_error.clone(),
+                )),
+                _ => None,
+            })
+        .collect();
+
+        if filtered.is_empty() {
+            ui.info("No healthy providers available to configure.");
+            return Ok(HashSet::new());
+        }
+
+        let items: Vec<String> = filtered
+            .iter()
+            .map(|(id, name, error)| {
+                let status = if error.is_none() || error.as_ref().is_some_and(|e| e.is_empty()) {
+                    "healthy".to_string()
+                } else if let Some(e) = &error {
+                    format!("healthy ({e})")
+                } else {
+                    "healthy".to_string()
+                };
+                format!("{} — {} ({})", id, name, status)
+            })
+            .collect();
+        let defaults = vec![true; items.len()];
+
+        let selected = ui.multi_select(
+            "Select providers to configure",
+            &items,
+            &defaults,
+        )?;
+
+        Ok(selected
+            .into_iter()
+            .map(|i| filtered[i].0.clone())
+            .collect())
+    }
+
+    async fn select_models(
+        ctx: &mut crate::AppContext,
+        discovery: &DiscoveryResult,
+        selected_caps: &HashSet<String>,
+    ) -> Result<HashSet<String>> {
+        let ui = &*ctx.ui;
+
+        let filtered: Vec<_> = Revaluator::for_models(discovery, selected_caps)
+            .into_iter()
+            .filter_map(|r| match r {
+                Recommendation::Model {
+                    model_id,
+                    family,
+                    version,
+                    size,
+                    model_type,
+                    best_variant,
+                    context_fit,
+                    can_run_by,
+                } => Some((
+                    model_id.clone(),
+                    family,
+                    version,
+                    size,
+                    model_type,
+                    best_variant,
+                    context_fit,
+                    can_run_by,
+                )),
+                _ => None,
+            })
+            .collect();
+
+        if filtered.is_empty() {
+            ui.info("No models available for the selected capabilities.");
+            return Ok(HashSet::new());
+        }
+
+        let items: Vec<String> = filtered
+            .iter()
+            .map(|(id, _family, _version, size, _model_type, _variant, fit, providers)| {
+                let fit_str = match fit {
+                    ContextFit::Full => "Full".to_string(),
+                    ContextFit::Partial(_) => "Partial".to_string(),
+                    ContextFit::None => "None".to_string(),
+                };
+                let providers_str = if providers.is_empty() {
+                    "none".to_string()
+                } else {
+                    providers.join(", ")
+                };
+                format!("{} — {} — Fit: {} ({})", id, size, fit_str, providers_str)
+            })
+            .collect();
+        let defaults = vec![true; items.len()];
+
+        let selected = ui.multi_select(
+            "Select models to configure",
+            &items,
+            &defaults,
+        )?;
+
+        Ok(selected
+            .into_iter()
+            .map(|i| filtered[i].0.clone())
+            .collect())
+    }
+
+    /*-- Configuration phase -------------------------------------------------*/
+
+    async fn configure_all(
+        ctx: &mut crate::AppContext,
+        discovery: &DiscoveryResult,
+        selected_caps: &HashSet<String>,
+        selected_launchers: &HashSet<String>,
+        selected_providers: &HashSet<String>,
+        selected_models: &HashSet<String>,
+    ) -> Result<()> {
+        let ui = &*ctx.ui;
+
+        // Configure providers first
+        for provider_id in selected_providers {
+            ui.info(&format!("\nConfiguring provider: {provider_id}..."));
+            let default_config = PROVIDER_REGISTRY
+                .default_config(provider_id)
+                .unwrap_or_default();
+
+            let provider_config = crate::config::ProviderConfig {
+                provider_id: provider_id.clone(),
+                provider_type: provider_id.to_string(),
+                config: default_config,
+            };
+
+            if ctx.config.insert_provider(provider_id, provider_config).is_err() {
+                ui.warn(&format!("Failed to save provider config for '{provider_id}'"));
+            }
+        }
+
+        // Configure launchers
+        for launcher_id in selected_launchers {
+            ui.info(&format!("\nConfiguring launcher: {launcher_id}..."));
+            let default_config = LAUNCHER_REGISTRY
+                .default_config(launcher_id)
+                .unwrap_or_default();
+
+            let launcher_config = crate::config::LauncherConfig {
+                launcher_id: launcher_id.to_string(),
+                launcher_type: launcher_id.to_string(),
+                enabled_capabilities: Vec::new(),
+                config: default_config,
+            };
+
+            if ctx.config.insert_launcher(launcher_id, launcher_config).is_err() {
+                ui.warn(&format!("Failed to save launcher config for '{launcher_id}'"));
+            }
+        }
+
+        // Configure models
+        for model_id in selected_models {
+            ui.info(&format!("\nConfiguring model: {model_id}..."));
+
+            // Prefer a selected provider that can actually run this model's
+            // variant; fall back to any selected provider.
+            let provider_id = Self::find_provider_for_model(model_id, selected_providers, discovery)
+                .or_else(|| selected_providers.iter().next().cloned());
+
+            let model_config = crate::config::ModelConfig {
+                model_id: model_id.clone(),
+                provider_id,
+                variant: None,
+            };
+
+            if ctx.config.insert_model(model_id, model_config).is_err() {
+                ui.warn(&format!("Failed to save model config for '{model_id}'"));
+            }
+        }
+
+        // Configure capabilities
+        for cap_type in selected_caps {
+            ui.info(&format!("\nConfiguring capability: {cap_type}..."));
+
+            let mut config = CAPABILITY_REGISTRY
+                .default_config(cap_type)
+                .unwrap_or_default();
+
+            // Set model_id if the capability requires a model
+            if let Some(model_id) = Self::find_model_for_capability(cap_type, selected_models) {
+                config["model_id"] = model_id.into();
+            }
+
+            let capability_config = crate::config::CapabilityConfig {
+                capability_id: cap_type.clone(),
+                capability_type: cap_type.clone(),
+                config,
+            };
+
+            if ctx
+                .config
+                .insert_capability(cap_type, capability_config)
+                .is_err()
+            {
+                ui.warn(&format!(
+                    "Failed to save capability config for '{cap_type}'"
+                ));
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Pick a selected provider that can run `model_id`'s recommended variant,
+    /// per the `can_run_by` list computed during discovery.
+    fn find_provider_for_model(
+        model_id: &str,
+        selected_providers: &HashSet<String>,
+        discovery: &DiscoveryResult,
+    ) -> Option<String> {
+        discovery.recommendations.iter().find_map(|r| match r {
+            Recommendation::Model {
+                model_id: rec_id,
+                can_run_by,
+                ..
+            } if rec_id == model_id => can_run_by
+                .iter()
+                .find(|p| selected_providers.contains(*p))
+                .cloned(),
+            _ => None,
+        })
+    }
+
+    /// Find a model_id from selected_models that satisfies a capability's model
+    /// requirement. Returns the first matching model or None if no match.
+    fn find_model_for_capability(
+        cap_type: &str,
+        selected_models: &HashSet<String>,
+    ) -> Option<String> {
+        let cap_meta = CAPABILITY_REGISTRY.get(cap_type)?;
+
+        let all_requirements: Vec<ModelRequirement> = cap_meta
+            .dependencies
+            .iter()
+            .filter_map(|d| match d {
+                Dependency::Model {
+                    requirement,
+                    resolved_id: None,
+                    ..
+                } => Some(requirement.clone()),
+                _ => None,
+            })
+            .collect();
+
+        if all_requirements.is_empty() {
+            return None;
+        }
+
+        // Check each selected model's real catalog metadata to see if it
+        // satisfies any requirement.
+        selected_models.iter().find(|model_id| {
+            MODEL_REGISTRY
+                .get(model_id)
+                .is_some_and(|md| all_requirements.iter().any(|req| req.admits_type(&md)))
+        }).cloned()
+    }
+
+    /*-- Pull phase ----------------------------------------------------------*/
+
+    async fn prompt_pull(
+        ctx: &mut crate::AppContext,
+        selected_models: &HashSet<String>,
+    ) -> Result<()> {
+        let ui = &*ctx.ui;
+
+        // Find local provider models that were configured
+        let pullable: Vec<_> = selected_models
+            .iter()
+            .filter_map(|model_id| {
+                ctx.config
+                    .get_model(model_id)
+                    .and_then(|mc| mc.provider_id.clone())
+                    .and_then(|provider_id| {
+                        ctx.config.get_provider(&provider_id).map(|pc| {
+                            (
+                                model_id.clone(),
+                                provider_id,
+                                pc.provider_type.clone(),
+                            )
+                        })
+                    })
+            })
+            .collect();
+
+        if pullable.is_empty() {
+            return Ok(());
+        }
+
+        let items: Vec<String> = pullable
+            .iter()
+            .map(|(model, provider, ptype)| {
+                format!(
+                    "{} → {} ({})",
+                    provider, model, ptype
+                )
+            })
+            .collect();
+
+        let pull_now = ui.confirm(
+            "\n→ Pull model weights now?",
+            !items.is_empty(),
+        )?;
+
+        if pull_now {
+            for (model_id, _provider_id, _provider_type) in &pullable {
+                ui.info(&format!("Pulling {}...", model_id));
+                // Pull is delegated to the model command; in auto mode we just
+                // log it here. The actual pull would be triggered by
+                // `ModelCommands::pull` which requires the model to be fully
+                // configured with a variant.
+            }
+        }
+
+        Ok(())
+    }
+
+    /*-- Summary phase -------------------------------------------------------*/
+
+    fn print_summary(
+        ctx: &crate::AppContext,
+        selected_caps: &HashSet<String>,
+        selected_launchers: &HashSet<String>,
+        selected_providers: &HashSet<String>,
+        selected_models: &HashSet<String>,
+    ) {
+        let ui = &*ctx.ui;
+
+        ui.info("\n=== Setup Complete ===");
+        ui.info(&format!(
+            "Providers: {}",
+            if selected_providers.is_empty() {
+                "none".to_string()
+            } else {
+                selected_providers.iter().cloned().collect::<Vec<_>>().join(", ")
+            }
+        ));
+        ui.info(&format!(
+            "Models: {}",
+            if selected_models.is_empty() {
+                "none".to_string()
+            } else {
+                selected_models.iter().cloned().collect::<Vec<_>>().join(", ")
+            }
+        ));
+        ui.info(&format!(
+            "Launchers: {}",
+            if selected_launchers.is_empty() {
+                "none".to_string()
+            } else {
+                selected_launchers.iter().cloned().collect::<Vec<_>>().join(", ")
+            }
+        ));
+        ui.info(&format!(
+            "Capabilities: {}",
+            if selected_caps.is_empty() {
+                "none".to_string()
+            } else {
+                selected_caps.iter().cloned().collect::<Vec<_>>().join(", ")
+            }
+        ));
+
+        ui.info(
+            "\nRun `granite-cli launcher list` to see configured launchers.",
+        );
+        if !selected_launchers.is_empty() {
+            let first_launcher = selected_launchers.iter().next().unwrap();
+            ui.info(&format!(
+                "Run `granite-cli launch {first_launcher}` to launch with Granite overlay.",
+            ));
+        }
+    }
+}
+
+/*-- tests -------------------------------------------------------------------*/
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::{Config, ModelConfig, ProviderConfig};
+    use crate::utils::ui::base::tests::CaptureUi;
+    use std::sync::Arc;
+
+    fn test_ctx() -> crate::AppContext {
+        crate::AppContext {
+            config: Config::default(),
+            ui: Arc::new(CaptureUi::default()),
+        }
+    }
+
+    fn ctx_with_provider(id: &str, provider_type: &str, config: serde_json::Value) -> crate::AppContext {
+        let mut ctx = test_ctx();
+        ctx.config.providers.insert(
+            id.to_string(),
+            ProviderConfig {
+                provider_id: id.to_string(),
+                provider_type: provider_type.to_string(),
+                config,
+            },
+        );
+        ctx
+    }
+
+    fn ctx_with_model(id: &str, provider_id: Option<&str>) -> crate::AppContext {
+        let mut ctx = test_ctx();
+        ctx.config.models.insert(
+            id.to_string(),
+            ModelConfig {
+                model_id: id.to_string(),
+                provider_id: provider_id.map(String::from),
+                variant: None,
+            },
+        );
+        ctx
+    }
+
+    // -- discover_providers ----------------------------------------------------
+
+    #[tokio::test]
+    async fn discover_providers_skips_configured() {
+        let ctx = ctx_with_provider("ollama", "ollama", serde_json::json!({}));
+        let result = Discover::run(&ctx).await;
+        assert!(result.configured_provider_ids.contains(&"ollama".to_string()));
+    }
+
+    #[tokio::test]
+    async fn discover_providers_recommends_unconfigured() {
+        let ctx = test_ctx();
+        let result = Discover::run(&ctx).await;
+        let provider_recs: Vec<_> = result
+            .recommendations
+            .iter()
+            .filter(|r| matches!(r, Recommendation::Provider { .. }))
+            .collect();
+        // Should have at least some provider recommendations
+        assert!(
+            !provider_recs.is_empty(),
+            "expected at least one provider recommendation"
+        );
+    }
+
+    // -- discover_models -------------------------------------------------------
+
+    #[tokio::test]
+    async fn discover_models_groups_by_family() {
+        let ctx = test_ctx();
+        let result = Discover::run(&ctx).await;
+        let model_recs: Vec<_> = result
+            .recommendations
+            .iter()
+            .filter(|r| matches!(r, Recommendation::Model { .. }))
+            .collect();
+        // Should have at least one model recommendation
+        assert!(
+            !model_recs.is_empty(),
+            "expected at least one model recommendation"
+        );
+    }
+
+    #[tokio::test]
+    async fn discover_models_recommendation_carries_real_registry_model_id() {
+        let ctx = test_ctx();
+        let result = Discover::run(&ctx).await;
+        for rec in &result.recommendations {
+            if let Recommendation::Model { model_id, family, .. } = rec {
+                assert!(
+                    MODEL_REGISTRY.get(model_id).is_some(),
+                    "model_id '{model_id}' should be a real catalog key, not the family name"
+                );
+                assert_ne!(
+                    model_id, family,
+                    "model_id should be the specific model's catalog id, not its family"
+                );
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn discover_models_skips_configured() {
+        let ctx = ctx_with_model(
+            "granite-3.1-8b-instruct",
+            Some("ollama"),
+        );
+        let result = Discover::run(&ctx).await;
+        assert!(result.configured_model_ids.contains(&"granite-3.1-8b-instruct".to_string()));
+    }
+
+    // -- discover_launchers ----------------------------------------------------
+
+    #[tokio::test]
+    async fn discover_launchers_skips_configured() {
+        let mut ctx = test_ctx();
+        ctx.config.launchers.insert(
+            "claude".to_string(),
+            crate::config::LauncherConfig {
+                launcher_id: "claude".to_string(),
+                launcher_type: "claude".to_string(),
+                enabled_capabilities: vec![],
+                config: serde_json::json!({}),
+            },
+        );
+        let result = Discover::run(&ctx).await;
+        assert!(result.configured_launcher_ids.contains(&"claude".to_string()));
+    }
+
+    #[tokio::test]
+    async fn discover_launchers_recommends_unconfigured() {
+        let ctx = test_ctx();
+        let result = Discover::run(&ctx).await;
+        let launcher_recs: Vec<_> = result
+            .recommendations
+            .iter()
+            .filter(|r| matches!(r, Recommendation::Launcher { .. }))
+            .collect();
+        assert!(
+            !launcher_recs.is_empty(),
+            "expected at least one launcher recommendation"
+        );
+    }
+
+    // -- discover_capabilities -------------------------------------------------
+
+    #[tokio::test]
+    async fn discover_capabilities_recommends_unconfigured() {
+        let ctx = test_ctx();
+        let result = Discover::run(&ctx).await;
+        let cap_recs: Vec<_> = result
+            .recommendations
+            .iter()
+            .filter(|r| matches!(r, Recommendation::Capability { .. }))
+            .collect();
+        assert!(
+            !cap_recs.is_empty(),
+            "expected at least one capability recommendation"
+        );
+    }
+
+    // -- version comparison ----------------------------------------------------
+
+    #[test]
+    fn compare_versions_desc_simple() {
+        assert_eq!(compare_versions_desc("3.1", "3.0"), std::cmp::Ordering::Less);
+        assert_eq!(compare_versions_desc("3.0", "3.1"), std::cmp::Ordering::Greater);
+        assert_eq!(compare_versions_desc("3.1", "3.1"), std::cmp::Ordering::Equal);
+    }
+
+    #[test]
+    fn compare_versions_desc_multi_part() {
+        assert_eq!(
+            compare_versions_desc("3.1.1", "3.1.0"),
+            std::cmp::Ordering::Less
+        );
+        assert_eq!(
+            compare_versions_desc("3.1", "3.1.0"),
+            std::cmp::Ordering::Greater
+        );
+    }
+
+    #[test]
+    fn compare_versions_desc_major_difference() {
+        assert_eq!(
+            compare_versions_desc("4.0", "3.1"),
+            std::cmp::Ordering::Less
+        );
+    }
+
+    // -- size helpers ----------------------------------------------------------
+
+    #[test]
+    fn format_size_billion() {
+        assert_eq!(format_size(8_000_000_000), "8B");
+    }
+
+    #[test]
+    fn format_size_million() {
+        assert_eq!(format_size(2_000_000), "2M");
+    }
+
+    #[test]
+    fn parse_size_billion() {
+        assert_eq!(parse_size("8B"), 8_000_000_000);
+    }
+
+    #[test]
+    fn parse_size_million() {
+        assert_eq!(parse_size("2M"), 2_000_000);
+    }
+
+    // -- Revaluator ------------------------------------------------------------
+
+    #[tokio::test]
+    async fn revaluator_for_models_filters_by_capability_requirements() {
+        let ctx = test_ctx();
+        let discovery = Discover::run(&ctx).await;
+
+        // agent-model requires Chat + ToolCalling support.
+        let selected_caps: HashSet<String> = ["agent-model".to_string()].into_iter().collect();
+        let filtered = Revaluator::for_models(&discovery, &selected_caps);
+
+        assert!(
+            !filtered.is_empty(),
+            "expected at least one granite model to satisfy agent-model's Chat+ToolCalling requirement"
+        );
+        // Every surviving recommendation's real catalog metadata must
+        // actually admit the requirement -- this is the regression check for
+        // the bug where a hand-rolled mock always reported empty
+        // `supported_functions`, so nothing ever matched.
+        for rec in &filtered {
+            if let Recommendation::Model { model_id, .. } = rec {
+                let md = MODEL_REGISTRY.get(model_id).expect("real catalog entry");
+                assert!(
+                    md.supported_functions.contains(&crate::models::ModelFunction::Chat),
+                    "{model_id} should support Chat"
+                );
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn revaluator_for_models_with_no_requirements_returns_all() {
+        let ctx = test_ctx();
+        let discovery = Discover::run(&ctx).await;
+        let filtered = Revaluator::for_models(&discovery, &HashSet::new());
+        let all_models: Vec<_> = discovery
+            .recommendations
+            .iter()
+            .filter(|r| matches!(r, Recommendation::Model { .. }))
+            .collect();
+        assert_eq!(filtered.len(), all_models.len());
+    }
+
+    #[tokio::test]
+    async fn revaluator_for_launchers_filters_by_binding_types() {
+        let ctx = test_ctx();
+        let discovery = Discover::run(&ctx).await;
+
+        // agent-model needs the AgentModel binding, which bob does not support.
+        let selected_caps: HashSet<String> = ["agent-model".to_string()].into_iter().collect();
+        let filtered = Revaluator::for_launchers(&discovery, &selected_caps);
+        assert!(
+            !filtered
+                .iter()
+                .any(|r| matches!(r, Recommendation::Launcher { launcher_type, .. } if launcher_type == "bob")),
+            "bob only supports Mcp and should be filtered out for agent-model"
+        );
+
+        // vision-mcp only needs the Mcp binding, which bob does support.
+        let mcp_caps: HashSet<String> = ["vision-mcp".to_string()].into_iter().collect();
+        let mcp_filtered = Revaluator::for_launchers(&discovery, &mcp_caps);
+        assert!(
+            mcp_filtered
+                .iter()
+                .any(|r| matches!(r, Recommendation::Launcher { launcher_type, .. } if launcher_type == "bob")),
+            "bob supports Mcp and should be included for vision-mcp"
+        );
+    }
+
+    #[tokio::test]
+    async fn revaluator_for_capabilities_filters_by_selected_launchers() {
+        let ctx = test_ctx();
+        let discovery = Discover::run(&ctx).await;
+
+        // bob only supports the Mcp binding, so only vision-mcp should show.
+        let bob_only: HashSet<String> = ["bob".to_string()].into_iter().collect();
+        let filtered = Revaluator::for_capabilities(&discovery, &bob_only);
+        assert!(
+            filtered
+                .iter()
+                .all(|r| matches!(r, Recommendation::Capability { capability_type, .. } if capability_type == "vision-mcp")),
+            "with only bob (Mcp-only) selected, only vision-mcp should be recommended"
+        );
+    }
+
+    #[tokio::test]
+    async fn revaluator_for_capabilities_with_no_launchers_returns_none() {
+        let ctx = test_ctx();
+        let discovery = Discover::run(&ctx).await;
+        let filtered = Revaluator::for_capabilities(&discovery, &HashSet::new());
+        assert!(filtered.is_empty());
+    }
+
+    // -- SetupCommands ---------------------------------------------------------
+
+    #[tokio::test]
+    async fn run_wizard_with_empty_config_shows_info() {
+        let mut ctx = test_ctx();
+        let _ = SetupCommands::run(&mut ctx, false, true).await;
+        // Wizard should complete without error even with no recommendations
+        // (it will show info messages)
+    }
+
+    #[tokio::test]
+    async fn run_auto_with_no_recommendations_shows_info() {
+        let _home = crate::config::TestConfigHome::new();
+        let mut ctx = test_ctx();
+        let result = SetupCommands::run(&mut ctx, true, true).await;
+        assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn select_launchers_excludes_launchers_without_a_resolved_binary() {
+        let capture = Arc::new(CaptureUi::default());
+        let mut ctx = crate::AppContext {
+            config: Config::default(),
+            ui: capture.clone(),
+        };
+
+        let discovery = DiscoveryResult {
+            recommendations: vec![
+                Recommendation::Launcher {
+                    launcher_type: "found".to_string(),
+                    launcher_name: "Found Launcher".to_string(),
+                    binary_path: Some("/usr/bin/found".to_string()),
+                },
+                Recommendation::Launcher {
+                    launcher_type: "missing".to_string(),
+                    launcher_name: "Missing Launcher".to_string(),
+                    binary_path: None,
+                },
+            ],
+            configured_provider_ids: vec![],
+            configured_model_ids: vec![],
+            configured_launcher_ids: vec![],
+            configured_capability_ids: vec![],
+        };
+
+        SetupCommands::select_launchers(&mut ctx, &discovery)
+            .await
+            .unwrap();
+
+        let prompts = capture.multi_select_prompts.borrow();
+        let (_, items, _) = &prompts[0];
+        assert_eq!(items.len(), 1, "the missing binary should have been excluded");
+        assert!(items[0].contains("found"));
+    }
+}

--- a/src/commands/setup.rs
+++ b/src/commands/setup.rs
@@ -5,6 +5,7 @@ use std::collections::{HashMap, HashSet};
 
 // Local
 use crate::capabilities::{BindingType, CAPABILITY_REGISTRY, Dependency, ModelRequirement};
+use crate::commands::model::ModelCommands;
 use crate::dependency::Requirement;
 use crate::launchers::LAUNCHER_REGISTRY;
 use crate::models::{ContextFit, MODEL_REGISTRY, ModelFunction, ModelMetadata, ModelType, ModelVariant};
@@ -1462,11 +1463,16 @@ impl SetupCommands {
 
         // Check each selected model's real catalog metadata to see if it
         // satisfies any requirement.
-        selected_models.iter().find(|model_id| {
-            MODEL_REGISTRY
-                .get(model_id)
-                .is_some_and(|md| all_requirements.iter().any(|req| req.admits_type(&md)))
-        }).cloned()
+        selected_models
+            .iter()
+            .find(|model_id| {
+                MODEL_REGISTRY.get(model_id).is_some_and(|md| {
+                    all_requirements
+                        .iter()
+                        .any(|req| admits_for_recommendation(req, &md))
+                })
+            })
+            .cloned()
     }
 
     /*-- Pull phase ----------------------------------------------------------*/
@@ -1475,7 +1481,9 @@ impl SetupCommands {
         ctx: &mut crate::AppContext,
         selected_models: &HashSet<String>,
     ) -> Result<()> {
-        let ui = &*ctx.ui;
+        // Cloned (not `&*ctx.ui`) so it doesn't hold a borrow of `ctx` --
+        // `ModelCommands::pull` below needs `&mut ctx` for the whole struct.
+        let ui = ctx.ui.clone();
 
         // Find local provider models that were configured
         let pullable: Vec<_> = selected_models
@@ -1500,6 +1508,7 @@ impl SetupCommands {
             alog_channel!(MessageLevel::Debug2, "No pullable models");
             return Ok(());
         }
+        alog_channel!(MessageLevel::Debug2, "Pullable models: {:#?}", pullable);
 
         let items: Vec<String> = pullable
             .iter()
@@ -1518,11 +1527,13 @@ impl SetupCommands {
 
         if pull_now {
             for (model_id, _provider_id, _provider_type) in &pullable {
-                ui.info(&format!("Pulling {}...", model_id));
-                // Pull is delegated to the model command; in auto mode we just
-                // log it here. The actual pull would be triggered by
-                // `ModelCommands::pull` which requires the model to be fully
-                // configured with a variant.
+                ui.info(&format!("Pulling {model_id}..."));
+                // `ModelCommands::pull` already reports success/failure to
+                // `ctx.ui` itself; just keep going on error rather than
+                // aborting the rest of the pull phase over one model.
+                if let Err(e) = ModelCommands::pull(ctx, model_id).await {
+                    alog_channel!(MessageLevel::Warning, "Pull failed for '{model_id}': {e}");
+                }
             }
         }
 
@@ -1934,6 +1945,106 @@ mod tests {
         }
     }
 
+    #[test]
+    fn admits_for_recommendation_excludes_unrequested_multimodal_functions() {
+        fn md_with_functions(functions: Vec<ModelFunction>) -> ModelMetadata {
+            ModelMetadata {
+                family: "Test".to_string(),
+                version: "1.0".to_string(),
+                size: 0,
+                context_length: 8192,
+                model_type: ModelType::Text,
+                huggingface_repo: String::new(),
+                native_dtype: String::new(),
+                architecture: crate::models::ModelArchitecture {
+                    num_hidden_layers: 0,
+                    hidden_size: 0,
+                    num_attention_heads: 0,
+                    num_key_value_heads: 0,
+                    head_dim: 0,
+                    layer_types: vec![],
+                },
+                variants: vec![],
+                description: None,
+                tags: vec![],
+                supported_functions: functions,
+            }
+        }
+
+        let chat_only_req = ModelRequirement {
+            supported_functions: vec![ModelFunction::Chat, ModelFunction::ToolCalling],
+            ..Default::default()
+        };
+        let vision_req = ModelRequirement {
+            supported_functions: vec![
+                ModelFunction::Chat,
+                ModelFunction::ToolCalling,
+                ModelFunction::ImageUnderstanding,
+            ],
+            ..Default::default()
+        };
+
+        let text_model = md_with_functions(vec![ModelFunction::Chat, ModelFunction::ToolCalling]);
+        let vision_model = md_with_functions(vec![
+            ModelFunction::Chat,
+            ModelFunction::ToolCalling,
+            ModelFunction::ImageUnderstanding,
+        ]);
+        let speech_model = md_with_functions(vec![ModelFunction::Chat, ModelFunction::Transcription]);
+
+        assert!(admits_for_recommendation(&chat_only_req, &text_model));
+        assert!(
+            !admits_for_recommendation(&chat_only_req, &vision_model),
+            "a plain Chat/ToolCalling requirement should exclude a vision model even though it can chat"
+        );
+        assert!(
+            !admits_for_recommendation(&chat_only_req, &speech_model),
+            "a plain Chat/ToolCalling requirement should exclude a speech model even though it can chat"
+        );
+        // A requirement that explicitly wants vision should still admit it.
+        assert!(admits_for_recommendation(&vision_req, &vision_model));
+    }
+
+    #[tokio::test]
+    async fn revaluator_for_models_excludes_multimodal_for_plain_chat_capability() {
+        let ctx = test_ctx();
+        let discovery = Discover::run(&ctx).await;
+
+        // agent-model only requires Chat + ToolCalling -- no multi-modal
+        // function -- so vision/speech models must not show up even though
+        // `all_model_candidates` (unlike the deduped default list) is
+        // guaranteed to contain some.
+        let selected_caps: HashSet<String> = ["agent-model".to_string()].into_iter().collect();
+        let filtered = Revaluator::for_models(&discovery.all_model_candidates, &selected_caps);
+
+        assert!(!filtered.is_empty());
+        for rec in &filtered {
+            if let Recommendation::Model { model_id, .. } = rec {
+                let md = MODEL_REGISTRY.get(model_id).expect("real catalog entry");
+                assert!(
+                    !md.supported_functions
+                        .iter()
+                        .any(|f| MULTIMODAL_FUNCTIONS.contains(f)),
+                    "{model_id} is multi-modal and should be excluded from a plain-chat capability's recommendations"
+                );
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn revaluator_for_models_still_includes_vision_for_vision_mcp() {
+        let ctx = test_ctx();
+        let discovery = Discover::run(&ctx).await;
+
+        let selected_caps: HashSet<String> = ["vision-mcp".to_string()].into_iter().collect();
+        let filtered = Revaluator::for_models(&discovery.all_model_candidates, &selected_caps);
+
+        assert!(
+            filtered.iter().any(|r| matches!(r, Recommendation::Model { model_id, .. } if model_id.contains("vision"))),
+            "vision-mcp explicitly requires ImageUnderstanding, so vision models must still be recommended"
+        );
+    }
+
     #[tokio::test]
     async fn revaluator_for_models_with_no_requirements_returns_all() {
         let ctx = test_ctx();
@@ -2200,6 +2311,65 @@ mod tests {
     // -- SetupCommands ---------------------------------------------------------
 
     #[tokio::test]
+    async fn prompt_pull_actually_invokes_model_commands_pull() {
+        // Regression test: `prompt_pull` used to just log "Pulling
+        // {model}..." and do nothing -- the pull was never actually
+        // triggered. Point the configured provider at a closed local port
+        // so the real pull attempt fails fast (no network dependency), and
+        // assert on the error message that only `ModelCommands::pull`
+        // itself produces, proving it was actually called rather than the
+        // old no-op.
+        let capture = Arc::new(CaptureUi::default());
+        capture.confirm_answers.borrow_mut().push_back(true);
+        let mut ctx = crate::AppContext {
+            config: Config::default(),
+            ui: capture.clone(),
+        };
+
+        ctx.config.providers.insert(
+            "ollama".to_string(),
+            ProviderConfig {
+                provider_id: "ollama".to_string(),
+                provider_type: "ollama".to_string(),
+                config: serde_json::json!({ "base_url": "http://127.0.0.1:1" }),
+            },
+        );
+
+        let model_id = "granite-3.1-8b-instruct";
+        let md = MODEL_REGISTRY.get(model_id).expect("fixture model should exist");
+        let variant = md
+            .variants
+            .iter()
+            .find(|v| v.format.eq_ignore_ascii_case("ollama"))
+            .expect("fixture model should have an Ollama-format variant");
+        ctx.config.models.insert(
+            model_id.to_string(),
+            ModelConfig {
+                model_id: model_id.to_string(),
+                provider_id: Some("ollama".to_string()),
+                variant: Some(format!("{}/{}", variant.format, variant.precision)),
+            },
+        );
+
+        let selected_models: HashSet<String> = [model_id.to_string()].into_iter().collect();
+        let result = SetupCommands::prompt_pull(&mut ctx, &selected_models).await;
+
+        assert!(
+            result.is_ok(),
+            "prompt_pull should not propagate a per-model pull failure"
+        );
+        assert!(
+            capture
+                .errors
+                .borrow()
+                .iter()
+                .any(|e| e.contains("Failed to pull model")),
+            "expected ModelCommands::pull's own failure message, proving it was actually invoked; got: {:?}",
+            capture.errors.borrow()
+        );
+    }
+
+    #[tokio::test]
     async fn run_wizard_with_empty_config_shows_info() {
         let mut ctx = test_ctx();
         let _ = SetupCommands::run(&mut ctx, false, true).await;
@@ -2290,4 +2460,3 @@ mod tests {
         );
     }
 }
-

--- a/src/commands/setup.rs
+++ b/src/commands/setup.rs
@@ -542,9 +542,14 @@ fn compare_versions_desc(a: &str, b: &str) -> std::cmp::Ordering {
 }
 
 fn find_latest_version(models: &[(String, ModelMetadata)]) -> Option<&(String, ModelMetadata)> {
+    // `compare_versions_desc` is a *reversed* comparator (higher version
+    // sorts first when fed to `sort_by`/`sort_by_key`, i.e. it reports the
+    // higher version as `Less`) -- so picking the "latest" requires
+    // `min_by`, not `max_by`. `max_by` would select the lowest version in
+    // the family instead.
     models
         .iter()
-        .max_by(|(_, a), (_, b)| compare_versions_desc(&a.version, &b.version))
+        .min_by(|(_, a), (_, b)| compare_versions_desc(&a.version, &b.version))
 }
 
 fn format_size(size: u64) -> String {
@@ -1055,19 +1060,38 @@ impl SetupCommands {
             }
         }
 
-        // Configure models
+        // Configure models. Providers were just configured above, so
+        // `ctx.config` already has real entries for every id in
+        // `selected_providers` -- look one up and construct it live to
+        // check actual format/precision compatibility, rather than relying
+        // on discovery's `can_run_by` (which only reflects providers that
+        // were *already* configured before this wizard run, and so is
+        // always empty on a first-time setup).
         for model_id in selected_models {
             ui.info(&format!("\nConfiguring model: {model_id}..."));
 
-            // Prefer a selected provider that can actually run this model's
-            // variant; fall back to any selected provider.
-            let provider_id = Self::find_provider_for_model(model_id, selected_providers, discovery)
-                .or_else(|| selected_providers.iter().next().cloned());
+            let best_variant = discovery.recommendations.iter().find_map(|r| match r {
+                Recommendation::Model {
+                    model_id: rec_id,
+                    best_variant,
+                    ..
+                } if rec_id == model_id => Some(best_variant.clone()),
+                _ => None,
+            });
+
+            let (provider_id, variant) = match &best_variant {
+                Some(v) => (
+                    Self::find_compatible_provider(v, selected_providers, ctx)
+                        .or_else(|| selected_providers.iter().next().cloned()),
+                    Some(format!("{}/{}", v.format, v.precision)),
+                ),
+                None => (selected_providers.iter().next().cloned(), None),
+            };
 
             let model_config = crate::config::ModelConfig {
                 model_id: model_id.clone(),
                 provider_id,
-                variant: None,
+                variant,
             };
 
             if ctx.config.insert_model(model_id, model_config).is_err() {
@@ -1108,24 +1132,28 @@ impl SetupCommands {
         Ok(())
     }
 
-    /// Pick a selected provider that can run `model_id`'s recommended variant,
-    /// per the `can_run_by` list computed during discovery.
-    fn find_provider_for_model(
-        model_id: &str,
+    /// Picks a selected provider that can actually run `variant`, by
+    /// constructing each one and checking `can_run_model`. Assumes providers
+    /// have already been written to `ctx.config` (as `configure_all` does,
+    /// before configuring models).
+    fn find_compatible_provider(
+        variant: &ModelVariant,
         selected_providers: &HashSet<String>,
-        discovery: &DiscoveryResult,
+        ctx: &crate::AppContext,
     ) -> Option<String> {
-        discovery.recommendations.iter().find_map(|r| match r {
-            Recommendation::Model {
-                model_id: rec_id,
-                can_run_by,
-                ..
-            } if rec_id == model_id => can_run_by
-                .iter()
-                .find(|p| selected_providers.contains(*p))
-                .cloned(),
-            _ => None,
-        })
+        selected_providers
+            .iter()
+            .find(|pid| {
+                ctx.config
+                    .get_provider(pid)
+                    .and_then(|pc| {
+                        PROVIDER_REGISTRY
+                            .construct(&pc.provider_type, &pc.provider_id, &pc.config, &ctx.config)
+                            .ok()
+                    })
+                    .is_some_and(|p| p.can_run_model(&variant.format, &variant.precision))
+            })
+            .cloned()
     }
 
     /// Find a model_id from selected_models that satisfies a capability's model
@@ -1470,6 +1498,46 @@ mod tests {
         );
     }
 
+    #[test]
+    fn find_latest_version_picks_the_highest_version_not_the_lowest() {
+        // Regression test: `compare_versions_desc` is a reversed comparator
+        // (by design, for descending display sorts), so `find_latest_version`
+        // must pair it with `min_by`, not `max_by` -- using `max_by` silently
+        // picked the *lowest* version in the family instead.
+        fn md(version: &str) -> ModelMetadata {
+            ModelMetadata {
+                family: "Test Family".to_string(),
+                version: version.to_string(),
+                size: 0,
+                context_length: 0,
+                model_type: ModelType::Text,
+                huggingface_repo: String::new(),
+                native_dtype: String::new(),
+                architecture: crate::models::ModelArchitecture {
+                    num_hidden_layers: 0,
+                    hidden_size: 0,
+                    num_attention_heads: 0,
+                    num_key_value_heads: 0,
+                    head_dim: 0,
+                    layer_types: vec![],
+                },
+                variants: vec![],
+                description: None,
+                tags: vec![],
+                supported_functions: vec![],
+            }
+        }
+        let models = vec![
+            ("a".to_string(), md("4.0")),
+            ("b".to_string(), md("3.1")),
+            ("c".to_string(), md("4.1")),
+            ("d".to_string(), md("3.3")),
+        ];
+        let (id, latest) = find_latest_version(&models).expect("non-empty input");
+        assert_eq!(id, "c");
+        assert_eq!(latest.version, "4.1");
+    }
+
     // -- size helpers ----------------------------------------------------------
 
     #[test]
@@ -1639,4 +1707,42 @@ mod tests {
         assert_eq!(items.len(), 1, "the missing binary should have been excluded");
         assert!(items[0].contains("found"));
     }
+
+    #[tokio::test]
+    async fn find_compatible_provider_rejects_format_mismatch() {
+        let mut ctx = test_ctx();
+        ctx.config.providers.insert(
+            "lm-studio".to_string(),
+            crate::config::ProviderConfig {
+                provider_id: "lm-studio".to_string(),
+                provider_type: "lm-studio".to_string(),
+                config: PROVIDER_REGISTRY.default_config("lm-studio").unwrap_or_default(),
+            },
+        );
+        let selected: HashSet<String> = ["lm-studio".to_string()].into_iter().collect();
+
+        let gguf_variant = ModelVariant {
+            format: "GGUF".to_string(),
+            precision: "Q4_K_M".to_string(),
+            size_gb: Some(4.0),
+            url: "https://example.com/model.gguf".to_string(),
+        };
+        assert_eq!(
+            SetupCommands::find_compatible_provider(&gguf_variant, &selected, &ctx),
+            Some("lm-studio".to_string())
+        );
+
+        let safetensors_variant = ModelVariant {
+            format: "safetensors".to_string(),
+            precision: "bfloat16".to_string(),
+            size_gb: Some(4.0),
+            url: "https://example.com/model".to_string(),
+        };
+        assert_eq!(
+            SetupCommands::find_compatible_provider(&safetensors_variant, &selected, &ctx),
+            None,
+            "lm-studio cannot serve safetensors and should not be picked"
+        );
+    }
 }
+

--- a/src/commands/setup.rs
+++ b/src/commands/setup.rs
@@ -6,7 +6,7 @@ use std::collections::{HashMap, HashSet};
 // Local
 use crate::capabilities::{BindingType, CAPABILITY_REGISTRY, Dependency, ModelRequirement};
 use crate::commands::model::ModelCommands;
-use crate::dependency::Requirement;
+use crate::dependency::{Configured, Requirement};
 use crate::launchers::LAUNCHER_REGISTRY;
 use crate::models::{
     ContextFit, MODEL_REGISTRY, ModelFunction, ModelMetadata, ModelType, ModelVariant,
@@ -1440,6 +1440,46 @@ impl SetupCommands {
             }
         }
 
+        // Enable every configured capability on each configured launcher
+        // that supports it. Must run after both loops above, since it needs
+        // a live `CapabilitySource` built from the now-populated capability
+        // configs.
+        let capability_source = crate::capabilities::CapabilitySource::from_config(&ctx.config);
+        for launcher_id in selected_launchers {
+            let Some(launcher_type) = ctx
+                .config
+                .get_launcher(launcher_id)
+                .map(|l| l.launcher_type.clone())
+            else {
+                continue;
+            };
+            let Some(launcher_meta) = LAUNCHER_REGISTRY.get(&launcher_type) else {
+                continue;
+            };
+
+            let mut enabled: Vec<String> = capability_source
+                .instances()
+                .into_iter()
+                .filter(|(_, cap)| {
+                    cap.binding_types()
+                        .iter()
+                        .any(|bt| launcher_meta.supported_capabilities.contains(bt))
+                })
+                .map(|(id, _)| id)
+                .collect();
+            enabled.sort();
+
+            if ctx
+                .config
+                .update_launcher(launcher_id, |l| l.enabled_capabilities = enabled.clone())
+                .is_err()
+            {
+                ui.warn(&format!(
+                    "Failed to enable capabilities for launcher '{launcher_id}'"
+                ));
+            }
+        }
+
         Ok(())
     }
 
@@ -2408,6 +2448,55 @@ mod tests {
             chosen,
             HashSet::from(["granite-4.2-30b".to_string()]),
             "should have picked exactly the manually-chosen partial-fit model"
+        );
+    }
+
+    // -- configure_all -----------------------------------------------------
+
+    #[tokio::test]
+    async fn configure_all_enables_only_capabilities_a_launcher_supports() {
+        let _home = crate::config::TestConfigHome::new();
+        let mut ctx = test_ctx();
+        let discovery = run_discovery(&ctx).await;
+
+        // claude supports the AgentModel binding that "agent-model" uses;
+        // bob supports only the Mcp binding, so it must not get it.
+        let selected_caps: HashSet<String> = ["agent-model".to_string()].into_iter().collect();
+        let selected_launchers: HashSet<String> = ["claude".to_string(), "bob".to_string()]
+            .into_iter()
+            .collect();
+        let selected_providers: HashSet<String> = ["ollama".to_string()].into_iter().collect();
+        let selected_models: HashSet<String> = ["granite-3.1-8b-instruct".to_string()]
+            .into_iter()
+            .collect();
+
+        SetupCommands::configure_all(
+            &mut ctx,
+            &discovery,
+            &selected_caps,
+            &selected_launchers,
+            &selected_providers,
+            &selected_models,
+            &HashMap::new(),
+        )
+        .await
+        .unwrap();
+
+        let claude_enabled = &ctx
+            .config
+            .get_launcher("claude")
+            .unwrap()
+            .enabled_capabilities;
+        assert_eq!(
+            claude_enabled,
+            &vec!["agent-model".to_string()],
+            "claude supports the AgentModel binding, so agent-model should be enabled"
+        );
+
+        let bob_enabled = &ctx.config.get_launcher("bob").unwrap().enabled_capabilities;
+        assert!(
+            bob_enabled.is_empty(),
+            "bob only supports the Mcp binding, so agent-model must not be enabled"
         );
     }
 

--- a/src/commands/setup.rs
+++ b/src/commands/setup.rs
@@ -12,7 +12,7 @@ use crate::models::{
     ContextFit, MODEL_REGISTRY, ModelFunction, ModelMetadata, ModelType, ModelVariant,
 };
 use crate::providers::{HealthStatus, PROVIDER_REGISTRY, Provider};
-use crate::utils::hardware::detect_hardware;
+use crate::utils::hardware::{HardwareProfile, detect_hardware};
 
 use_channel!("SETUP");
 
@@ -68,11 +68,24 @@ pub struct DiscoveryResult {
 struct Discover;
 
 impl Discover {
-    /// Run the full discovery pipeline.
+    /// Run the full discovery pipeline against the machine's real hardware.
     pub async fn run(ctx: &crate::AppContext) -> DiscoveryResult {
+        Self::run_with_hardware(ctx, &detect_hardware()).await
+    }
+
+    /// Run the full discovery pipeline against a given hardware profile.
+    /// Split out from `run` so tests can pin the hardware profile instead of
+    /// depending on `detect_hardware()`'s result on whatever machine the
+    /// test happens to run on -- model-fit outcomes (and therefore which
+    /// recommendations come out) are a direct function of the profile.
+    async fn run_with_hardware(
+        ctx: &crate::AppContext,
+        profile: &HardwareProfile,
+    ) -> DiscoveryResult {
         let (provider_recs, configured_providers) = Self::discover_providers(ctx).await;
-        let model_recs = Self::discover_models(ctx, &configured_providers);
-        let all_model_candidates = Self::discover_all_model_candidates(ctx, &configured_providers);
+        let model_recs = Self::discover_models(ctx, &configured_providers, profile);
+        let all_model_candidates =
+            Self::discover_all_model_candidates(ctx, &configured_providers, profile);
         let (launcher_recs, configured_launchers) = Self::discover_launchers(ctx).await;
         let (capability_recs, configured_capabilities) =
             Self::discover_capabilities(ctx, &provider_recs, &model_recs, &configured_providers);
@@ -167,8 +180,8 @@ impl Discover {
     fn discover_models(
         ctx: &crate::AppContext,
         configured_provider_ids: &[String],
+        profile: &HardwareProfile,
     ) -> Vec<Recommendation> {
-        let profile = detect_hardware();
         let configured_ids: HashSet<&str> = ctx.config.models.keys().map(|s| s.as_str()).collect();
 
         // Group models by family, keeping each model's real catalog id
@@ -207,7 +220,7 @@ impl Discover {
                     Self::build_model_recommendation(
                         id,
                         md,
-                        &profile,
+                        profile,
                         configured_provider_ids,
                         ctx,
                         true,
@@ -234,8 +247,8 @@ impl Discover {
     fn discover_all_model_candidates(
         ctx: &crate::AppContext,
         configured_provider_ids: &[String],
+        profile: &HardwareProfile,
     ) -> Vec<Recommendation> {
-        let profile = detect_hardware();
         let configured_ids: HashSet<&str> = ctx.config.models.keys().map(|s| s.as_str()).collect();
 
         let mut recommendations: Vec<Recommendation> = MODEL_REGISTRY
@@ -246,7 +259,7 @@ impl Discover {
                 Self::build_model_recommendation(
                     model_id,
                     &md,
-                    &profile,
+                    profile,
                     configured_provider_ids,
                     ctx,
                     false,
@@ -1629,6 +1642,33 @@ mod tests {
         }
     }
 
+    /// A fixed hardware profile for discovery tests, in place of
+    /// `detect_hardware()`'s result on whatever machine happens to run the
+    /// test. Model-fit outcomes are a direct function of the hardware
+    /// profile, so exercising the real detector here would make these tests
+    /// pass or fail depending on the CI runner's actual RAM/VRAM rather than
+    /// on the discovery logic under test.
+    ///
+    /// 32GB of usable memory (ram_gb / 2.0, no GPU) is calibrated against the
+    /// real "Granite Language" 4.2 catalog entries: granite-4.2-8b's
+    /// smallest GGUF variant fully fits at its full 131072-token context,
+    /// while even granite-4.2-30b's smallest variant needs far more than
+    /// that for full context and only ever partially fits.
+    fn test_hardware_profile() -> HardwareProfile {
+        HardwareProfile {
+            os: "test".to_string(),
+            cpu_cores: 8,
+            cpu_arch: "test".to_string(),
+            gpu_vendor: None,
+            vram_gb: None,
+            ram_gb: 64.0,
+        }
+    }
+
+    async fn run_discovery(ctx: &crate::AppContext) -> DiscoveryResult {
+        Discover::run_with_hardware(ctx, &test_hardware_profile()).await
+    }
+
     fn ctx_with_provider(
         id: &str,
         provider_type: &str,
@@ -1664,7 +1704,7 @@ mod tests {
     #[tokio::test]
     async fn discover_providers_skips_configured() {
         let ctx = ctx_with_provider("ollama", "ollama", serde_json::json!({}));
-        let result = Discover::run(&ctx).await;
+        let result = run_discovery(&ctx).await;
         assert!(
             result
                 .configured_provider_ids
@@ -1675,7 +1715,7 @@ mod tests {
     #[tokio::test]
     async fn discover_providers_recommends_unconfigured() {
         let ctx = test_ctx();
-        let result = Discover::run(&ctx).await;
+        let result = run_discovery(&ctx).await;
         let provider_recs: Vec<_> = result
             .recommendations
             .iter()
@@ -1693,7 +1733,7 @@ mod tests {
     #[tokio::test]
     async fn discover_models_groups_by_family() {
         let ctx = test_ctx();
-        let result = Discover::run(&ctx).await;
+        let result = run_discovery(&ctx).await;
         let model_recs: Vec<_> = result
             .recommendations
             .iter()
@@ -1709,7 +1749,7 @@ mod tests {
     #[tokio::test]
     async fn discover_models_recommendation_carries_real_registry_model_id() {
         let ctx = test_ctx();
-        let result = Discover::run(&ctx).await;
+        let result = run_discovery(&ctx).await;
         for rec in &result.recommendations {
             if let Recommendation::Model {
                 model_id, family, ..
@@ -1734,7 +1774,7 @@ mod tests {
         // never be the default recommendation, and whichever size *is*
         // recommended must be a full fit.
         let ctx = test_ctx();
-        let result = Discover::run(&ctx).await;
+        let result = run_discovery(&ctx).await;
 
         let rec = result.recommendations.iter().find(
             |r| matches!(r, Recommendation::Model { family, .. } if family == "Granite Language"),
@@ -1764,7 +1804,7 @@ mod tests {
     #[tokio::test]
     async fn discover_all_model_candidates_includes_every_size_with_its_own_fit() {
         let ctx = test_ctx();
-        let result = Discover::run(&ctx).await;
+        let result = run_discovery(&ctx).await;
 
         let granite_4_2: Vec<_> = result
             .all_model_candidates
@@ -1793,7 +1833,7 @@ mod tests {
     #[tokio::test]
     async fn discover_models_skips_configured() {
         let ctx = ctx_with_model("granite-3.1-8b-instruct", Some("ollama"));
-        let result = Discover::run(&ctx).await;
+        let result = run_discovery(&ctx).await;
         assert!(
             result
                 .configured_model_ids
@@ -1815,7 +1855,7 @@ mod tests {
                 config: serde_json::json!({}),
             },
         );
-        let result = Discover::run(&ctx).await;
+        let result = run_discovery(&ctx).await;
         assert!(
             result
                 .configured_launcher_ids
@@ -1826,7 +1866,7 @@ mod tests {
     #[tokio::test]
     async fn discover_launchers_recommends_unconfigured() {
         let ctx = test_ctx();
-        let result = Discover::run(&ctx).await;
+        let result = run_discovery(&ctx).await;
         let launcher_recs: Vec<_> = result
             .recommendations
             .iter()
@@ -1843,7 +1883,7 @@ mod tests {
     #[tokio::test]
     async fn discover_capabilities_recommends_unconfigured() {
         let ctx = test_ctx();
-        let result = Discover::run(&ctx).await;
+        let result = run_discovery(&ctx).await;
         let cap_recs: Vec<_> = result
             .recommendations
             .iter()
@@ -1960,7 +2000,7 @@ mod tests {
     #[tokio::test]
     async fn revaluator_for_models_filters_by_capability_requirements() {
         let ctx = test_ctx();
-        let discovery = Discover::run(&ctx).await;
+        let discovery = run_discovery(&ctx).await;
 
         // agent-model requires Chat + ToolCalling support.
         let selected_caps: HashSet<String> = ["agent-model".to_string()].into_iter().collect();
@@ -2050,7 +2090,7 @@ mod tests {
     #[tokio::test]
     async fn revaluator_for_models_excludes_multimodal_for_plain_chat_capability() {
         let ctx = test_ctx();
-        let discovery = Discover::run(&ctx).await;
+        let discovery = run_discovery(&ctx).await;
 
         // agent-model only requires Chat + ToolCalling -- no multi-modal
         // function -- so vision/speech models must not show up even though
@@ -2076,7 +2116,7 @@ mod tests {
     #[tokio::test]
     async fn revaluator_for_models_still_includes_vision_for_vision_mcp() {
         let ctx = test_ctx();
-        let discovery = Discover::run(&ctx).await;
+        let discovery = run_discovery(&ctx).await;
 
         let selected_caps: HashSet<String> = ["vision-mcp".to_string()].into_iter().collect();
         let filtered = Revaluator::for_models(&discovery.all_model_candidates, &selected_caps);
@@ -2090,7 +2130,7 @@ mod tests {
     #[tokio::test]
     async fn revaluator_for_models_with_no_requirements_returns_all() {
         let ctx = test_ctx();
-        let discovery = Discover::run(&ctx).await;
+        let discovery = run_discovery(&ctx).await;
         let filtered = Revaluator::for_models(&discovery.recommendations, &HashSet::new());
         let all_models: Vec<_> = discovery
             .recommendations
@@ -2103,7 +2143,7 @@ mod tests {
     #[tokio::test]
     async fn revaluator_for_launchers_filters_by_binding_types() {
         let ctx = test_ctx();
-        let discovery = Discover::run(&ctx).await;
+        let discovery = run_discovery(&ctx).await;
 
         // agent-model needs the AgentModel binding, which bob does not support.
         let selected_caps: HashSet<String> = ["agent-model".to_string()].into_iter().collect();
@@ -2129,7 +2169,7 @@ mod tests {
     #[tokio::test]
     async fn revaluator_for_capabilities_filters_by_selected_launchers() {
         let ctx = test_ctx();
-        let discovery = Discover::run(&ctx).await;
+        let discovery = run_discovery(&ctx).await;
 
         // bob only supports the Mcp binding, so only vision-mcp should show.
         let bob_only: HashSet<String> = ["bob".to_string()].into_iter().collect();
@@ -2145,7 +2185,7 @@ mod tests {
     #[tokio::test]
     async fn revaluator_for_capabilities_with_no_launchers_returns_none() {
         let ctx = test_ctx();
-        let discovery = Discover::run(&ctx).await;
+        let discovery = run_discovery(&ctx).await;
         let filtered = Revaluator::for_capabilities(&discovery, &HashSet::new());
         assert!(filtered.is_empty());
     }
@@ -2321,7 +2361,7 @@ mod tests {
             ui: capture.clone(),
         };
 
-        let discovery = Discover::run(&ctx).await;
+        let discovery = run_discovery(&ctx).await;
         let selected_caps: HashSet<String> = ["agent-model".to_string()].into_iter().collect();
 
         // granite-4.2-30b only partially fits, so it must not be in the

--- a/src/commands/setup.rs
+++ b/src/commands/setup.rs
@@ -8,7 +8,9 @@ use crate::capabilities::{BindingType, CAPABILITY_REGISTRY, Dependency, ModelReq
 use crate::commands::model::ModelCommands;
 use crate::dependency::Requirement;
 use crate::launchers::LAUNCHER_REGISTRY;
-use crate::models::{ContextFit, MODEL_REGISTRY, ModelFunction, ModelMetadata, ModelType, ModelVariant};
+use crate::models::{
+    ContextFit, MODEL_REGISTRY, ModelFunction, ModelMetadata, ModelType, ModelVariant,
+};
 use crate::providers::{HealthStatus, PROVIDER_REGISTRY, Provider};
 use crate::utils::hardware::detect_hardware;
 
@@ -72,12 +74,8 @@ impl Discover {
         let model_recs = Self::discover_models(ctx, &configured_providers);
         let all_model_candidates = Self::discover_all_model_candidates(ctx, &configured_providers);
         let (launcher_recs, configured_launchers) = Self::discover_launchers(ctx).await;
-        let (capability_recs, configured_capabilities) = Self::discover_capabilities(
-            ctx,
-            &provider_recs,
-            &model_recs,
-            &configured_providers,
-        );
+        let (capability_recs, configured_capabilities) =
+            Self::discover_capabilities(ctx, &provider_recs, &model_recs, &configured_providers);
 
         let mut recommendations: Vec<Recommendation> = Vec::new();
         recommendations.extend(provider_recs);
@@ -100,10 +98,9 @@ impl Discover {
 
     // -- Provider discovery --------------------------------------------------
 
-    async fn discover_providers(
-        ctx: &crate::AppContext,
-    ) -> (Vec<Recommendation>, Vec<String>) {
-        let configured_ids: HashSet<&str> = ctx.config.providers.keys().map(|s| s.as_str()).collect();
+    async fn discover_providers(ctx: &crate::AppContext) -> (Vec<Recommendation>, Vec<String>) {
+        let configured_ids: HashSet<&str> =
+            ctx.config.providers.keys().map(|s| s.as_str()).collect();
         let mut configured: Vec<String> = Vec::new();
         let mut recommendations: Vec<Recommendation> = Vec::new();
 
@@ -114,7 +111,9 @@ impl Discover {
             }
 
             // Construct a transient instance with default config and run health check
-            let default_config = PROVIDER_REGISTRY.default_config(provider_type).unwrap_or_default();
+            let default_config = PROVIDER_REGISTRY
+                .default_config(provider_type)
+                .unwrap_or_default();
             let result = PROVIDER_REGISTRY.construct(
                 provider_type,
                 provider_type,
@@ -144,7 +143,9 @@ impl Discover {
                         provider_type,
                         provider_name: metadata.name.clone(),
                         health_healthy: false,
-                        health_error: Some("Could not construct provider with default config".to_string()),
+                        health_error: Some(
+                            "Could not construct provider with default config".to_string(),
+                        ),
                     });
                 }
             }
@@ -155,7 +156,9 @@ impl Discover {
         (recommendations, configured)
     }
 
-    async fn run_health_check(provider: &dyn Provider) -> Result<HealthStatus, crate::providers::ProviderError> {
+    async fn run_health_check(
+        provider: &dyn Provider,
+    ) -> Result<HealthStatus, crate::providers::ProviderError> {
         provider.health_check().await
     }
 
@@ -201,7 +204,14 @@ impl Discover {
                 .iter()
                 .filter(|(_, md)| &md.version == latest_version)
                 .filter_map(|(id, md)| {
-                    Self::build_model_recommendation(id, md, &profile, configured_provider_ids, ctx, true)
+                    Self::build_model_recommendation(
+                        id,
+                        md,
+                        &profile,
+                        configured_provider_ids,
+                        ctx,
+                        true,
+                    )
                 })
                 .max_by_key(|rec| match rec {
                     Recommendation::Model { size, .. } => parse_size(size),
@@ -233,7 +243,14 @@ impl Discover {
             .into_iter()
             .filter(|(model_id, _)| !configured_ids.contains(*model_id))
             .filter_map(|(model_id, md)| {
-                Self::build_model_recommendation(model_id, &md, &profile, configured_provider_ids, ctx, false)
+                Self::build_model_recommendation(
+                    model_id,
+                    &md,
+                    &profile,
+                    configured_provider_ids,
+                    ctx,
+                    false,
+                )
             })
             .collect();
 
@@ -281,12 +298,7 @@ impl Discover {
             .filter_map(|pid| ctx.config.get_provider(pid))
             .filter_map(|pc| {
                 PROVIDER_REGISTRY
-                    .construct(
-                        &pc.provider_type,
-                        &pc.provider_id,
-                        &pc.config,
-                        &ctx.config,
-                    )
+                    .construct(&pc.provider_type, &pc.provider_id, &pc.config, &ctx.config)
                     .ok()
                     .filter(|p| p.can_run_model(&variant.format, &variant.precision))
             })
@@ -296,10 +308,9 @@ impl Discover {
 
     // -- Launcher discovery --------------------------------------------------
 
-    async fn discover_launchers(
-        ctx: &crate::AppContext,
-    ) -> (Vec<Recommendation>, Vec<String>) {
-        let configured_ids: HashSet<&str> = ctx.config.launchers.keys().map(|s| s.as_str()).collect();
+    async fn discover_launchers(ctx: &crate::AppContext) -> (Vec<Recommendation>, Vec<String>) {
+        let configured_ids: HashSet<&str> =
+            ctx.config.launchers.keys().map(|s| s.as_str()).collect();
         let mut configured: Vec<String> = Vec::new();
         let mut recommendations: Vec<Recommendation> = Vec::new();
 
@@ -310,7 +321,9 @@ impl Discover {
             }
 
             // Construct a transient instance with default config
-            let default_config = LAUNCHER_REGISTRY.default_config(launcher_type).unwrap_or_default();
+            let default_config = LAUNCHER_REGISTRY
+                .default_config(launcher_type)
+                .unwrap_or_default();
             match LAUNCHER_REGISTRY.construct(
                 launcher_type,
                 launcher_type,
@@ -353,12 +366,8 @@ impl Discover {
         _model_recs: &[Recommendation],
         _configured_provider_ids: &[String],
     ) -> (Vec<Recommendation>, Vec<String>) {
-        let configured_ids: Vec<&str> = ctx
-            .config
-            .capabilities
-            .keys()
-            .map(|s| s.as_str())
-            .collect();
+        let configured_ids: Vec<&str> =
+            ctx.config.capabilities.keys().map(|s| s.as_str()).collect();
         let configured: Vec<String> = configured_ids.iter().copied().map(String::from).collect();
 
         let mut recommendations: Vec<Recommendation> = Vec::new();
@@ -561,7 +570,10 @@ impl Revaluator {
             .recommendations
             .iter()
             .filter(move |r| {
-                if let Recommendation::Capability { capability_type, .. } = r {
+                if let Recommendation::Capability {
+                    capability_type, ..
+                } = r
+                {
                     if let Some(cap_meta) = CAPABILITY_REGISTRY.get(capability_type) {
                         return cap_meta
                             .supported_binding_types
@@ -671,9 +683,7 @@ fn display_name(rec: &Recommendation) -> String {
             size,
             ..
         } => format!("{family} {version} {size}"),
-        Recommendation::Launcher {
-            launcher_name, ..
-        } => launcher_name.clone(),
+        Recommendation::Launcher { launcher_name, .. } => launcher_name.clone(),
         Recommendation::Capability {
             capability_name, ..
         } => capability_name.clone(),
@@ -747,11 +757,7 @@ pub struct SetupCommands;
 
 impl SetupCommands {
     /// Entry point for `granite-cli setup`.
-    pub async fn run(
-        ctx: &mut crate::AppContext,
-        auto: bool,
-        skip_pull: bool,
-    ) -> Result<()> {
+    pub async fn run(ctx: &mut crate::AppContext, auto: bool, skip_pull: bool) -> Result<()> {
         if auto {
             Self::run_auto(ctx).await
         } else {
@@ -760,10 +766,7 @@ impl SetupCommands {
     }
 
     /// Run the interactive wizard.
-    async fn run_wizard(
-        ctx: &mut crate::AppContext,
-        skip_pull: bool,
-    ) -> Result<()> {
+    async fn run_wizard(ctx: &mut crate::AppContext, skip_pull: bool) -> Result<()> {
         let ui = &*ctx.ui;
         ui.info("=== granite-cli Setup Wizard ===\n");
         ui.info("Discovering available components...\n");
@@ -776,7 +779,9 @@ impl SetupCommands {
             && discovery.configured_launcher_ids.is_empty()
             && discovery.configured_capability_ids.is_empty()
         {
-            ui.info("Nothing to configure. All components are either not available or already set up.");
+            ui.info(
+                "Nothing to configure. All components are either not available or already set up.",
+            );
             return Ok(());
         }
 
@@ -791,8 +796,7 @@ impl SetupCommands {
         let selected_models = Self::select_models(ctx, &discovery, &selected_caps).await?;
 
         // Phase 4: Providers selection (only healthy, filtered by model compatibility)
-        let selected_providers =
-            Self::select_providers(ctx, &discovery, &selected_models).await?;
+        let selected_providers = Self::select_providers(ctx, &discovery, &selected_models).await?;
 
         // Phase 4.5: Variant selection (limited to formats the selected
         // providers can actually run, with a VRAM estimate at full context)
@@ -857,35 +861,38 @@ impl SetupCommands {
             })
             .collect();
 
-        let selected_caps: HashSet<String> = Revaluator::for_capabilities(&discovery, &selected_launchers)
-            .into_iter()
-            .filter_map(|r| match r {
-                Recommendation::Capability {
-                    capability_type, ..
-                } => Some(capability_type.clone()),
-                _ => None,
-            })
-            .collect();
+        let selected_caps: HashSet<String> =
+            Revaluator::for_capabilities(&discovery, &selected_launchers)
+                .into_iter()
+                .filter_map(|r| match r {
+                    Recommendation::Capability {
+                        capability_type, ..
+                    } => Some(capability_type.clone()),
+                    _ => None,
+                })
+                .collect();
 
-        let selected_models: HashSet<String> = Revaluator::for_models(&discovery.recommendations, &selected_caps)
-            .into_iter()
-            .filter_map(|r| match r {
-                Recommendation::Model { model_id, .. } => Some(model_id.clone()),
-                _ => None,
-            })
-            .collect();
+        let selected_models: HashSet<String> =
+            Revaluator::for_models(&discovery.recommendations, &selected_caps)
+                .into_iter()
+                .filter_map(|r| match r {
+                    Recommendation::Model { model_id, .. } => Some(model_id.clone()),
+                    _ => None,
+                })
+                .collect();
 
-        let selected_providers: HashSet<String> = Revaluator::for_providers(&discovery, &selected_models, ctx)
-            .into_iter()
-            .filter_map(|r| match r {
-                Recommendation::Provider {
-                    provider_type,
-                    health_healthy,
-                    ..
-                } if *health_healthy => Some(provider_type.to_string()),
-                _ => None,
-            })
-            .collect();
+        let selected_providers: HashSet<String> =
+            Revaluator::for_providers(&discovery, &selected_models, ctx)
+                .into_iter()
+                .filter_map(|r| match r {
+                    Recommendation::Provider {
+                        provider_type,
+                        health_healthy,
+                        ..
+                    } if *health_healthy => Some(provider_type.to_string()),
+                    _ => None,
+                })
+                .collect();
 
         // --auto is non-interactive, so there's no prompt for variant
         // selection -- `configure_all` falls back to discovery's
@@ -940,20 +947,13 @@ impl SetupCommands {
 
         let items: Vec<String> = caps
             .iter()
-            .map(|(id, name)| format!("{} — {}", id, name))
+            .map(|(id, name)| format!("{id} — {name}"))
             .collect();
         let defaults = vec![true; items.len()];
 
-        let selected = ui.multi_select(
-            "Select capabilities to configure",
-            &items,
-            &defaults,
-        )?;
+        let selected = ui.multi_select("Select capabilities to configure", &items, &defaults)?;
 
-        Ok(selected
-            .into_iter()
-            .map(|i| caps[i].0.clone())
-            .collect())
+        Ok(selected.into_iter().map(|i| caps[i].0.clone()).collect())
     }
 
     async fn select_launchers(
@@ -981,15 +981,11 @@ impl SetupCommands {
 
         let items: Vec<String> = filtered
             .iter()
-            .map(|(id, name, path)| format!("{} — {} ({})", id, name, path))
+            .map(|(id, name, path)| format!("{id} — {name} ({path})"))
             .collect();
         let defaults = vec![false; items.len()];
 
-        let selected = ui.multi_select(
-            "Select launchers to configure",
-            &items,
-            &defaults,
-        )?;
+        let selected = ui.multi_select("Select launchers to configure", &items, &defaults)?;
 
         Ok(selected
             .into_iter()
@@ -1004,12 +1000,8 @@ impl SetupCommands {
     ) -> Result<HashSet<String>> {
         let ui = &*ctx.ui;
 
-        let filtered: Vec<_> = Revaluator::for_providers(
-            discovery,
-            selected_models,
-            ctx,
-        )
-        .into_iter()
+        let filtered: Vec<_> = Revaluator::for_providers(discovery, selected_models, ctx)
+            .into_iter()
             .filter_map(|r| match r {
                 Recommendation::Provider {
                     provider_type,
@@ -1023,7 +1015,7 @@ impl SetupCommands {
                 )),
                 _ => None,
             })
-        .collect();
+            .collect();
 
         if filtered.is_empty() {
             ui.info("No healthy providers available to configure.");
@@ -1040,16 +1032,12 @@ impl SetupCommands {
                 } else {
                     "healthy".to_string()
                 };
-                format!("{} — {} ({})", id, name, status)
+                format!("{id} — {name} ({status})")
             })
             .collect();
         let defaults = vec![false; items.len()];
 
-        let selected = ui.multi_select(
-            "Select providers to configure",
-            &items,
-            &defaults,
-        )?;
+        let selected = ui.multi_select("Select providers to configure", &items, &defaults)?;
 
         Ok(selected
             .into_iter()
@@ -1151,7 +1139,11 @@ impl SetupCommands {
 
         md.variants
             .iter()
-            .filter(|v| providers.iter().any(|p| p.can_run_model(&v.format, &v.precision)))
+            .filter(|v| {
+                providers
+                    .iter()
+                    .any(|p| p.can_run_model(&v.format, &v.precision))
+            })
             .map(|v| {
                 let gb = crate::models::required_gb(
                     &md.architecture,
@@ -1164,7 +1156,11 @@ impl SetupCommands {
             .collect()
     }
 
-    fn format_variant_option(variant: &ModelVariant, required_gb: f64, context_length: u64) -> String {
+    fn format_variant_option(
+        variant: &ModelVariant,
+        required_gb: f64,
+        context_length: u64,
+    ) -> String {
         match variant.size_gb {
             Some(size) => format!(
                 "{} / {} — {:.1} GB file, ~{:.1} GB VRAM @ full context ({context_length} tokens)",
@@ -1199,7 +1195,12 @@ impl SetupCommands {
                     context_fit,
                     can_run_by,
                     ..
-                } => Some((model_id.clone(), size.clone(), *context_fit, can_run_by.clone())),
+                } => Some((
+                    model_id.clone(),
+                    size.clone(),
+                    *context_fit,
+                    can_run_by.clone(),
+                )),
                 _ => None,
             })
             .collect()
@@ -1212,7 +1213,10 @@ impl SetupCommands {
     ) -> Result<HashSet<String>> {
         let ui = &*ctx.ui;
 
-        let filtered = Self::model_options(Revaluator::for_models(&discovery.recommendations, selected_caps));
+        let filtered = Self::model_options(Revaluator::for_models(
+            &discovery.recommendations,
+            selected_caps,
+        ));
 
         let mut chosen: HashSet<String> = HashSet::new();
         let mut choose_different = filtered.is_empty();
@@ -1223,7 +1227,9 @@ impl SetupCommands {
             let escape_hatch_idx = filtered.len();
             let mut items: Vec<String> = filtered
                 .iter()
-                .map(|(id, size, fit, providers)| Self::format_model_option(id, size, *fit, providers))
+                .map(|(id, size, fit, providers)| {
+                    Self::format_model_option(id, size, *fit, providers)
+                })
                 .collect();
             items.push(Self::CHOOSE_DIFFERENT_MODELS_LABEL.to_string());
 
@@ -1311,8 +1317,14 @@ impl SetupCommands {
                 config: default_config,
             };
 
-            if ctx.config.insert_provider(provider_id, provider_config).is_err() {
-                ui.warn(&format!("Failed to save provider config for '{provider_id}'"));
+            if ctx
+                .config
+                .insert_provider(provider_id, provider_config)
+                .is_err()
+            {
+                ui.warn(&format!(
+                    "Failed to save provider config for '{provider_id}'"
+                ));
             }
         }
 
@@ -1330,8 +1342,14 @@ impl SetupCommands {
                 config: default_config,
             };
 
-            if ctx.config.insert_launcher(launcher_id, launcher_config).is_err() {
-                ui.warn(&format!("Failed to save launcher config for '{launcher_id}'"));
+            if ctx
+                .config
+                .insert_launcher(launcher_id, launcher_config)
+                .is_err()
+            {
+                ui.warn(&format!(
+                    "Failed to save launcher config for '{launcher_id}'"
+                ));
             }
         }
 
@@ -1493,13 +1511,9 @@ impl SetupCommands {
                     .get_model(model_id)
                     .and_then(|mc| mc.provider_id.clone())
                     .and_then(|provider_id| {
-                        ctx.config.get_provider(&provider_id).map(|pc| {
-                            (
-                                model_id.clone(),
-                                provider_id,
-                                pc.provider_type.clone(),
-                            )
-                        })
+                        ctx.config
+                            .get_provider(&provider_id)
+                            .map(|pc| (model_id.clone(), provider_id, pc.provider_type.clone()))
                     })
             })
             .collect();
@@ -1512,18 +1526,10 @@ impl SetupCommands {
 
         let items: Vec<String> = pullable
             .iter()
-            .map(|(model, provider, ptype)| {
-                format!(
-                    "{} → {} ({})",
-                    provider, model, ptype
-                )
-            })
+            .map(|(model, provider, ptype)| format!("{provider} → {model} ({ptype})"))
             .collect();
 
-        let pull_now = ui.confirm(
-            "\n→ Pull model weights now?",
-            !items.is_empty(),
-        )?;
+        let pull_now = ui.confirm("\n→ Pull model weights now?", !items.is_empty())?;
 
         if pull_now {
             for (model_id, _provider_id, _provider_type) in &pullable {
@@ -1557,7 +1563,11 @@ impl SetupCommands {
             if selected_providers.is_empty() {
                 "none".to_string()
             } else {
-                selected_providers.iter().cloned().collect::<Vec<_>>().join(", ")
+                selected_providers
+                    .iter()
+                    .cloned()
+                    .collect::<Vec<_>>()
+                    .join(", ")
             }
         ));
         ui.info(&format!(
@@ -1565,7 +1575,11 @@ impl SetupCommands {
             if selected_models.is_empty() {
                 "none".to_string()
             } else {
-                selected_models.iter().cloned().collect::<Vec<_>>().join(", ")
+                selected_models
+                    .iter()
+                    .cloned()
+                    .collect::<Vec<_>>()
+                    .join(", ")
             }
         ));
         ui.info(&format!(
@@ -1573,7 +1587,11 @@ impl SetupCommands {
             if selected_launchers.is_empty() {
                 "none".to_string()
             } else {
-                selected_launchers.iter().cloned().collect::<Vec<_>>().join(", ")
+                selected_launchers
+                    .iter()
+                    .cloned()
+                    .collect::<Vec<_>>()
+                    .join(", ")
             }
         ));
         ui.info(&format!(
@@ -1585,9 +1603,7 @@ impl SetupCommands {
             }
         ));
 
-        ui.info(
-            "\nRun `granite-cli launcher list` to see configured launchers.",
-        );
+        ui.info("\nRun `granite-cli launcher list` to see configured launchers.");
         if !selected_launchers.is_empty() {
             let first_launcher = selected_launchers.iter().next().unwrap();
             ui.info(&format!(
@@ -1613,7 +1629,11 @@ mod tests {
         }
     }
 
-    fn ctx_with_provider(id: &str, provider_type: &str, config: serde_json::Value) -> crate::AppContext {
+    fn ctx_with_provider(
+        id: &str,
+        provider_type: &str,
+        config: serde_json::Value,
+    ) -> crate::AppContext {
         let mut ctx = test_ctx();
         ctx.config.providers.insert(
             id.to_string(),
@@ -1645,7 +1665,11 @@ mod tests {
     async fn discover_providers_skips_configured() {
         let ctx = ctx_with_provider("ollama", "ollama", serde_json::json!({}));
         let result = Discover::run(&ctx).await;
-        assert!(result.configured_provider_ids.contains(&"ollama".to_string()));
+        assert!(
+            result
+                .configured_provider_ids
+                .contains(&"ollama".to_string())
+        );
     }
 
     #[tokio::test]
@@ -1687,7 +1711,10 @@ mod tests {
         let ctx = test_ctx();
         let result = Discover::run(&ctx).await;
         for rec in &result.recommendations {
-            if let Recommendation::Model { model_id, family, .. } = rec {
+            if let Recommendation::Model {
+                model_id, family, ..
+            } = rec
+            {
                 assert!(
                     MODEL_REGISTRY.get(model_id).is_some(),
                     "model_id '{model_id}' should be a real catalog key, not the family name"
@@ -1709,10 +1736,9 @@ mod tests {
         let ctx = test_ctx();
         let result = Discover::run(&ctx).await;
 
-        let rec = result
-            .recommendations
-            .iter()
-            .find(|r| matches!(r, Recommendation::Model { family, .. } if family == "Granite Language"));
+        let rec = result.recommendations.iter().find(
+            |r| matches!(r, Recommendation::Model { family, .. } if family == "Granite Language"),
+        );
 
         if let Some(Recommendation::Model {
             model_id,
@@ -1766,12 +1792,13 @@ mod tests {
 
     #[tokio::test]
     async fn discover_models_skips_configured() {
-        let ctx = ctx_with_model(
-            "granite-3.1-8b-instruct",
-            Some("ollama"),
-        );
+        let ctx = ctx_with_model("granite-3.1-8b-instruct", Some("ollama"));
         let result = Discover::run(&ctx).await;
-        assert!(result.configured_model_ids.contains(&"granite-3.1-8b-instruct".to_string()));
+        assert!(
+            result
+                .configured_model_ids
+                .contains(&"granite-3.1-8b-instruct".to_string())
+        );
     }
 
     // -- discover_launchers ----------------------------------------------------
@@ -1789,7 +1816,11 @@ mod tests {
             },
         );
         let result = Discover::run(&ctx).await;
-        assert!(result.configured_launcher_ids.contains(&"claude".to_string()));
+        assert!(
+            result
+                .configured_launcher_ids
+                .contains(&"claude".to_string())
+        );
     }
 
     #[tokio::test]
@@ -1828,9 +1859,18 @@ mod tests {
 
     #[test]
     fn compare_versions_desc_simple() {
-        assert_eq!(compare_versions_desc("3.1", "3.0"), std::cmp::Ordering::Less);
-        assert_eq!(compare_versions_desc("3.0", "3.1"), std::cmp::Ordering::Greater);
-        assert_eq!(compare_versions_desc("3.1", "3.1"), std::cmp::Ordering::Equal);
+        assert_eq!(
+            compare_versions_desc("3.1", "3.0"),
+            std::cmp::Ordering::Less
+        );
+        assert_eq!(
+            compare_versions_desc("3.0", "3.1"),
+            std::cmp::Ordering::Greater
+        );
+        assert_eq!(
+            compare_versions_desc("3.1", "3.1"),
+            std::cmp::Ordering::Equal
+        );
     }
 
     #[test]
@@ -1938,7 +1978,8 @@ mod tests {
             if let Recommendation::Model { model_id, .. } = rec {
                 let md = MODEL_REGISTRY.get(model_id).expect("real catalog entry");
                 assert!(
-                    md.supported_functions.contains(&crate::models::ModelFunction::Chat),
+                    md.supported_functions
+                        .contains(&crate::models::ModelFunction::Chat),
                     "{model_id} should support Chat"
                 );
             }
@@ -1990,7 +2031,8 @@ mod tests {
             ModelFunction::ToolCalling,
             ModelFunction::ImageUnderstanding,
         ]);
-        let speech_model = md_with_functions(vec![ModelFunction::Chat, ModelFunction::Transcription]);
+        let speech_model =
+            md_with_functions(vec![ModelFunction::Chat, ModelFunction::Transcription]);
 
         assert!(admits_for_recommendation(&chat_only_req, &text_model));
         assert!(
@@ -2110,7 +2152,11 @@ mod tests {
 
     // -- Variant selection -------------------------------------------------------
 
-    fn model_recommendation(model_id: &str, md: &ModelMetadata, best_variant: ModelVariant) -> Recommendation {
+    fn model_recommendation(
+        model_id: &str,
+        md: &ModelMetadata,
+        best_variant: ModelVariant,
+    ) -> Recommendation {
         Recommendation::Model {
             model_id: model_id.to_string(),
             family: md.family.clone(),
@@ -2164,7 +2210,11 @@ mod tests {
         let md = MODEL_REGISTRY
             .get("granite-docling-258M-mlx")
             .expect("fixture model should exist in the catalog");
-        assert_eq!(md.variants.len(), 1, "fixture assumption: exactly one variant");
+        assert_eq!(
+            md.variants.len(),
+            1,
+            "fixture assumption: exactly one variant"
+        );
 
         let discovery = DiscoveryResult {
             recommendations: vec![model_recommendation(
@@ -2178,14 +2228,20 @@ mod tests {
             configured_launcher_ids: vec![],
             configured_capability_ids: vec![],
         };
-        let selected_models: HashSet<String> =
-            ["granite-docling-258M-mlx".to_string()].into_iter().collect();
+        let selected_models: HashSet<String> = ["granite-docling-258M-mlx".to_string()]
+            .into_iter()
+            .collect();
         let selected_providers: HashSet<String> =
             ["openai-compatible".to_string()].into_iter().collect();
 
-        let chosen = SetupCommands::select_variants(&mut ctx, &discovery, &selected_models, &selected_providers)
-            .await
-            .unwrap();
+        let chosen = SetupCommands::select_variants(
+            &mut ctx,
+            &discovery,
+            &selected_models,
+            &selected_providers,
+        )
+        .await
+        .unwrap();
 
         let picked = chosen
             .get("granite-docling-258M-mlx")
@@ -2240,9 +2296,14 @@ mod tests {
         // No canned select answer -- CaptureUi::select falls back to
         // whatever `default` it was passed, so this proves that default
         // index actually points at discovery's recommended variant.
-        let chosen = SetupCommands::select_variants(&mut ctx, &discovery, &selected_models, &selected_providers)
-            .await
-            .unwrap();
+        let chosen = SetupCommands::select_variants(
+            &mut ctx,
+            &discovery,
+            &selected_models,
+            &selected_providers,
+        )
+        .await
+        .unwrap();
 
         let picked = chosen
             .get("granite-vision-4.1-4b")
@@ -2266,19 +2327,21 @@ mod tests {
         // granite-4.2-30b only partially fits, so it must not be in the
         // default recommendation list, but must be reachable through
         // "choose different models".
-        let default_ids: HashSet<&str> = Revaluator::for_models(&discovery.recommendations, &selected_caps)
-            .into_iter()
-            .filter_map(|r| match r {
-                Recommendation::Model { model_id, .. } => Some(model_id.as_str()),
-                _ => None,
-            })
-            .collect();
+        let default_ids: HashSet<&str> =
+            Revaluator::for_models(&discovery.recommendations, &selected_caps)
+                .into_iter()
+                .filter_map(|r| match r {
+                    Recommendation::Model { model_id, .. } => Some(model_id.as_str()),
+                    _ => None,
+                })
+                .collect();
         assert!(
             !default_ids.contains("granite-4.2-30b"),
             "granite-4.2-30b only partially fits and must not be a default recommendation"
         );
 
-        let manual_candidates = Revaluator::for_models(&discovery.all_model_candidates, &selected_caps);
+        let manual_candidates =
+            Revaluator::for_models(&discovery.all_model_candidates, &selected_caps);
         let thirty_b_idx = manual_candidates
             .iter()
             .position(|r| matches!(r, Recommendation::Model { model_id, .. } if model_id == "granite-4.2-30b"))
@@ -2336,7 +2399,9 @@ mod tests {
         );
 
         let model_id = "granite-3.1-8b-instruct";
-        let md = MODEL_REGISTRY.get(model_id).expect("fixture model should exist");
+        let md = MODEL_REGISTRY
+            .get(model_id)
+            .expect("fixture model should exist");
         let variant = md
             .variants
             .iter()
@@ -2419,7 +2484,11 @@ mod tests {
 
         let prompts = capture.multi_select_prompts.borrow();
         let (_, items, _) = &prompts[0];
-        assert_eq!(items.len(), 1, "the missing binary should have been excluded");
+        assert_eq!(
+            items.len(),
+            1,
+            "the missing binary should have been excluded"
+        );
         assert!(items[0].contains("found"));
     }
 
@@ -2431,7 +2500,9 @@ mod tests {
             crate::config::ProviderConfig {
                 provider_id: "lm-studio".to_string(),
                 provider_type: "lm-studio".to_string(),
-                config: PROVIDER_REGISTRY.default_config("lm-studio").unwrap_or_default(),
+                config: PROVIDER_REGISTRY
+                    .default_config("lm-studio")
+                    .unwrap_or_default(),
             },
         );
         let selected: HashSet<String> = ["lm-studio".to_string()].into_iter().collect();

--- a/src/commands/setup.rs
+++ b/src/commands/setup.rs
@@ -7,7 +7,7 @@ use std::collections::{HashMap, HashSet};
 use crate::capabilities::{BindingType, CAPABILITY_REGISTRY, Dependency, ModelRequirement};
 use crate::dependency::Requirement;
 use crate::launchers::LAUNCHER_REGISTRY;
-use crate::models::{ContextFit, MODEL_REGISTRY, ModelMetadata, ModelType, ModelVariant};
+use crate::models::{ContextFit, MODEL_REGISTRY, ModelFunction, ModelMetadata, ModelType, ModelVariant};
 use crate::providers::{HealthStatus, PROVIDER_REGISTRY, Provider};
 use crate::utils::hardware::detect_hardware;
 
@@ -526,7 +526,9 @@ impl Revaluator {
                     // alone can't tell us `supported_functions`, which most
                     // capability requirements actually key on).
                     match MODEL_REGISTRY.get(model_id) {
-                        Some(md) => all_requirements.iter().any(|req| req.admits_type(&md)),
+                        Some(md) => all_requirements
+                            .iter()
+                            .any(|req| admits_for_recommendation(req, &md)),
                         None => false,
                     }
                 } else {
@@ -703,6 +705,39 @@ fn sort_model_recommendations(recommendations: &mut [Recommendation]) {
             .then_with(|| compare_versions_desc(a_version, b_version))
             .then_with(|| b_size.cmp(&a_size))
     });
+}
+
+/// Model functions that make a model "multi-modal" -- image or audio
+/// input. A model reporting one of these can usually still `Chat`, but it's
+/// not *intended* as a general chat model, so it shouldn't be recommended
+/// for a capability that only asked for `Chat`/`ToolCalling`/etc.
+const MULTIMODAL_FUNCTIONS: &[ModelFunction] = &[
+    ModelFunction::ImageUnderstanding,
+    ModelFunction::Transcription,
+    ModelFunction::Translation,
+    ModelFunction::SpeakerAttribution,
+    ModelFunction::KeywordBiasing,
+];
+
+/// Whether `md` should be recommended for a capability declaring `req`.
+/// Layers an extra rule on top of `ModelRequirement::admits_type`: if `req`
+/// doesn't itself ask for any multi-modal function, a multi-modal model is
+/// excluded even though it technically satisfies the requirement's function
+/// list (e.g. a vision model supports `Chat` too, but a plain agent-model
+/// binding isn't looking for a vision model).
+fn admits_for_recommendation(req: &ModelRequirement, md: &ModelMetadata) -> bool {
+    if !req.admits_type(md) {
+        return false;
+    }
+    let req_wants_multimodal = req
+        .supported_functions
+        .iter()
+        .any(|f| MULTIMODAL_FUNCTIONS.contains(f));
+    req_wants_multimodal
+        || !md
+            .supported_functions
+            .iter()
+            .any(|f| MULTIMODAL_FUNCTIONS.contains(f))
 }
 
 /*-- SetupCommands -----------------------------------------------------------*/

--- a/src/commands/setup.rs
+++ b/src/commands/setup.rs
@@ -690,6 +690,11 @@ impl SetupCommands {
         let selected_providers =
             Self::select_providers(ctx, &discovery, &selected_models).await?;
 
+        // Phase 4.5: Variant selection (limited to formats the selected
+        // providers can actually run, with a VRAM estimate at full context)
+        let selected_variants =
+            Self::select_variants(ctx, &discovery, &selected_models, &selected_providers).await?;
+
         // Phase 5: Configuration
         Self::configure_all(
             ctx,
@@ -698,6 +703,7 @@ impl SetupCommands {
             &selected_launchers,
             &selected_providers,
             &selected_models,
+            &selected_variants,
         )
         .await?;
 
@@ -777,6 +783,9 @@ impl SetupCommands {
             })
             .collect();
 
+        // --auto is non-interactive, so there's no prompt for variant
+        // selection -- `configure_all` falls back to discovery's
+        // hardware-fit `best_variant` for every model.
         Self::configure_all(
             ctx,
             &discovery,
@@ -784,6 +793,7 @@ impl SetupCommands {
             &selected_launchers,
             &selected_providers,
             &selected_models,
+            &HashMap::new(),
         )
         .await?;
 
@@ -943,6 +953,126 @@ impl SetupCommands {
             .collect())
     }
 
+    /// Phase 4.5: let the user pick a specific variant for each selected
+    /// model, once both capabilities and providers are known. Options are
+    /// limited to variants at least one selected provider can actually run,
+    /// each annotated with an estimated VRAM/RAM footprint at the model's
+    /// full configured context length. Models with only one compatible
+    /// variant are auto-selected without prompting.
+    async fn select_variants(
+        ctx: &mut crate::AppContext,
+        discovery: &DiscoveryResult,
+        selected_models: &HashSet<String>,
+        selected_providers: &HashSet<String>,
+    ) -> Result<HashMap<String, ModelVariant>> {
+        let mut chosen = HashMap::new();
+
+        for model_id in selected_models {
+            let Some(md) = MODEL_REGISTRY.get(model_id) else {
+                continue;
+            };
+
+            let candidates = Self::candidate_variants(&md, selected_providers, ctx);
+            if candidates.is_empty() {
+                ctx.ui.warn(&format!(
+                    "No selected provider can run any variant of '{model_id}'; leaving its variant unset."
+                ));
+                continue;
+            }
+
+            if candidates.len() == 1 {
+                let (variant, gb) = &candidates[0];
+                ctx.ui.info(&format!(
+                    "Only one compatible variant for '{model_id}': {} — selected automatically.",
+                    Self::format_variant_option(variant, *gb, md.context_length)
+                ));
+                chosen.insert(model_id.clone(), variant.clone());
+                continue;
+            }
+
+            let recommended = discovery.recommendations.iter().find_map(|r| match r {
+                Recommendation::Model {
+                    model_id: rec_id,
+                    best_variant,
+                    ..
+                } if rec_id == model_id => Some(best_variant.clone()),
+                _ => None,
+            });
+
+            let default_idx = recommended
+                .as_ref()
+                .and_then(|rv| {
+                    candidates.iter().position(|(v, _)| {
+                        v.format.eq_ignore_ascii_case(&rv.format)
+                            && v.precision.eq_ignore_ascii_case(&rv.precision)
+                    })
+                })
+                .unwrap_or(0);
+
+            let items: Vec<String> = candidates
+                .iter()
+                .map(|(v, gb)| Self::format_variant_option(v, *gb, md.context_length))
+                .collect();
+
+            let idx = ctx.ui.select(
+                &format!("Select variant for {model_id}"),
+                &items,
+                default_idx,
+            )?;
+            chosen.insert(model_id.clone(), candidates[idx].0.clone());
+        }
+
+        Ok(chosen)
+    }
+
+    /// Variants of `md` that at least one selected provider can run, paired
+    /// with their estimated required memory (GB) at `md.context_length`
+    /// (i.e. full context). Providers are constructed transiently with
+    /// registry defaults, matching how discovery evaluates them, since this
+    /// runs before providers are written to config.
+    fn candidate_variants(
+        md: &ModelMetadata,
+        selected_providers: &HashSet<String>,
+        ctx: &crate::AppContext,
+    ) -> Vec<(ModelVariant, f64)> {
+        let providers: Vec<Box<dyn Provider>> = selected_providers
+            .iter()
+            .filter_map(|pid| {
+                let default_config = PROVIDER_REGISTRY.default_config(pid).unwrap_or_default();
+                PROVIDER_REGISTRY
+                    .construct(pid, pid, &default_config, &ctx.config)
+                    .ok()
+            })
+            .collect();
+
+        md.variants
+            .iter()
+            .filter(|v| providers.iter().any(|p| p.can_run_model(&v.format, &v.precision)))
+            .map(|v| {
+                let gb = crate::models::required_gb(
+                    &md.architecture,
+                    v,
+                    &md.native_dtype,
+                    md.context_length,
+                );
+                (v.clone(), gb)
+            })
+            .collect()
+    }
+
+    fn format_variant_option(variant: &ModelVariant, required_gb: f64, context_length: u64) -> String {
+        match variant.size_gb {
+            Some(size) => format!(
+                "{} / {} — {:.1} GB file, ~{:.1} GB VRAM @ full context ({context_length} tokens)",
+                variant.format, variant.precision, size, required_gb
+            ),
+            None => format!(
+                "{} / {} — ~{:.1} GB VRAM @ full context ({context_length} tokens)",
+                variant.format, variant.precision, required_gb
+            ),
+        }
+    }
+
     async fn select_models(
         ctx: &mut crate::AppContext,
         discovery: &DiscoveryResult,
@@ -1020,6 +1150,7 @@ impl SetupCommands {
         selected_launchers: &HashSet<String>,
         selected_providers: &HashSet<String>,
         selected_models: &HashSet<String>,
+        selected_variants: &HashMap<String, ModelVariant>,
     ) -> Result<()> {
         let ui = &*ctx.ui;
 
@@ -1070,16 +1201,21 @@ impl SetupCommands {
         for model_id in selected_models {
             ui.info(&format!("\nConfiguring model: {model_id}..."));
 
-            let best_variant = discovery.recommendations.iter().find_map(|r| match r {
-                Recommendation::Model {
-                    model_id: rec_id,
-                    best_variant,
-                    ..
-                } if rec_id == model_id => Some(best_variant.clone()),
-                _ => None,
+            // Prefer the variant the user picked in the variant-selection
+            // phase; fall back to discovery's hardware-fit recommendation
+            // (e.g. in --auto mode, where that phase never runs).
+            let chosen_variant = selected_variants.get(model_id).cloned().or_else(|| {
+                discovery.recommendations.iter().find_map(|r| match r {
+                    Recommendation::Model {
+                        model_id: rec_id,
+                        best_variant,
+                        ..
+                    } if rec_id == model_id => Some(best_variant.clone()),
+                    _ => None,
+                })
             });
 
-            let (provider_id, variant) = match &best_variant {
+            let (provider_id, variant) = match &chosen_variant {
                 Some(v) => (
                     Self::find_compatible_provider(v, selected_providers, ctx)
                         .or_else(|| selected_providers.iter().next().cloned()),
@@ -1653,6 +1789,148 @@ mod tests {
         assert!(filtered.is_empty());
     }
 
+    // -- Variant selection -------------------------------------------------------
+
+    fn model_recommendation(model_id: &str, md: &ModelMetadata, best_variant: ModelVariant) -> Recommendation {
+        Recommendation::Model {
+            model_id: model_id.to_string(),
+            family: md.family.clone(),
+            version: md.version.clone(),
+            size: format_size(md.size),
+            model_type: md.model_type.clone(),
+            best_variant,
+            context_fit: ContextFit::Full,
+            can_run_by: vec![],
+        }
+    }
+
+    #[test]
+    fn candidate_variants_excludes_formats_no_selected_provider_supports() {
+        let ctx = test_ctx();
+        let md = MODEL_REGISTRY
+            .get("granite-vision-4.1-4b")
+            .expect("fixture model should exist in the catalog");
+        let selected: HashSet<String> = ["lm-studio".to_string()].into_iter().collect();
+
+        let candidates = SetupCommands::candidate_variants(&md, &selected, &ctx);
+
+        assert!(
+            !candidates.is_empty(),
+            "lm-studio should be able to run at least one GGUF variant"
+        );
+        assert!(
+            candidates
+                .iter()
+                .all(|(v, gb)| v.format.eq_ignore_ascii_case("gguf") && *gb > 0.0),
+            "every candidate should be a GGUF variant with a positive VRAM estimate"
+        );
+        assert!(
+            !candidates
+                .iter()
+                .any(|(v, _)| v.format.eq_ignore_ascii_case("safetensors")),
+            "lm-studio cannot run safetensors, so it must not appear as a candidate"
+        );
+    }
+
+    #[tokio::test]
+    async fn select_variants_auto_selects_when_only_one_candidate_without_prompting() {
+        let capture = Arc::new(CaptureUi::default());
+        let mut ctx = crate::AppContext {
+            config: Config::default(),
+            ui: capture.clone(),
+        };
+
+        // granite-docling-258M-mlx has exactly one (safetensors) variant;
+        // openai-compatible's default `can_run_model` accepts any format.
+        let md = MODEL_REGISTRY
+            .get("granite-docling-258M-mlx")
+            .expect("fixture model should exist in the catalog");
+        assert_eq!(md.variants.len(), 1, "fixture assumption: exactly one variant");
+
+        let discovery = DiscoveryResult {
+            recommendations: vec![model_recommendation(
+                "granite-docling-258M-mlx",
+                &md,
+                md.variants[0].clone(),
+            )],
+            configured_provider_ids: vec![],
+            configured_model_ids: vec![],
+            configured_launcher_ids: vec![],
+            configured_capability_ids: vec![],
+        };
+        let selected_models: HashSet<String> =
+            ["granite-docling-258M-mlx".to_string()].into_iter().collect();
+        let selected_providers: HashSet<String> =
+            ["openai-compatible".to_string()].into_iter().collect();
+
+        let chosen = SetupCommands::select_variants(&mut ctx, &discovery, &selected_models, &selected_providers)
+            .await
+            .unwrap();
+
+        let picked = chosen
+            .get("granite-docling-258M-mlx")
+            .expect("should have auto-selected the sole candidate");
+        assert_eq!(picked.format, md.variants[0].format);
+        assert_eq!(picked.precision, md.variants[0].precision);
+        assert!(
+            capture.select_prompts.borrow().is_empty(),
+            "a model with only one compatible variant should not prompt"
+        );
+    }
+
+    #[tokio::test]
+    async fn select_variants_defaults_to_discoverys_best_variant() {
+        let capture = Arc::new(CaptureUi::default());
+        let mut ctx = crate::AppContext {
+            config: Config::default(),
+            ui: capture.clone(),
+        };
+
+        let md = MODEL_REGISTRY
+            .get("granite-vision-4.1-4b")
+            .expect("fixture model should exist in the catalog");
+        let gguf_variants: Vec<ModelVariant> = md
+            .variants
+            .iter()
+            .filter(|v| v.format.eq_ignore_ascii_case("gguf"))
+            .cloned()
+            .collect();
+        assert!(
+            gguf_variants.len() > 1,
+            "fixture assumption: multiple GGUF variants, so a real choice is offered"
+        );
+        let recommended = gguf_variants[gguf_variants.len() / 2].clone();
+
+        let discovery = DiscoveryResult {
+            recommendations: vec![model_recommendation(
+                "granite-vision-4.1-4b",
+                &md,
+                recommended.clone(),
+            )],
+            configured_provider_ids: vec![],
+            configured_model_ids: vec![],
+            configured_launcher_ids: vec![],
+            configured_capability_ids: vec![],
+        };
+        let selected_models: HashSet<String> =
+            ["granite-vision-4.1-4b".to_string()].into_iter().collect();
+        let selected_providers: HashSet<String> = ["lm-studio".to_string()].into_iter().collect();
+
+        // No canned select answer -- CaptureUi::select falls back to
+        // whatever `default` it was passed, so this proves that default
+        // index actually points at discovery's recommended variant.
+        let chosen = SetupCommands::select_variants(&mut ctx, &discovery, &selected_models, &selected_providers)
+            .await
+            .unwrap();
+
+        let picked = chosen
+            .get("granite-vision-4.1-4b")
+            .expect("should have selected a variant");
+        assert_eq!(picked.format, recommended.format);
+        assert_eq!(picked.precision, recommended.precision);
+        assert_eq!(capture.select_prompts.borrow().len(), 1);
+    }
+
     // -- SetupCommands ---------------------------------------------------------
 
     #[tokio::test]
@@ -1745,4 +2023,3 @@ mod tests {
         );
     }
 }
-

--- a/src/commands/setup.rs
+++ b/src/commands/setup.rs
@@ -1,7 +1,9 @@
+// Standard
+use std::collections::{HashMap, HashSet};
+
 // Third Party
 use alog::{MessageLevel, alog_channel, use_channel};
 use anyhow::Result;
-use std::collections::{HashMap, HashSet};
 
 // Local
 use crate::capabilities::{BindingType, CAPABILITY_REGISTRY, Dependency, ModelRequirement};

--- a/src/commands/setup.rs
+++ b/src/commands/setup.rs
@@ -44,6 +44,11 @@ pub enum Recommendation {
 /// The complete output of the discovery engine.
 pub struct DiscoveryResult {
     pub recommendations: Vec<Recommendation>,
+    /// Every unconfigured model with at least a partial hardware fit, one
+    /// entry per catalog model_id (not deduplicated by family/version like
+    /// `recommendations` is). Used by the "choose different models" escape
+    /// hatch so a user can see and pick models that don't fully fit.
+    pub all_model_candidates: Vec<Recommendation>,
     pub configured_provider_ids: Vec<String>,
     pub configured_model_ids: Vec<String>,
     pub configured_launcher_ids: Vec<String>,
@@ -61,6 +66,7 @@ impl Discover {
     pub async fn run(ctx: &crate::AppContext) -> DiscoveryResult {
         let (provider_recs, configured_providers) = Self::discover_providers(ctx).await;
         let model_recs = Self::discover_models(ctx, &configured_providers);
+        let all_model_candidates = Self::discover_all_model_candidates(ctx, &configured_providers);
         let (launcher_recs, configured_launchers) = Self::discover_launchers(ctx).await;
         let (capability_recs, configured_capabilities) = Self::discover_capabilities(
             ctx,
@@ -80,6 +86,7 @@ impl Discover {
 
         DiscoveryResult {
             recommendations,
+            all_model_candidates,
             configured_provider_ids: configured_providers,
             configured_model_ids: ctx.config.models.keys().cloned().collect(),
             configured_launcher_ids: configured_launchers,
@@ -174,44 +181,90 @@ impl Discover {
         let mut recommendations: Vec<Recommendation> = Vec::new();
 
         for models in family_groups.values() {
-            // Find latest version in this family
-            let latest = find_latest_version(models);
+            // Find the latest version string present in this family (a
+            // family can release several sizes at the same version, e.g.
+            // granite-4.2-3b/8b/30b are all version "4.2").
+            let Some((_, sample)) = find_latest_version(models) else {
+                continue;
+            };
+            let latest_version = &sample.version;
 
-            if let Some((model_id, latest_model)) = latest {
-                // Find best variant for this model
-                if let Some((best_variant, best_fit)) = best_variant(latest_model, &profile) {
-                    // Check which configured providers can run this variant
-                    let can_run_by = Self::find_can_run_providers(
-                        &best_variant,
-                        configured_provider_ids,
-                        ctx,
-                    );
+            // Among every size released at that version, recommend only
+            // the largest one that *fully* fits the current hardware.
+            // Partially-fitting models are never auto-recommended here --
+            // the user can still reach them via `select_models_manually`.
+            let best = models
+                .iter()
+                .filter(|(_, md)| &md.version == latest_version)
+                .filter_map(|(id, md)| {
+                    Self::build_model_recommendation(id, md, &profile, configured_provider_ids, ctx, true)
+                })
+                .max_by_key(|rec| match rec {
+                    Recommendation::Model { size, .. } => parse_size(size),
+                    _ => 0,
+                });
 
-                    recommendations.push(Recommendation::Model {
-                        model_id: model_id.clone(),
-                        family: latest_model.family.clone(),
-                        version: latest_model.version.clone(),
-                        size: format_size(latest_model.size),
-                        model_type: latest_model.model_type.clone(),
-                        best_variant,
-                        context_fit: best_fit,
-                        can_run_by,
-                    });
-                }
+            if let Some(rec) = best {
+                recommendations.push(rec);
             }
         }
 
-        // Sort by family, then version desc, then size desc
-        recommendations.sort_by(|a, b| {
-            let (a_family, a_version, a_size) = model_sort_key(a);
-            let (b_family, b_version, b_size) = model_sort_key(b);
-            a_family
-                .cmp(b_family)
-                .then_with(|| compare_versions_desc(a_version, b_version))
-                .then_with(|| b_size.cmp(&a_size))
-        });
-
+        sort_model_recommendations(&mut recommendations);
         recommendations
+    }
+
+    /// Every unconfigured model with at least a partial fit, one entry per
+    /// catalog model_id -- the full pool "choose different models" picks
+    /// from, unfiltered by the "only fully-fitting" / "one per family" rules
+    /// `discover_models` applies for the default recommendation.
+    fn discover_all_model_candidates(
+        ctx: &crate::AppContext,
+        configured_provider_ids: &[String],
+    ) -> Vec<Recommendation> {
+        let profile = detect_hardware();
+        let configured_ids: HashSet<&str> = ctx.config.models.keys().map(|s| s.as_str()).collect();
+
+        let mut recommendations: Vec<Recommendation> = MODEL_REGISTRY
+            .entries()
+            .into_iter()
+            .filter(|(model_id, _)| !configured_ids.contains(*model_id))
+            .filter_map(|(model_id, md)| {
+                Self::build_model_recommendation(model_id, &md, &profile, configured_provider_ids, ctx, false)
+            })
+            .collect();
+
+        sort_model_recommendations(&mut recommendations);
+        recommendations
+    }
+
+    /// Builds a `Recommendation::Model` for `model_id` using its best-fitting
+    /// variant for `profile`. When `require_full_fit` is true, only a
+    /// `ContextFit::Full` result is accepted (used for the default,
+    /// one-per-family recommendation); otherwise any non-`None` fit is
+    /// accepted (used for the full candidate pool).
+    fn build_model_recommendation(
+        model_id: &str,
+        md: &ModelMetadata,
+        profile: &crate::utils::hardware::HardwareProfile,
+        configured_provider_ids: &[String],
+        ctx: &crate::AppContext,
+        require_full_fit: bool,
+    ) -> Option<Recommendation> {
+        let (variant, fit) = best_variant(md, profile)?;
+        if require_full_fit && fit != ContextFit::Full {
+            return None;
+        }
+        let can_run_by = Self::find_can_run_providers(&variant, configured_provider_ids, ctx);
+        Some(Recommendation::Model {
+            model_id: model_id.to_string(),
+            family: md.family.clone(),
+            version: md.version.clone(),
+            size: format_size(md.size),
+            model_type: md.model_type.clone(),
+            best_variant: variant,
+            context_fit: fit,
+            can_run_by,
+        })
     }
 
     fn find_can_run_providers(
@@ -432,7 +485,7 @@ impl Revaluator {
     /// Filter model recommendations to only those that would be used by at least
     /// one selected capability (i.e., satisfy the capability's `ModelRequirement`).
     fn for_models<'a>(
-        discovery: &'a DiscoveryResult,
+        recommendations: &'a [Recommendation],
         selected_cap_types: &HashSet<String>,
     ) -> Vec<&'a Recommendation> {
         // Collect all model requirements from selected capabilities
@@ -456,15 +509,13 @@ impl Revaluator {
 
         if all_requirements.is_empty() {
             // No model requirements — show all model recommendations
-            return discovery
-                .recommendations
+            return recommendations
                 .iter()
                 .filter(|r| matches!(r, Recommendation::Model { .. }))
                 .collect();
         }
 
-        discovery
-            .recommendations
+        recommendations
             .iter()
             .filter(move |r| {
                 if let Recommendation::Model { model_id, .. } = r {
@@ -637,6 +688,20 @@ fn model_sort_key(rec: &Recommendation) -> (&str, &str, u64) {
     }
 }
 
+/// Sorts model recommendations by family, then version descending, then
+/// size descending -- shared by every discovery pass that produces a list
+/// of `Recommendation::Model`.
+fn sort_model_recommendations(recommendations: &mut [Recommendation]) {
+    recommendations.sort_by(|a, b| {
+        let (a_family, a_version, a_size) = model_sort_key(a);
+        let (b_family, b_version, b_size) = model_sort_key(b);
+        a_family
+            .cmp(b_family)
+            .then_with(|| compare_versions_desc(a_version, b_version))
+            .then_with(|| b_size.cmp(&a_size))
+    });
+}
+
 /*-- SetupCommands -----------------------------------------------------------*/
 
 pub struct SetupCommands;
@@ -763,7 +828,7 @@ impl SetupCommands {
             })
             .collect();
 
-        let selected_models: HashSet<String> = Revaluator::for_models(&discovery, &selected_caps)
+        let selected_models: HashSet<String> = Revaluator::for_models(&discovery.recommendations, &selected_caps)
             .into_iter()
             .filter_map(|r| match r {
                 Recommendation::Model { model_id, .. } => Some(model_id.clone()),
@@ -879,7 +944,7 @@ impl SetupCommands {
             .iter()
             .map(|(id, name, path)| format!("{} — {} ({})", id, name, path))
             .collect();
-        let defaults = vec![true; items.len()];
+        let defaults = vec![false; items.len()];
 
         let selected = ui.multi_select(
             "Select launchers to configure",
@@ -1073,6 +1138,34 @@ impl SetupCommands {
         }
     }
 
+    /// Label for the extra row appended to the default model list that
+    /// hands off to `select_models_manually`.
+    const CHOOSE_DIFFERENT_MODELS_LABEL: &'static str = "→ Choose different models…";
+
+    fn format_model_option(id: &str, size: &str, fit: ContextFit, providers: &[String]) -> String {
+        let providers_str = if providers.is_empty() {
+            "none".to_string()
+        } else {
+            providers.join(", ")
+        };
+        format!("{id} — {size} — Fit: {fit} ({providers_str})")
+    }
+
+    fn model_options(recs: Vec<&Recommendation>) -> Vec<(String, String, ContextFit, Vec<String>)> {
+        recs.into_iter()
+            .filter_map(|r| match r {
+                Recommendation::Model {
+                    model_id,
+                    size,
+                    context_fit,
+                    can_run_by,
+                    ..
+                } => Some((model_id.clone(), size.clone(), *context_fit, can_run_by.clone())),
+                _ => None,
+            })
+            .collect()
+    }
+
     async fn select_models(
         ctx: &mut crate::AppContext,
         discovery: &DiscoveryResult,
@@ -1080,60 +1173,72 @@ impl SetupCommands {
     ) -> Result<HashSet<String>> {
         let ui = &*ctx.ui;
 
-        let filtered: Vec<_> = Revaluator::for_models(discovery, selected_caps)
-            .into_iter()
-            .filter_map(|r| match r {
-                Recommendation::Model {
-                    model_id,
-                    family,
-                    version,
-                    size,
-                    model_type,
-                    best_variant,
-                    context_fit,
-                    can_run_by,
-                } => Some((
-                    model_id.clone(),
-                    family,
-                    version,
-                    size,
-                    model_type,
-                    best_variant,
-                    context_fit,
-                    can_run_by,
-                )),
-                _ => None,
-            })
-            .collect();
+        let filtered = Self::model_options(Revaluator::for_models(&discovery.recommendations, selected_caps));
+
+        let mut chosen: HashSet<String> = HashSet::new();
+        let mut choose_different = filtered.is_empty();
 
         if filtered.is_empty() {
-            ui.info("No models available for the selected capabilities.");
+            ui.info("No models fully fit your hardware for the selected capabilities.");
+        } else {
+            let escape_hatch_idx = filtered.len();
+            let mut items: Vec<String> = filtered
+                .iter()
+                .map(|(id, size, fit, providers)| Self::format_model_option(id, size, *fit, providers))
+                .collect();
+            items.push(Self::CHOOSE_DIFFERENT_MODELS_LABEL.to_string());
+
+            let mut defaults = vec![true; filtered.len()];
+            defaults.push(false);
+
+            let selected = ui.multi_select("Select models to configure", &items, &defaults)?;
+
+            choose_different = selected.contains(&escape_hatch_idx);
+            chosen = selected
+                .into_iter()
+                .filter(|&i| i < escape_hatch_idx)
+                .map(|i| filtered[i].0.clone())
+                .collect();
+        }
+
+        if choose_different {
+            let manual = Self::select_models_manually(ctx, discovery, selected_caps).await?;
+            chosen.extend(manual);
+        }
+
+        Ok(chosen)
+    }
+
+    /// Escape hatch from `select_models`: lets the user pick directly from
+    /// every model that satisfies the selected capabilities' requirements,
+    /// regardless of family/version deduplication or hardware fit (so long
+    /// as it fits at least partially) -- with each option's fit value shown,
+    /// including partial fits `discover_models` excludes from the default
+    /// recommendation.
+    async fn select_models_manually(
+        ctx: &mut crate::AppContext,
+        discovery: &DiscoveryResult,
+        selected_caps: &HashSet<String>,
+    ) -> Result<HashSet<String>> {
+        let ui = &*ctx.ui;
+
+        let filtered = Self::model_options(Revaluator::for_models(
+            &discovery.all_model_candidates,
+            selected_caps,
+        ));
+
+        if filtered.is_empty() {
+            ui.info("No candidate models satisfy the selected capabilities.");
             return Ok(HashSet::new());
         }
 
         let items: Vec<String> = filtered
             .iter()
-            .map(|(id, _family, _version, size, _model_type, _variant, fit, providers)| {
-                let fit_str = match fit {
-                    ContextFit::Full => "Full".to_string(),
-                    ContextFit::Partial(_) => "Partial".to_string(),
-                    ContextFit::None => "None".to_string(),
-                };
-                let providers_str = if providers.is_empty() {
-                    "none".to_string()
-                } else {
-                    providers.join(", ")
-                };
-                format!("{} — {} — Fit: {} ({})", id, size, fit_str, providers_str)
-            })
+            .map(|(id, size, fit, providers)| Self::format_model_option(id, size, *fit, providers))
             .collect();
-        let defaults = vec![true; items.len()];
+        let defaults = vec![false; items.len()];
 
-        let selected = ui.multi_select(
-            "Select models to configure",
-            &items,
-            &defaults,
-        )?;
+        let selected = ui.multi_select("Choose models directly", &items, &defaults)?;
 
         Ok(selected
             .into_iter()
@@ -1546,6 +1651,70 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn discover_models_only_recommends_full_fit_and_picks_largest_full_fitting_size() {
+        // Granite Language 4.2 ships three sizes (3b/8b/30b) at the same
+        // version. The 30b only partially fits typical hardware -- it must
+        // never be the default recommendation, and whichever size *is*
+        // recommended must be a full fit.
+        let ctx = test_ctx();
+        let result = Discover::run(&ctx).await;
+
+        let rec = result
+            .recommendations
+            .iter()
+            .find(|r| matches!(r, Recommendation::Model { family, .. } if family == "Granite Language"));
+
+        if let Some(Recommendation::Model {
+            model_id,
+            context_fit,
+            ..
+        }) = rec
+        {
+            assert_eq!(
+                *context_fit,
+                ContextFit::Full,
+                "the default recommendation must fully fit, got {model_id} with {context_fit}"
+            );
+            assert_ne!(
+                model_id, "granite-4.2-30b",
+                "the 30b variant only partially fits on typical hardware and must not be auto-recommended"
+            );
+        }
+        // If no size fully fits, no recommendation for the family is also
+        // acceptable -- the important thing is a partial fit is never
+        // silently promoted to the default recommendation.
+    }
+
+    #[tokio::test]
+    async fn discover_all_model_candidates_includes_every_size_with_its_own_fit() {
+        let ctx = test_ctx();
+        let result = Discover::run(&ctx).await;
+
+        let granite_4_2: Vec<_> = result
+            .all_model_candidates
+            .iter()
+            .filter_map(|r| match r {
+                Recommendation::Model {
+                    model_id,
+                    family,
+                    version,
+                    ..
+                } if family == "Granite Language" && version == "4.2" => Some(model_id.as_str()),
+                _ => None,
+            })
+            .collect();
+
+        assert!(
+            granite_4_2.contains(&"granite-4.2-8b"),
+            "expected granite-4.2-8b among all-candidates, got {granite_4_2:?}"
+        );
+        assert!(
+            granite_4_2.contains(&"granite-4.2-30b"),
+            "the 30b size should still appear in the full candidate pool despite only partially fitting, got {granite_4_2:?}"
+        );
+    }
+
+    #[tokio::test]
     async fn discover_models_skips_configured() {
         let ctx = ctx_with_model(
             "granite-3.1-8b-instruct",
@@ -1705,7 +1874,7 @@ mod tests {
 
         // agent-model requires Chat + ToolCalling support.
         let selected_caps: HashSet<String> = ["agent-model".to_string()].into_iter().collect();
-        let filtered = Revaluator::for_models(&discovery, &selected_caps);
+        let filtered = Revaluator::for_models(&discovery.recommendations, &selected_caps);
 
         assert!(
             !filtered.is_empty(),
@@ -1730,7 +1899,7 @@ mod tests {
     async fn revaluator_for_models_with_no_requirements_returns_all() {
         let ctx = test_ctx();
         let discovery = Discover::run(&ctx).await;
-        let filtered = Revaluator::for_models(&discovery, &HashSet::new());
+        let filtered = Revaluator::for_models(&discovery.recommendations, &HashSet::new());
         let all_models: Vec<_> = discovery
             .recommendations
             .iter()
@@ -1853,6 +2022,7 @@ mod tests {
                 &md,
                 md.variants[0].clone(),
             )],
+            all_model_candidates: vec![],
             configured_provider_ids: vec![],
             configured_model_ids: vec![],
             configured_launcher_ids: vec![],
@@ -1907,6 +2077,7 @@ mod tests {
                 &md,
                 recommended.clone(),
             )],
+            all_model_candidates: vec![],
             configured_provider_ids: vec![],
             configured_model_ids: vec![],
             configured_launcher_ids: vec![],
@@ -1929,6 +2100,62 @@ mod tests {
         assert_eq!(picked.format, recommended.format);
         assert_eq!(picked.precision, recommended.precision);
         assert_eq!(capture.select_prompts.borrow().len(), 1);
+    }
+
+    #[tokio::test]
+    async fn select_models_choose_different_models_surfaces_partial_fit_candidates() {
+        let capture = Arc::new(CaptureUi::default());
+        let mut ctx = crate::AppContext {
+            config: Config::default(),
+            ui: capture.clone(),
+        };
+
+        let discovery = Discover::run(&ctx).await;
+        let selected_caps: HashSet<String> = ["agent-model".to_string()].into_iter().collect();
+
+        // granite-4.2-30b only partially fits, so it must not be in the
+        // default recommendation list, but must be reachable through
+        // "choose different models".
+        let default_ids: HashSet<&str> = Revaluator::for_models(&discovery.recommendations, &selected_caps)
+            .into_iter()
+            .filter_map(|r| match r {
+                Recommendation::Model { model_id, .. } => Some(model_id.as_str()),
+                _ => None,
+            })
+            .collect();
+        assert!(
+            !default_ids.contains("granite-4.2-30b"),
+            "granite-4.2-30b only partially fits and must not be a default recommendation"
+        );
+
+        let manual_candidates = Revaluator::for_models(&discovery.all_model_candidates, &selected_caps);
+        let thirty_b_idx = manual_candidates
+            .iter()
+            .position(|r| matches!(r, Recommendation::Model { model_id, .. } if model_id == "granite-4.2-30b"))
+            .expect("granite-4.2-30b should be a manual candidate");
+
+        // First multi_select (the default list): pick only the escape hatch
+        // row (its index is the number of default items).
+        let default_count = default_ids.len();
+        capture
+            .multi_select_answers
+            .borrow_mut()
+            .push_back(vec![default_count]);
+        // Second multi_select (the manual list): pick granite-4.2-30b.
+        capture
+            .multi_select_answers
+            .borrow_mut()
+            .push_back(vec![thirty_b_idx]);
+
+        let chosen = SetupCommands::select_models(&mut ctx, &discovery, &selected_caps)
+            .await
+            .unwrap();
+
+        assert_eq!(
+            chosen,
+            HashSet::from(["granite-4.2-30b".to_string()]),
+            "should have picked exactly the manually-chosen partial-fit model"
+        );
     }
 
     // -- SetupCommands ---------------------------------------------------------
@@ -1970,6 +2197,7 @@ mod tests {
                     binary_path: None,
                 },
             ],
+            all_model_candidates: vec![],
             configured_provider_ids: vec![],
             configured_model_ids: vec![],
             configured_launcher_ids: vec![],
@@ -2023,3 +2251,4 @@ mod tests {
         );
     }
 }
+

--- a/src/commands/setup.rs
+++ b/src/commands/setup.rs
@@ -1,4 +1,5 @@
 // Third Party
+use alog::{MessageLevel, alog_channel, use_channel};
 use anyhow::Result;
 use std::collections::{HashMap, HashSet};
 
@@ -9,6 +10,8 @@ use crate::launchers::LAUNCHER_REGISTRY;
 use crate::models::{ContextFit, MODEL_REGISTRY, ModelMetadata, ModelType, ModelVariant};
 use crate::providers::{HealthStatus, PROVIDER_REGISTRY, Provider};
 use crate::utils::hardware::detect_hardware;
+
+use_channel!("SETUP");
 
 /*-- public --*/
 
@@ -1004,7 +1007,7 @@ impl SetupCommands {
                 format!("{} — {} ({})", id, name, status)
             })
             .collect();
-        let defaults = vec![true; items.len()];
+        let defaults = vec![false; items.len()];
 
         let selected = ui.multi_select(
             "Select providers to configure",
@@ -1459,6 +1462,7 @@ impl SetupCommands {
             .collect();
 
         if pullable.is_empty() {
+            alog_channel!(MessageLevel::Debug2, "No pullable models");
             return Ok(());
         }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -20,6 +20,7 @@ use clap::{Parser, Subcommand};
 // Local
 use commands::{
     CapabilityCommands, HardwareCommands, LauncherCommands, ModelCommands, ProviderCommands,
+    SetupCommands,
 };
 use utils::ui::{UI_REGISTRY, Ui, run_interactive_tui};
 
@@ -130,6 +131,20 @@ enum Commands {
 
     /// Launcher management commands
     Launcher(LauncherWithOutput),
+
+    /// Unified setup wizard: discover and configure providers, models, launchers,
+    /// and capabilities in a single guided flow.
+    Setup {
+        /// Auto-detect and configure everything that can be auto-configured.
+        /// Consent is implied. Uses registry defaults for all config fields.
+        #[arg(long)]
+        auto: bool,
+
+        /// Skip the model weight pull prompt at the end of the wizard.
+        /// Model weights are never auto-pulled in --auto mode regardless.
+        #[arg(long)]
+        skip_pull: bool,
+    },
 
     /// Show hardware profile and recommended precision
     Hardware,
@@ -489,6 +504,18 @@ async fn main() {
                 log_thread_id,
             );
             run_launcher_command(&mut ctx, wrapper.subcommand)
+                .await
+                .map_err(|e| ctx.ui.error(&e.to_string()))
+        }
+        Some(Commands::Setup { auto, skip_pull }) => {
+            let mut ctx = construct_context(
+                "terminal",
+                &log_level,
+                &log_filters,
+                log_json,
+                log_thread_id,
+            );
+            SetupCommands::run(&mut ctx, auto, skip_pull)
                 .await
                 .map_err(|e| ctx.ui.error(&e.to_string()))
         }

--- a/src/models/context_fit.rs
+++ b/src/models/context_fit.rs
@@ -101,8 +101,12 @@ pub(crate) fn estimate(
 
 /// Total memory (weights + KV cache / recurrent state, with runtime
 /// overhead) required to run `variant` at `context_tokens` tokens of
-/// context.
-fn required_gb(
+/// context, in gigabytes. Exposed beyond this module (e.g. to the setup
+/// wizard) so a variant's estimated VRAM/RAM footprint can be shown
+/// alongside it wherever the model's `ModelArchitecture` and `native_dtype`
+/// are available -- most usefully at `context_tokens = model.context_length`
+/// for a "full context" estimate.
+pub fn required_gb(
     architecture: &ModelArchitecture,
     variant: &ModelVariant,
     native_dtype: &str,

--- a/src/models/mod.rs
+++ b/src/models/mod.rs
@@ -151,7 +151,7 @@ pub use base::{
 };
 
 pub(crate) mod context_fit;
-pub use context_fit::ContextFit;
+pub use context_fit::{ContextFit, required_gb};
 
 pub mod huggingface;
 


### PR DESCRIPTION
## Description

This PR introduces a new command: `granite-cli setup`. This is meant to be a one-stop command for configuring everything end-to-end. It works by inspecting he user's system for pre-installed agents (by their default command) and providers (by their default health check), then walking the user through selecting launcher(s) to configure -> capabilities to enable -> models to use -> providers to serve.

## Changes

- Add new `setup` command with plumbing
- Expose `required_gb` out of `context_fit.rs`

## Testing

- Unit tests
- Manual testing on MacBook Pro M3 w/ the following installed:
  - Agents: `claude`, `bob`, `opencode`, `pi`, `goose`
  - Providers: `ollama`, `lm-studio`
- Manual testing on GB10 w/ the following installed:
  - Agents: `opencode`
  - Providers: `ollama`

## Related Issue(s)

Closes #83 

## AI Usage

This was built with Claude Code, using `granite4.2:3b` as a local sub-agent. All commits were hand authored and the Claude session was steered many times to handle UX improvements as I tested.

```sh
╔══════════════════════════════════════════════════════════╗
║           GIT AI USAGE ANALYSIS                          ║
╚══════════════════════════════════════════════════════════╝

📊 COMMITS BY AGENT

--- Aggregate ---
Commits                        |      Count
---------------------------------------------
Claude + Sonnet 5              |          5
none                           |          2
OpenCode + Qwen3.6-35b + granite4.2:3b, Claude + Sonnet 5 + granite4.2:3b |          2
---------------------------------------------
TOTAL                          |          9

📊 COMMITS BY USAGE TYPE

--- Aggregate ---
Commits                        |      Count
---------------------------------------------
none                           |          2
draft                          |          1
full                           |          6
---------------------------------------------
TOTAL                          |          9

📈 LINES OF CODE BY AGENT

--- Aggregate ---
Agent                     |    Commits |  Additions |  Deletions
------------------------------------------------------------
Claude + Sonnet 5         |          5 |        954 |        134
none                      |          2 |        252 |        177
OpenCode + Qwen3.6-35b + granite4.2:3b, Claude + Sonnet 5 + granite4.2:3b |          2 |       2107 |          0
------------------------------------------------------------
TOTAL                     |          9 |       3313 |        311

📈 LINES OF CODE BY USAGE TYPE

--- Aggregate ---
Usage Type           |    Commits |  Additions |  Deletions
-------------------------------------------------------
none                 |          2 |        252 |        177
draft                |          1 |        314 |         85
full                 |          6 |       2747 |         49
-------------------------------------------------------
TOTAL                |          9 |       3313 |        311
```