### PR TITLE
Custom models

### DIFF
--- a/src/capabilities/agent_model.rs
+++ b/src/capabilities/agent_model.rs
@@ -266,6 +266,8 @@ mod tests {
             "granite-3.1-8b-instruct".to_string(),
             ModelConfig {
                 model_id: "granite-3.1-8b-instruct".to_string(),
+                model_type: "granite-3.1-8b-instruct".to_string(),
+                config: serde_json::json!({}),
                 provider_id: None,
                 variant: variant_str.clone(),
             },
@@ -476,6 +478,8 @@ mod tests {
             "granite-3.1-8b-instruct".to_string(),
             ModelConfig {
                 model_id: "granite-3.1-8b-instruct".to_string(),
+                model_type: "granite-3.1-8b-instruct".to_string(),
+                config: serde_json::json!({}),
                 provider_id: None,
                 variant: None,
             },
@@ -498,6 +502,8 @@ mod tests {
             "granite-3.1-8b-instruct".to_string(),
             ModelConfig {
                 model_id: "granite-3.1-8b-instruct".to_string(),
+                model_type: "granite-3.1-8b-instruct".to_string(),
+                config: serde_json::json!({}),
                 provider_id: None,
                 variant: None,
             },

--- a/src/capabilities/mod.rs
+++ b/src/capabilities/mod.rs
@@ -126,6 +126,8 @@ mod tests {
             "granite-3.1-8b-instruct".to_string(),
             ModelConfig {
                 model_id: "granite-3.1-8b-instruct".to_string(),
+                model_type: "granite-3.1-8b-instruct".to_string(),
+                config: serde_json::json!({}),
                 provider_id: None,
                 variant: None,
             },

--- a/src/capabilities/sub_agent.rs
+++ b/src/capabilities/sub_agent.rs
@@ -313,6 +313,8 @@ mod tests {
             "granite-3.1-8b-instruct".to_string(),
             ModelConfig {
                 model_id: "granite-3.1-8b-instruct".to_string(),
+                model_type: "granite-3.1-8b-instruct".to_string(),
+                config: serde_json::json!({}),
                 provider_id: None,
                 variant: None,
             },
@@ -350,6 +352,8 @@ mod tests {
             "granite-3.1-8b-instruct".to_string(),
             ModelConfig {
                 model_id: "granite-3.1-8b-instruct".to_string(),
+                model_type: "granite-3.1-8b-instruct".to_string(),
+                config: serde_json::json!({}),
                 provider_id: None,
                 variant: None,
             },

--- a/src/capabilities/sub_agent_explore.rs
+++ b/src/capabilities/sub_agent_explore.rs
@@ -361,6 +361,8 @@ mod tests {
             "granite-3.1-8b-instruct".to_string(),
             ModelConfig {
                 model_id: "granite-3.1-8b-instruct".to_string(),
+                model_type: "granite-3.1-8b-instruct".to_string(),
+                config: serde_json::json!({}),
                 provider_id: None,
                 variant: None,
             },
@@ -399,6 +401,8 @@ mod tests {
             "granite-3.1-8b-instruct".to_string(),
             ModelConfig {
                 model_id: "granite-3.1-8b-instruct".to_string(),
+                model_type: "granite-3.1-8b-instruct".to_string(),
+                config: serde_json::json!({}),
                 provider_id: None,
                 variant: None,
             },

--- a/src/capabilities/sub_agent_plan.rs
+++ b/src/capabilities/sub_agent_plan.rs
@@ -387,6 +387,8 @@ mod tests {
             "granite-3.1-8b-instruct".to_string(),
             ModelConfig {
                 model_id: "granite-3.1-8b-instruct".to_string(),
+                model_type: "granite-3.1-8b-instruct".to_string(),
+                config: serde_json::json!({}),
                 provider_id: None,
                 variant: None,
             },
@@ -425,6 +427,8 @@ mod tests {
             "granite-3.1-8b-instruct".to_string(),
             ModelConfig {
                 model_id: "granite-3.1-8b-instruct".to_string(),
+                model_type: "granite-3.1-8b-instruct".to_string(),
+                config: serde_json::json!({}),
                 provider_id: None,
                 variant: None,
             },

--- a/src/capabilities/vision_mcp/mod.rs
+++ b/src/capabilities/vision_mcp/mod.rs
@@ -392,6 +392,8 @@ mod tests {
             "granite-3.1-8b-instruct".to_string(),
             ModelConfig {
                 model_id: "granite-3.1-8b-instruct".to_string(),
+                model_type: "granite-3.1-8b-instruct".to_string(),
+                config: serde_json::json!({}),
                 provider_id: None,
                 variant: None,
             },

--- a/src/commands/capability.rs
+++ b/src/commands/capability.rs
@@ -331,7 +331,7 @@ impl CapabilityCommands {
             configurable_types[index]
         };
 
-        ModelCommands::setup(ctx, model_type).await?;
+        ModelCommands::setup(ctx, model_type, None).await?;
 
         let (usable_after, _) = Self::model_candidates(ctx, requirement);
         let new_usable: Vec<_> = usable_after

--- a/src/commands/capability.rs
+++ b/src/commands/capability.rs
@@ -655,6 +655,8 @@ mod tests {
             "granite-3.1-8b-instruct".to_string(),
             ModelConfig {
                 model_id: "granite-3.1-8b-instruct".to_string(),
+                model_type: "granite-3.1-8b-instruct".to_string(),
+                config: serde_json::json!({}),
                 provider_id: Some("ollama".to_string()),
                 variant: None,
             },
@@ -704,6 +706,8 @@ mod tests {
             "granite-3.1-8b-instruct".to_string(),
             ModelConfig {
                 model_id: "granite-3.1-8b-instruct".to_string(),
+                model_type: "granite-3.1-8b-instruct".to_string(),
+                config: serde_json::json!({}),
                 provider_id: None,
                 variant: None,
             },

--- a/src/commands/launcher.rs
+++ b/src/commands/launcher.rs
@@ -620,6 +620,8 @@ mod tests {
             model_id.to_string(),
             crate::config::ModelConfig {
                 model_id: model_id.to_string(),
+                model_type: model_id.to_string(),
+                config: serde_json::json!({}),
                 provider_id: None,
                 variant: None,
             },

--- a/src/commands/model.rs
+++ b/src/commands/model.rs
@@ -4,12 +4,15 @@ use anyhow::Result;
 // Local
 use crate::commands::ProviderCommands;
 use crate::dependency::{self, Configured, DependsOn, Requirement};
-use crate::models::{ContextFit, MODEL_REGISTRY, ModelMetadata, ModelType, ModelVariant};
+use crate::models::{
+    ContextFit, MODEL_REGISTRY, ModelMetadata, ModelSource, ModelType, ModelVariant,
+};
 use crate::providers::{
     PROVIDER_REGISTRY, Provider, ProviderMetadata, ProviderSource, ProviderType, PullResult,
 };
 use crate::utils::Searchable;
 use crate::utils::hardware::detect_hardware;
+use crate::utils::prompt_from_schema;
 use crate::utils::ui::Ui;
 
 /// Compare semantic versions in descending order (higher versions first).
@@ -72,6 +75,33 @@ impl Requirement<dyn Provider> for VariantRequirement {
 }
 
 impl DependsOn<dyn Provider> for VariantRequirement {
+    type Requirement = Self;
+
+    fn requirement(&self) -> Self {
+        self.clone()
+    }
+}
+
+/// Fallback dependency for a model with no declared variants -- the expected
+/// shape for most custom models, which describe an endpoint that's already
+/// running rather than an artifact `granite-cli` would pull. Admits every
+/// provider type/instance unconditionally, so `select_provider` still offers
+/// "use an existing provider" / "configure a new one" without filtering by
+/// format/precision.
+#[derive(Clone)]
+struct AnyProviderRequirement;
+
+impl Requirement<dyn Provider> for AnyProviderRequirement {
+    fn admits_type(&self, _metadata: &ProviderMetadata) -> bool {
+        true
+    }
+
+    fn admits_instance(&self, _instance: &dyn Provider) -> bool {
+        true
+    }
+}
+
+impl DependsOn<dyn Provider> for AnyProviderRequirement {
     type Requirement = Self;
 
     fn requirement(&self) -> Self {
@@ -377,28 +407,30 @@ impl ModelCommands {
     }
 
     pub fn list(ctx: &crate::AppContext, filter_type: Option<ModelType>) -> Result<()> {
+        let source = ModelSource::from_config(&ctx.config);
         let mut enriched: Vec<(Vec<String>, ModelMetadata)> = Vec::new();
 
-        for (model_id, model_config) in &ctx.config.models {
-            if let Some(model_md) = MODEL_REGISTRY.get(model_id) {
-                if let Some(ref t) = filter_type
-                    && model_md.model_type != *t
-                {
-                    continue;
-                }
-                let row = vec![
-                    model_id.clone(),
-                    model_md.family.clone(),
-                    model_md.format_size(),
-                    model_md.context_length.to_string(),
-                    model_md.model_type.to_string(),
-                    model_config
-                        .provider_id
-                        .clone()
-                        .unwrap_or_else(|| "None".to_string()),
-                ];
-                enriched.push((row, model_md.clone()));
+        for (instance_id, model) in source.instances() {
+            let md = model.to_metadata();
+            if let Some(ref t) = filter_type
+                && md.model_type != *t
+            {
+                continue;
             }
+            let provider_id = ctx
+                .config
+                .get_model(&instance_id)
+                .and_then(|c| c.provider_id.clone())
+                .unwrap_or_else(|| "None".to_string());
+            let row = vec![
+                instance_id.clone(),
+                md.family.clone(),
+                md.format_size(),
+                md.context_length.to_string(),
+                md.model_type.to_string(),
+                provider_id,
+            ];
+            enriched.push((row, md));
         }
         sort_enriched_rows(&mut enriched);
 
@@ -412,10 +444,10 @@ impl ModelCommands {
         Ok(())
     }
 
-    /// Key-value fields for model detail. Returns `None` if the ID is not in the registry.
-    /// Shared by the CLI command and the TUI.
-    pub(crate) fn info_fields(model_id: &str) -> Option<Vec<(&'static str, String)>> {
-        let model = MODEL_REGISTRY.get(model_id)?;
+    /// Key-value fields describing `model`'s data -- shared by the catalog
+    /// path (`info_fields`, a static registry lookup) and `info`'s
+    /// configured-instance path (a live constructed model's real values).
+    fn metadata_fields(model: &ModelMetadata) -> Vec<(&'static str, String)> {
         let mut fields: Vec<(&'static str, String)> = vec![
             ("Family", model.family.clone()),
             ("Version", model.version.clone()),
@@ -449,23 +481,52 @@ impl ModelCommands {
             .collect::<Vec<_>>()
             .join(", ");
         fields.push(("Supported Functions", funcs_str));
-        Some(fields)
+        fields
     }
 
-    pub fn info(ctx: &crate::AppContext, model_id: &str) -> Result<()> {
-        match Self::info_fields(model_id) {
+    /// Key-value fields for a catalog model's detail. Returns `None` if the
+    /// registry key is not in the registry. Shared by the CLI command and
+    /// the TUI, which only ever browses the catalog, never a configured
+    /// instance's live values.
+    pub(crate) fn info_fields(model_type: &str) -> Option<Vec<(&'static str, String)>> {
+        MODEL_REGISTRY
+            .get(model_type)
+            .map(|m| Self::metadata_fields(&m))
+    }
+
+    pub fn info(ctx: &crate::AppContext, id: &str) -> Result<()> {
+        // Prefer a configured instance's real, live values (e.g. a custom
+        // model's user-entered fields aren't in the registry at all) --
+        // fall back to pure catalog browsing by registry key.
+        if let Some(model_config) = ctx.config.get_model(id) {
+            let source = ModelSource::from_config(&ctx.config);
+            if let Some((_, model)) = source.instances().into_iter().find(|(iid, _)| iid == id) {
+                let md = model.to_metadata();
+                let mut fields = Self::metadata_fields(&md);
+                fields.push(("Config: Type", model_config.model_type.clone()));
+                fields.push((
+                    "Config: Provider",
+                    format!("{:?}", model_config.provider_id),
+                ));
+                fields.push(("Config: Variant", format!("{:?}", model_config.variant)));
+                ctx.ui.detail(id, &fields);
+                return Ok(());
+            }
+        }
+
+        match Self::info_fields(id) {
             Some(mut fields) => {
-                if let Some(configured) = ctx.config.get_model(model_id) {
+                if let Some(configured) = ctx.config.get_model(id) {
                     fields.push(("Config: Provider", format!("{:?}", configured.provider_id)));
                     fields.push(("Config: Variant", format!("{:?}", configured.variant)));
                 }
 
-                ctx.ui.detail(model_id, &fields);
+                ctx.ui.detail(id, &fields);
                 Ok(())
             }
             None => {
                 ctx.ui
-                    .error(&format!("Model '{model_id}' not found in registry."));
+                    .error(&format!("Model '{id}' not found in registry."));
                 let available: Vec<_> = MODEL_REGISTRY
                     .entries()
                     .keys()
@@ -478,163 +539,201 @@ impl ModelCommands {
         }
     }
 
-    pub async fn setup(ctx: &mut crate::AppContext, model_id: &str) -> Result<()> {
-        match MODEL_REGISTRY.get(model_id) {
-            Some(model) => {
-                ctx.ui.info(&format!("\nSetting up model: {model_id}"));
-                ctx.ui.info(
-                    model
-                        .description
-                        .as_deref()
-                        .unwrap_or("No description available."),
-                );
-                ctx.ui.info("");
-                ctx.ui.info(&format!(
-                    "Size: {} params, {} context",
-                    model.format_size(),
-                    model.context_length
-                ));
-                ctx.ui.info(&format!("Type: {}", model.model_type));
-                ctx.ui.info("");
+    /// Interactive model setup wizard. `model_type` is the catalog/registry
+    /// key (e.g. `granite-3.1-8b-instruct`, or `custom`). `instance_id` is
+    /// this instance's nickname, distinct from its type -- defaults to
+    /// `model_type` when not given, but a caller may pass a different value
+    /// to configure multiple named instances of one type (e.g. the same
+    /// catalog model against two different providers, or several custom
+    /// models).
+    pub async fn setup(
+        ctx: &mut crate::AppContext,
+        model_type: &str,
+        instance_id: Option<&str>,
+    ) -> Result<()> {
+        let Some(placeholder) = MODEL_REGISTRY.get(model_type) else {
+            ctx.ui
+                .error(&format!("Model type '{model_type}' not found in registry."));
+            let available: Vec<_> = MODEL_REGISTRY
+                .entries()
+                .keys()
+                .map(|k| k.to_string())
+                .collect();
+            ctx.ui
+                .info(&format!("Available models: {}", available.join(", ")));
+            anyhow::bail!("Model not found");
+        };
 
-                let variant_options: Vec<_> = model
-                    .variants
-                    .iter()
-                    .map(|v| match (v.size_gb, v.precision.is_empty()) {
-                        (Some(size), false) => {
-                            format!("{} / {} ({:.1} GB)", v.format, v.precision, size)
-                        }
-                        (Some(size), true) => format!("{} ({:.1} GB)", v.format, size),
-                        (None, false) => format!("{} / {}", v.format, v.precision),
-                        (None, true) => v.format.clone(),
-                    })
-                    .collect();
+        ctx.ui.info(&format!("\nSetting up model: {model_type}"));
+        ctx.ui.info(
+            placeholder
+                .description
+                .as_deref()
+                .unwrap_or("No description available."),
+        );
+        ctx.ui.info("");
+        ctx.ui.info(&format!(
+            "Size: {} params, {} context",
+            placeholder.format_size(),
+            placeholder.context_length
+        ));
+        ctx.ui.info(&format!("Type: {}", placeholder.model_type));
+        ctx.ui.info("");
 
-                let variant_index = ctx
-                    .ui
-                    .select("Select model variant:", &variant_options, 0)?;
+        let instance_id = match instance_id {
+            Some(id) => id.to_string(),
+            None => ctx.ui.text("Instance name: ", model_type)?,
+        };
 
-                let selected_variant = &model.variants[variant_index];
-                ctx.ui.info(&format!(
-                    "\nSelected: {} / {}",
-                    selected_variant.format, selected_variant.precision
-                ));
-
-                if ctx.config.get_model(model_id).is_some() {
-                    let overwrite = ctx.ui.confirm(
-                        &format!("Model '{model_id}' is already configured. Overwrite?"),
-                        false,
-                    )?;
-                    if !overwrite {
-                        ctx.ui.info("Model setup skipped.");
-                        return Ok(());
-                    }
-                }
-
-                let requirement = VariantRequirement {
-                    format: selected_variant.format.clone(),
-                    precision: selected_variant.precision.clone(),
-                };
-                let source = ProviderSource::from_config(&ctx.config);
-                let resolution = dependency::resolve(&requirement, &source);
-
-                let provider_id = Self::select_provider(ctx, &resolution).await?;
-
-                let model_config = crate::config::ModelConfig {
-                    model_id: model_id.to_string(),
-                    provider_id: provider_id.clone(),
-                    variant: Some(format!(
-                        "{}/{}",
-                        selected_variant.format, selected_variant.precision
-                    )),
-                };
-
-                if let Err(e) = ctx.config.insert_model(model_id, model_config) {
-                    ctx.ui.warn(&format!("failed to save model config: {e}"));
-                }
-
-                ctx.ui
-                    .info(&format!("\nModel '{model_id}' configured successfully!"));
-
-                if let Some(pid) = &provider_id {
-                    let is_local = ctx
-                        .config
-                        .get_provider(pid)
-                        .and_then(|pc| PROVIDER_REGISTRY.get(&pc.provider_type))
-                        .map(|meta| meta.provider_type == ProviderType::Local)
-                        .unwrap_or(false);
-
-                    if is_local {
-                        let pull_now = ctx.ui.confirm(
-                            &format!(
-                                "'{}' is a local provider. Pull '{} ({}/{})' now?",
-                                pid, model_id, selected_variant.format, selected_variant.precision
-                            ),
-                            true,
-                        )?;
-                        if pull_now {
-                            let source = crate::models::ModelSource::from_config(&ctx.config);
-                            match source
-                                .instances()
-                                .into_iter()
-                                .find(|(id, _)| id == model_id)
-                                .map(|(_, m)| m.provider())
-                            {
-                                Some(Ok(provider)) => {
-                                    ensure_model_pulled(
-                                        provider.as_ref(),
-                                        &model,
-                                        selected_variant,
-                                        ctx.ui.as_ref(),
-                                    )
-                                    .await?;
-                                }
-                                Some(Err(e)) => ctx.ui.warn(&format!(
-                                    "Provider '{pid}' is not available; skipping pull: {e}"
-                                )),
-                                None => ctx.ui.warn(&format!(
-                                    "Provider '{pid}' is not available; skipping pull."
-                                )),
-                            }
-                        }
-                    }
-                }
-
-                Ok(())
-            }
-            None => {
-                ctx.ui
-                    .error(&format!("Model '{model_id}' not found in registry."));
-                let available: Vec<_> = MODEL_REGISTRY
-                    .entries()
-                    .keys()
-                    .map(|k| k.to_string())
-                    .collect();
-                ctx.ui
-                    .info(&format!("Available models: {}", available.join(", ")));
-                anyhow::bail!("Model not found");
+        let existing_config = ctx.config.get_model(&instance_id).cloned();
+        if existing_config.is_some() {
+            let overwrite = ctx.ui.confirm(
+                &format!("Model '{instance_id}' is already configured. Overwrite?"),
+                false,
+            )?;
+            if !overwrite {
+                ctx.ui.info("Model setup skipped.");
+                return Ok(());
             }
         }
+
+        let schema = MODEL_REGISTRY.config_schema(model_type).ok_or_else(|| {
+            anyhow::anyhow!("No config schema registered for model type '{model_type}'")
+        })?;
+        let defaults = existing_config
+            .as_ref()
+            .map(|c| c.config.clone())
+            .or_else(|| MODEL_REGISTRY.default_config(model_type))
+            .unwrap_or_else(|| serde_json::json!({}));
+        let model_specific_cfg = prompt_from_schema(&*ctx.ui, &schema, &defaults)?;
+
+        // Construct a live, provider-less instance now -- this replaces the
+        // placeholder as the source of truth for variants/description from
+        // here on (real for catalog models, user-entered for custom).
+        let live = MODEL_REGISTRY
+            .construct(model_type, &instance_id, &model_specific_cfg, &ctx.config)
+            .map_err(|e| anyhow::anyhow!("Failed to construct model '{model_type}': {e}"))?;
+
+        let selected_variant: Option<ModelVariant> = if live.variants().is_empty() {
+            None
+        } else {
+            let variant_options: Vec<_> = live
+                .variants()
+                .iter()
+                .map(|v| match (v.size_gb, v.precision.is_empty()) {
+                    (Some(size), false) => {
+                        format!("{} / {} ({:.1} GB)", v.format, v.precision, size)
+                    }
+                    (Some(size), true) => format!("{} ({:.1} GB)", v.format, size),
+                    (None, false) => format!("{} / {}", v.format, v.precision),
+                    (None, true) => v.format.clone(),
+                })
+                .collect();
+
+            let variant_index = ctx
+                .ui
+                .select("Select model variant:", &variant_options, 0)?;
+
+            let variant = live.variants()[variant_index].clone();
+            ctx.ui.info(&format!(
+                "\nSelected: {} / {}",
+                variant.format, variant.precision
+            ));
+            Some(variant)
+        };
+
+        let provider_source = ProviderSource::from_config(&ctx.config);
+        let provider_id = if let Some(variant) = &selected_variant {
+            let requirement = VariantRequirement {
+                format: variant.format.clone(),
+                precision: variant.precision.clone(),
+            };
+            let resolution = dependency::resolve(&requirement, &provider_source);
+            Self::select_provider(ctx, &resolution).await?
+        } else {
+            let resolution = dependency::resolve(&AnyProviderRequirement, &provider_source);
+            Self::select_provider(ctx, &resolution).await?
+        };
+
+        let model_config = crate::config::ModelConfig {
+            model_id: instance_id.clone(),
+            model_type: model_type.to_string(),
+            provider_id: provider_id.clone(),
+            variant: selected_variant
+                .as_ref()
+                .map(|v| format!("{}/{}", v.format, v.precision)),
+            config: model_specific_cfg,
+        };
+
+        if let Err(e) = ctx.config.insert_model(&instance_id, model_config) {
+            ctx.ui.warn(&format!("failed to save model config: {e}"));
+        }
+
+        ctx.ui
+            .info(&format!("\nModel '{instance_id}' configured successfully!"));
+
+        if let (Some(pid), Some(variant)) = (&provider_id, &selected_variant) {
+            let is_local = ctx
+                .config
+                .get_provider(pid)
+                .and_then(|pc| PROVIDER_REGISTRY.get(&pc.provider_type))
+                .map(|meta| meta.provider_type == ProviderType::Local)
+                .unwrap_or(false);
+
+            if is_local {
+                let pull_now = ctx.ui.confirm(
+                    &format!(
+                        "'{}' is a local provider. Pull '{} ({}/{})' now?",
+                        pid, instance_id, variant.format, variant.precision
+                    ),
+                    true,
+                )?;
+                if pull_now {
+                    let source = ModelSource::from_config(&ctx.config);
+                    match source
+                        .instances()
+                        .into_iter()
+                        .find(|(id, _)| id == &instance_id)
+                        .map(|(_, m)| m.provider())
+                    {
+                        Some(Ok(provider)) => {
+                            ensure_model_pulled(
+                                provider.as_ref(),
+                                &live.to_metadata(),
+                                variant,
+                                ctx.ui.as_ref(),
+                            )
+                            .await?;
+                        }
+                        Some(Err(e)) => ctx.ui.warn(&format!(
+                            "Provider '{pid}' is not available; skipping pull: {e}"
+                        )),
+                        None => ctx.ui.warn(&format!(
+                            "Provider '{pid}' is not available; skipping pull."
+                        )),
+                    }
+                }
+            }
+        }
+
+        Ok(())
     }
 
     pub async fn pull(ctx: &mut crate::AppContext, model_id: &str) -> Result<()> {
-        let model = match MODEL_REGISTRY.get(model_id) {
-            Some(model) => model,
-            None => {
-                ctx.ui
-                    .error(&format!("Model '{model_id}' not found in registry."));
-                let available: Vec<_> = MODEL_REGISTRY
-                    .entries()
-                    .keys()
-                    .map(|k| k.to_string())
-                    .collect();
-                ctx.ui
-                    .info(&format!("Available models: {}", available.join(", ")));
-                anyhow::bail!("Model not found");
-            }
-        };
-
         let configured = ctx.config.get_model(model_id);
+        if configured.is_none() && MODEL_REGISTRY.get(model_id).is_none() {
+            ctx.ui
+                .error(&format!("Model '{model_id}' not found in registry."));
+            let available: Vec<_> = MODEL_REGISTRY
+                .entries()
+                .keys()
+                .map(|k| k.to_string())
+                .collect();
+            ctx.ui
+                .info(&format!("Available models: {}", available.join(", ")));
+            anyhow::bail!("Model not found");
+        }
+
         let (variant_str, provider_id) = match configured {
             Some(c) if c.variant.is_some() && c.provider_id.is_some() => {
                 (c.variant.clone().unwrap(), c.provider_id.clone().unwrap())
@@ -650,8 +749,16 @@ impl ModelCommands {
             anyhow::anyhow!("Invalid stored variant '{variant_str}' for model '{model_id}'.")
         })?;
 
+        let source = ModelSource::from_config(&ctx.config);
+        let model = source
+            .instances()
+            .into_iter()
+            .find(|(id, _)| id == model_id)
+            .ok_or_else(|| anyhow::anyhow!("model '{model_id}' is not configured"))?
+            .1;
+
         let variant: &ModelVariant = model
-            .variants
+            .variants()
             .iter()
             .find(|v| v.format == format && v.precision == precision)
             .ok_or_else(|| {
@@ -660,30 +767,23 @@ impl ModelCommands {
                 )
             })?;
 
-        let source = crate::models::ModelSource::from_config(&ctx.config);
-        let provider = source
-            .instances()
-            .into_iter()
-            .find(|(id, _)| id == model_id)
-            .ok_or_else(|| anyhow::anyhow!("model '{model_id}' is not configured"))?
-            .1
-            .provider()
-            .map_err(|e| {
-                anyhow::anyhow!(
-                    "Provider '{provider_id}' is not configured or enabled. Run `provider setup` first: {e}"
-                )
-            })?;
+        let provider = model.provider().map_err(|e| {
+            anyhow::anyhow!(
+                "Provider '{provider_id}' is not configured or enabled. Run `provider setup` first: {e}"
+            )
+        })?;
 
-        let result = ensure_model_pulled(provider.as_ref(), &model, variant, ctx.ui.as_ref()).await;
+        let md = model.to_metadata();
+        let result = ensure_model_pulled(provider.as_ref(), &md, variant, ctx.ui.as_ref()).await;
         match result {
             Ok(PullResult::Success) => {
                 ctx.ui
-                    .info(&format!("Model '{}' pulled successfully.", model.family));
+                    .info(&format!("Model '{}' pulled successfully.", md.family));
             }
             Ok(PullResult::Unnecessary) => {
                 ctx.ui.info(&format!(
                     "No pull needed for '{}' ({}).",
-                    model.family,
+                    md.family,
                     provider.name()
                 ));
             }
@@ -847,8 +947,10 @@ mod tests {
             id.to_string(),
             ModelConfig {
                 model_id: id.to_string(),
+                model_type: id.to_string(),
                 provider_id: provider_id.map(String::from),
                 variant: None,
+                config: serde_json::json!({}),
             },
         );
         ctx
@@ -866,8 +968,10 @@ mod tests {
             model_id.to_string(),
             ModelConfig {
                 model_id: model_id.to_string(),
+                model_type: model_id.to_string(),
                 provider_id: Some(provider_id.to_string()),
                 variant: Some(variant.to_string()),
+                config: serde_json::json!({}),
             },
         );
         ctx_with_config(config)
@@ -1539,5 +1643,168 @@ mod tests {
         let tables = tables!(ctx);
         let (_, _, rows) = &tables[0];
         assert!(rows.is_empty());
+    }
+
+    // -- custom models --------------------------------------------------------
+
+    /// Configures a `"custom"`-typed model instance directly (bypassing the
+    /// interactive wizard) with `config_value` as its `CustomModelConfig`
+    /// JSON, so `list`/`info`/`pull` tests can assert on its real values
+    /// without needing to script every prompt.
+    fn ctx_with_custom_model(
+        instance_id: &str,
+        config_value: serde_json::Value,
+        provider_id: Option<&str>,
+    ) -> crate::AppContext {
+        let mut ctx = empty_ctx();
+        ctx.config.models.insert(
+            instance_id.to_string(),
+            ModelConfig {
+                model_id: instance_id.to_string(),
+                model_type: "custom".to_string(),
+                provider_id: provider_id.map(String::from),
+                variant: None,
+                config: config_value,
+            },
+        );
+        ctx
+    }
+
+    #[test]
+    fn list_shows_a_custom_models_real_values_not_the_registry_placeholder() {
+        let ctx = ctx_with_custom_model(
+            "my-custom",
+            serde_json::json!({
+                "family": "My Local Model",
+                "context_length": 4096,
+            }),
+            None,
+        );
+        ModelCommands::list(&ctx, None).unwrap();
+        let tables = tables!(ctx);
+        let (_, _, rows) = &tables[0];
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0][0], "my-custom");
+        assert!(
+            rows[0].iter().any(|c| c == "My Local Model"),
+            "expected the configured family, got {:?}",
+            rows[0]
+        );
+    }
+
+    #[test]
+    fn info_shows_a_custom_models_real_values_and_config_type() {
+        let ctx = ctx_with_custom_model(
+            "my-custom",
+            serde_json::json!({
+                "family": "My Local Model",
+                "context_length": 4096,
+            }),
+            None,
+        );
+        ModelCommands::info(&ctx, "my-custom").unwrap();
+        let details = details!(ctx);
+        assert_eq!(details.len(), 1);
+        let (title, fields) = &details[0];
+        assert_eq!(title, "my-custom");
+        assert!(
+            fields
+                .iter()
+                .any(|(k, v)| k == "Family" && v == "My Local Model")
+        );
+        assert!(
+            fields
+                .iter()
+                .any(|(k, v)| k == "Config: Type" && v == "custom")
+        );
+    }
+
+    #[tokio::test]
+    async fn pull_uses_the_custom_models_own_variants_not_the_registry_placeholder() {
+        let mut config = config_with_provider(
+            "openai",
+            "openai-compatible",
+            serde_json::json!({ "base_url": "http://localhost:8080" }),
+        );
+        config.models.insert(
+            "my-custom".to_string(),
+            ModelConfig {
+                model_id: "my-custom".to_string(),
+                model_type: "custom".to_string(),
+                provider_id: Some("openai".to_string()),
+                variant: Some("safetensors/bfloat16".to_string()),
+                config: serde_json::json!({
+                    "family": "My Local Model",
+                    "variants": [
+                        { "format": "safetensors", "precision": "bfloat16", "size_gb": null, "url": "" }
+                    ],
+                }),
+            },
+        );
+        let mut ctx = ctx_with_config(config);
+
+        // OpenAIProvider::pull_model is a pure warning (no network call), so
+        // this exercises the full lookup path -- proving the variant came
+        // from the custom model's own config, not the (empty) registry
+        // placeholder for "custom".
+        let result = ModelCommands::pull(&mut ctx, "my-custom").await;
+        assert!(result.is_ok(), "{result:?}");
+        let warns = (&*(ctx.ui) as &dyn std::any::Any)
+            .downcast_ref::<CaptureUi>()
+            .unwrap()
+            .warns
+            .borrow();
+        assert!(!warns.is_empty());
+    }
+
+    #[tokio::test]
+    async fn setup_custom_model_with_no_variants_skips_variant_selection_and_picks_existing_provider()
+     {
+        let _home = crate::config::TestConfigHome::new();
+        let mut ctx = ctx_with_config(config_with_provider(
+            "my-openai",
+            "openai-compatible",
+            serde_json::json!({ "base_url": "http://localhost:8080" }),
+        ));
+
+        ModelCommands::setup(&mut ctx, "custom", Some("my-custom"))
+            .await
+            .unwrap();
+
+        let configured = ctx
+            .config
+            .get_model("my-custom")
+            .expect("custom model should be saved under its instance id");
+        assert_eq!(configured.model_type, "custom");
+        assert_eq!(
+            configured.provider_id,
+            Some("my-openai".to_string()),
+            "with no variants to filter by, the sole existing provider should be selected"
+        );
+        assert!(
+            configured.variant.is_none(),
+            "a custom model with no declared variants should have no stored variant"
+        );
+
+        // Never prompted for a variant -- `live.variants()` was empty --
+        // even though the provider-selection prompt (auto-resolved to the
+        // sole existing provider via its default index) still ran.
+        assert!(
+            !capture_select_prompts(&ctx)
+                .iter()
+                .any(|p| p.contains("variant")),
+            "should not have prompted for a variant"
+        );
+    }
+
+    fn capture_select_prompts(ctx: &crate::AppContext) -> Vec<String> {
+        (&*(ctx.ui) as &dyn std::any::Any)
+            .downcast_ref::<CaptureUi>()
+            .unwrap()
+            .select_prompts
+            .borrow()
+            .iter()
+            .map(|(prompt, _, _)| prompt.clone())
+            .collect()
     }
 }

--- a/src/commands/setup.rs
+++ b/src/commands/setup.rs
@@ -1403,6 +1403,8 @@ impl SetupCommands {
 
             let model_config = crate::config::ModelConfig {
                 model_id: model_id.clone(),
+                model_type: model_id.clone(),
+                config: serde_json::json!({}),
                 provider_id,
                 variant,
             };
@@ -1734,6 +1736,8 @@ mod tests {
             id.to_string(),
             ModelConfig {
                 model_id: id.to_string(),
+                model_type: id.to_string(),
+                config: serde_json::json!({}),
                 provider_id: provider_id.map(String::from),
                 variant: None,
             },
@@ -2542,6 +2546,8 @@ mod tests {
             model_id.to_string(),
             ModelConfig {
                 model_id: model_id.to_string(),
+                model_type: model_id.to_string(),
+                config: serde_json::json!({}),
                 provider_id: Some("ollama".to_string()),
                 variant: Some(format!("{}/{}", variant.format, variant.precision)),
             },

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -53,9 +53,20 @@ pub struct Config {
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
 pub struct ModelConfig {
+    /// Instance id -- the config/file key this model is stored under.
+    /// Defaults to `model_type` (see `commands::ModelCommands::setup`), but
+    /// may differ to let the same catalog type be configured more than once
+    /// (e.g. against different providers or precisions).
     pub model_id: String,
+    /// Registry key: the catalog id this instance was constructed from (a
+    /// `resources/models.yaml` id, or `"custom"`).
+    pub model_type: String,
     pub provider_id: Option<String>,
     pub variant: Option<String>,
+    /// Model-type-specific config (e.g. `CustomModelConfig`'s fields for a
+    /// `"custom"` instance). `{}` for catalog models, which take no config
+    /// beyond `provider_config`.
+    pub config: serde_json::Value,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -1,9 +1,16 @@
-use alog::{MessageLevel, alog_channel, use_channel};
-use anyhow::{Context, Result};
-use serde::{Deserialize, Serialize};
+// Standard
 use std::collections::HashMap;
 use std::fs;
 use std::path::{Path, PathBuf};
+
+// Third Party
+use alog::{MessageLevel, alog_channel, use_channel};
+use anyhow::{Context, Result};
+use serde::{Deserialize, Serialize};
+
+use_channel!("CONF");
+
+const PATH_DELIM: &str = "---";
 
 trait ConfigId {
     fn config_id(&self) -> &str;
@@ -32,8 +39,6 @@ impl ConfigId for LauncherConfig {
         &self.launcher_id
     }
 }
-
-use_channel!("CONF");
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
 pub struct Config {
@@ -215,17 +220,18 @@ impl Config {
                     .unwrap_or_default();
                 if let Ok(config) = Self::load_yaml_from_file::<V>(&path) {
                     let id = config.config_id().to_string();
-                    if id != file_name {
+                    let file_id = Self::id_from_filename(&file_name);
+                    if id != file_id {
                         let type_name = std::any::type_name::<V>();
                         alog_channel!(
                             MessageLevel::Warning,
                             "Found invalid config file {} with id \"{}\" (type: {})",
-                            file_name,
+                            file_id,
                             id,
                             type_name
                         );
                     } else {
-                        map.insert(into_key(&file_name), config);
+                        map.insert(into_key(&id), config);
                     }
                 }
             }
@@ -259,31 +265,39 @@ impl Config {
         Ok(config)
     }
 
+    fn id_to_filename(id: &str) -> String {
+        id.replace(std::path::MAIN_SEPARATOR, PATH_DELIM)
+    }
+
+    fn id_from_filename(id: &str) -> String {
+        id.replace(PATH_DELIM, std::path::MAIN_SEPARATOR_STR)
+    }
+
     fn save(&self) -> Result<()> {
         #[cfg(test)]
         Self::assert_test_isolated();
 
         // Save individual model files
         for (id, model) in &self.models {
-            let path = Self::models_dir()?.join(format!("{id}.yaml"));
+            let path = Self::models_dir()?.join(format!("{}.yaml", Self::id_to_filename(id)));
             Self::save_yaml_to_file(&path, model)?;
         }
 
         // Save individual provider files
         for (id, provider) in &self.providers {
-            let path = Self::providers_dir()?.join(format!("{id}.yaml"));
+            let path = Self::providers_dir()?.join(format!("{}.yaml", Self::id_to_filename(id)));
             Self::save_yaml_to_file(&path, provider)?;
         }
 
         // Save individual capability files
         for (id, capability) in &self.capabilities {
-            let path = Self::capabilities_dir()?.join(format!("{id}.yaml"));
+            let path = Self::capabilities_dir()?.join(format!("{}.yaml", Self::id_to_filename(id)));
             Self::save_yaml_to_file(&path, capability)?;
         }
 
         // Save individual launcher files
         for (id, launcher) in &self.launchers {
-            let path = Self::launchers_dir()?.join(format!("{id}.yaml"));
+            let path = Self::launchers_dir()?.join(format!("{}.yaml", Self::id_to_filename(id)));
             Self::save_yaml_to_file(&path, launcher)?;
         }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -203,8 +203,15 @@ enum ModelSubcommands {
 
     /// Interactive model setup wizard
     Setup {
-        /// Model ID to set up
-        model_id: String,
+        /// Catalog model type to set up (e.g. `granite-3.1-8b-instruct`, or `custom`)
+        model_type: String,
+
+        /// Nickname for this model instance. Defaults to `model_type`;
+        /// pass a distinct value to configure multiple named instances of
+        /// the same catalog type (e.g. two precisions of the same model
+        /// against different providers, or several custom models).
+        #[arg(long = "id")]
+        instance_id: Option<String>,
     },
 
     /// Pull (download) a configured model's weights via its provider
@@ -617,7 +624,10 @@ async fn run_model_command(ctx: &mut AppContext, subcmd: ModelSubcommands) -> an
             ModelCommands::recommend(ctx, filter, &providers, wide)
         }
         ModelSubcommands::Info { model_id } => ModelCommands::info(ctx, &model_id),
-        ModelSubcommands::Setup { model_id } => ModelCommands::setup(ctx, &model_id).await,
+        ModelSubcommands::Setup {
+            model_type,
+            instance_id,
+        } => ModelCommands::setup(ctx, &model_type, instance_id.as_deref()).await,
         ModelSubcommands::Pull { model_id } => ModelCommands::pull(ctx, &model_id).await,
         ModelSubcommands::Remove { model_id } => ModelCommands::remove(ctx, &model_id),
     }

--- a/src/models/base.rs
+++ b/src/models/base.rs
@@ -181,6 +181,28 @@ pub trait Model: crate::registry::Named + Send + Sync {
             )
             .map_err(|e| anyhow::anyhow!(e))
     }
+
+    /// Snapshot this instance's data into a `ModelMetadata` value, using the
+    /// same accessors the registry uses to describe a catalog entry. Lets
+    /// command code display a model uniformly whether it came from a static
+    /// catalog lookup or a live constructed instance (e.g. a `"custom"`
+    /// model, whose real values only exist on the instance).
+    fn to_metadata(&self) -> ModelMetadata {
+        ModelMetadata {
+            family: self.family().to_string(),
+            version: self.version().to_string(),
+            size: self.size(),
+            context_length: self.context_length(),
+            model_type: self.model_type().clone(),
+            huggingface_repo: self.huggingface_repo().to_string(),
+            native_dtype: self.native_dtype().to_string(),
+            architecture: self.architecture().clone(),
+            variants: self.variants().to_vec(),
+            description: self.description().map(str::to_string),
+            tags: self.tags().to_vec(),
+            supported_functions: self.supported_functions().to_vec(),
+        }
+    }
 }
 
 /*-- ConfiguredModel -----------------------------------------------------------*/
@@ -372,8 +394,9 @@ impl Searchable for ModelMetadata {
 
 /*-- Supporting Types --------------------------------------------------------*/
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, schemars::JsonSchema)]
 pub enum ModelType {
+    #[default]
     Text,
     Vision,
     Speech,
@@ -391,7 +414,7 @@ impl std::fmt::Display for ModelType {
     }
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, schemars::JsonSchema)]
 pub struct ModelVariant {
     pub format: String,
     pub precision: String,
@@ -519,6 +542,102 @@ mod searchable_tests {
         let fields = m.search_fields();
         assert!(fields.contains(&"instruct"));
         assert!(fields.contains(&"chat"));
+    }
+}
+
+#[cfg(test)]
+mod to_metadata_tests {
+    use super::*;
+
+    struct FullTestModel;
+
+    impl crate::registry::Named for FullTestModel {
+        fn instance_id(&self) -> &str {
+            "full-test-model"
+        }
+    }
+
+    impl Model for FullTestModel {
+        fn family(&self) -> &str {
+            "Test Family"
+        }
+        fn version(&self) -> &str {
+            "9.9"
+        }
+        fn size(&self) -> u64 {
+            42
+        }
+        fn context_length(&self) -> u64 {
+            2048
+        }
+        fn model_type(&self) -> &ModelType {
+            &ModelType::Vision
+        }
+        fn huggingface_repo(&self) -> &str {
+            "test/full"
+        }
+        fn native_dtype(&self) -> &str {
+            "float16"
+        }
+        fn architecture(&self) -> &ModelArchitecture {
+            static ARCH: std::sync::LazyLock<ModelArchitecture> =
+                std::sync::LazyLock::new(|| ModelArchitecture {
+                    num_hidden_layers: 1,
+                    hidden_size: 2,
+                    num_attention_heads: 3,
+                    num_key_value_heads: 4,
+                    head_dim: 5,
+                    layer_types: vec![LayerTypeCount {
+                        kind: LayerKind::FullAttention,
+                        count: 1,
+                    }],
+                });
+            &ARCH
+        }
+        fn variants(&self) -> &[ModelVariant] {
+            static VARIANTS: std::sync::LazyLock<Vec<ModelVariant>> =
+                std::sync::LazyLock::new(|| {
+                    vec![ModelVariant {
+                        format: "GGUF".to_string(),
+                        precision: "Q4_K_M".to_string(),
+                        size_gb: Some(1.0),
+                        url: "http://example.com".to_string(),
+                    }]
+                });
+            &VARIANTS
+        }
+        fn description(&self) -> Option<&str> {
+            Some("a description")
+        }
+        fn tags(&self) -> &[String] {
+            static TAGS: std::sync::LazyLock<Vec<String>> =
+                std::sync::LazyLock::new(|| vec!["tag1".to_string()]);
+            &TAGS
+        }
+        fn supported_functions(&self) -> &[ModelFunction] {
+            static FUNCS: std::sync::LazyLock<Vec<ModelFunction>> =
+                std::sync::LazyLock::new(|| vec![ModelFunction::Chat]);
+            &FUNCS
+        }
+    }
+
+    #[test]
+    fn to_metadata_round_trips_every_field() {
+        let model = FullTestModel;
+        let md = model.to_metadata();
+        assert_eq!(md.family, "Test Family");
+        assert_eq!(md.version, "9.9");
+        assert_eq!(md.size, 42);
+        assert_eq!(md.context_length, 2048);
+        assert_eq!(md.model_type, ModelType::Vision);
+        assert_eq!(md.huggingface_repo, "test/full");
+        assert_eq!(md.native_dtype, "float16");
+        assert_eq!(md.architecture.num_hidden_layers, 1);
+        assert_eq!(md.variants.len(), 1);
+        assert_eq!(md.variants[0].format, "GGUF");
+        assert_eq!(md.description, Some("a description".to_string()));
+        assert_eq!(md.tags, vec!["tag1".to_string()]);
+        assert_eq!(md.supported_functions, vec![ModelFunction::Chat]);
     }
 }
 

--- a/src/models/custom.rs
+++ b/src/models/custom.rs
@@ -1,0 +1,280 @@
+// Third Party
+use alog::{MessageLevel, alog_channel, use_channel};
+use serde::{Deserialize, Serialize};
+
+// Local
+use crate::models::base::{
+    HasModelMetadata, Model, ModelArchitecture, ModelFunction, ModelMetadata, ModelType,
+    ModelVariant,
+};
+use crate::registry::{ConfigConstructable, Named};
+
+use_channel!("MODEL");
+
+/*-- CustomModelConfig ---------------------------------------------------------*/
+
+/// User-supplied description of a model that isn't in the built-in catalog.
+/// Every field here becomes one of the values a codegen'd catalog model
+/// would otherwise get from `resources/models.yaml`. `architecture` is
+/// deliberately not configurable -- `CustomModel` always reports an empty
+/// one, so `context_fit` degrades to `ContextFit::None` for custom models
+/// rather than prompting for a full per-layer memory shape.
+#[derive(Debug, Clone, Serialize, Deserialize, Default, schemars::JsonSchema)]
+pub struct CustomModelConfig {
+    pub family: String,
+    #[serde(default)]
+    pub version: String,
+    #[serde(default)]
+    pub size: u64,
+    #[serde(default)]
+    pub context_length: u64,
+    #[serde(default)]
+    pub model_type: ModelType,
+    #[serde(default)]
+    pub huggingface_repo: String,
+    #[serde(default)]
+    pub native_dtype: String,
+    /// Pullable artifact variants, if any. Most custom models describe an
+    /// endpoint that's already running somewhere rather than something
+    /// `granite-cli` would download -- leave this empty and `model setup`
+    /// skips variant selection, letting any configured provider serve it.
+    #[serde(default)]
+    pub variants: Vec<ModelVariant>,
+    #[serde(default)]
+    pub description: Option<String>,
+    #[serde(default)]
+    pub tags: Vec<String>,
+    #[serde(default)]
+    pub supported_functions: Vec<ModelFunction>,
+}
+
+fn empty_architecture() -> ModelArchitecture {
+    ModelArchitecture {
+        num_hidden_layers: 0,
+        hidden_size: 0,
+        num_attention_heads: 0,
+        num_key_value_heads: 0,
+        head_dim: 0,
+        layer_types: vec![],
+    }
+}
+
+/*-- CustomModel -----------------------------------------------------------------*/
+
+/// Hand-authored `Model` implementation for user-defined models, registered
+/// in `MODEL_REGISTRY` under the catalog key `"custom"`. Unlike every other
+/// registered model (codegen'd from `resources/models.yaml` with real,
+/// compile-time-known values), a `CustomModel` instance's real values only
+/// exist once it's been constructed from a user's `CustomModelConfig` --
+/// `HasModelMetadata::metadata()` below returns a placeholder used only for
+/// catalog browsing before that.
+pub struct CustomModel {
+    instance_id: String,
+    config: CustomModelConfig,
+    provider_config: Option<crate::config::ProviderConfig>,
+}
+
+impl ConfigConstructable for CustomModel {
+    type Config = CustomModelConfig;
+
+    fn new(
+        instance_id: &str,
+        cfg: &serde_json::Value,
+        _global_config: &crate::config::Config,
+    ) -> Self {
+        let config: CustomModelConfig = serde_json::from_value(cfg.clone()).unwrap_or_default();
+        let provider_config = cfg.get("provider_config").and_then(|v| {
+            serde_json::from_value(v.clone())
+                .map_err(|e| {
+                    alog_channel!(
+                        MessageLevel::Warning,
+                        "Failed to deserialize provider_config: {}",
+                        e
+                    )
+                })
+                .ok()
+        });
+        Self {
+            instance_id: instance_id.to_string(),
+            config,
+            provider_config,
+        }
+    }
+}
+
+impl Named for CustomModel {
+    fn instance_id(&self) -> &str {
+        &self.instance_id
+    }
+}
+
+impl Model for CustomModel {
+    fn family(&self) -> &str {
+        &self.config.family
+    }
+
+    fn version(&self) -> &str {
+        &self.config.version
+    }
+
+    fn size(&self) -> u64 {
+        self.config.size
+    }
+
+    fn context_length(&self) -> u64 {
+        self.config.context_length
+    }
+
+    fn model_type(&self) -> &ModelType {
+        &self.config.model_type
+    }
+
+    fn huggingface_repo(&self) -> &str {
+        &self.config.huggingface_repo
+    }
+
+    fn native_dtype(&self) -> &str {
+        &self.config.native_dtype
+    }
+
+    fn architecture(&self) -> &ModelArchitecture {
+        static ARCHITECTURE: std::sync::LazyLock<ModelArchitecture> =
+            std::sync::LazyLock::new(empty_architecture);
+        &ARCHITECTURE
+    }
+
+    fn variants(&self) -> &[ModelVariant] {
+        &self.config.variants
+    }
+
+    fn description(&self) -> Option<&str> {
+        self.config.description.as_deref()
+    }
+
+    fn tags(&self) -> &[String] {
+        &self.config.tags
+    }
+
+    fn supported_functions(&self) -> &[ModelFunction] {
+        &self.config.supported_functions
+    }
+
+    fn provider_config(&self) -> Option<&crate::config::ProviderConfig> {
+        self.provider_config.as_ref()
+    }
+}
+
+impl HasModelMetadata for CustomModel {
+    fn metadata() -> ModelMetadata {
+        ModelMetadata {
+            family: "Custom Model".to_string(),
+            version: String::new(),
+            size: 0,
+            context_length: 0,
+            model_type: ModelType::Text,
+            huggingface_repo: String::new(),
+            native_dtype: String::new(),
+            architecture: empty_architecture(),
+            variants: vec![],
+            description: Some(
+                "User-defined model. Run `model setup custom` to describe its family, size, \
+                 context length, and (optionally) pullable variants."
+                    .to_string(),
+            ),
+            tags: vec!["custom".to_string()],
+            supported_functions: vec![],
+        }
+    }
+}
+
+/*-- tests -----------------------------------------------------------------------*/
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn metadata_is_a_placeholder_with_no_variants() {
+        let md = CustomModel::metadata();
+        assert_eq!(md.family, "Custom Model");
+        assert!(md.variants.is_empty());
+        assert!(md.tags.contains(&"custom".to_string()));
+    }
+
+    #[test]
+    fn new_populates_fields_from_config() {
+        let cfg = serde_json::json!({
+            "family": "My Local Model",
+            "version": "1.0",
+            "size": 7_000_000_000u64,
+            "context_length": 8192,
+            "model_type": "Text",
+            "huggingface_repo": "me/my-model",
+            "native_dtype": "bfloat16",
+            "variants": [],
+            "tags": ["chat"],
+            "supported_functions": ["Chat"],
+        });
+        let model = CustomModel::new("my-nickname", &cfg, &crate::config::Config::default());
+        assert_eq!(model.instance_id(), "my-nickname");
+        assert_eq!(model.family(), "My Local Model");
+        assert_eq!(model.size(), 7_000_000_000);
+        assert_eq!(model.context_length(), 8192);
+        assert_eq!(model.model_type(), &ModelType::Text);
+        assert_eq!(model.huggingface_repo(), "me/my-model");
+        assert!(model.variants().is_empty());
+        assert_eq!(model.tags(), &["chat".to_string()]);
+        assert_eq!(model.supported_functions(), &[ModelFunction::Chat]);
+        assert!(model.architecture().layer_types.is_empty());
+        assert!(model.provider_config().is_none());
+    }
+
+    #[test]
+    fn new_extracts_provider_config_from_sibling_key() {
+        let provider_config = crate::config::ProviderConfig {
+            provider_id: "my-openai".to_string(),
+            provider_type: "openai-compatible".to_string(),
+            config: serde_json::json!({ "base_url": "http://localhost:8080" }),
+        };
+        let cfg = serde_json::json!({
+            "family": "My Local Model",
+            "provider_config": provider_config,
+        });
+        let model = CustomModel::new("my-nickname", &cfg, &crate::config::Config::default());
+        let pc = model.provider_config().expect("provider_config present");
+        assert_eq!(pc.provider_id, "my-openai");
+        assert_eq!(pc.provider_type, "openai-compatible");
+    }
+
+    #[test]
+    fn config_schema_exposes_expected_properties() {
+        let schema = schemars::schema_for!(CustomModelConfig);
+        let properties = schema
+            .get("properties")
+            .and_then(|p| p.as_object())
+            .expect("object schema with properties");
+        for field in [
+            "family",
+            "context_length",
+            "model_type",
+            "variants",
+            "supported_functions",
+        ] {
+            assert!(properties.contains_key(field), "missing field {field}");
+        }
+    }
+
+    #[test]
+    fn to_metadata_round_trips_configured_values() {
+        let cfg = serde_json::json!({
+            "family": "My Local Model",
+            "context_length": 4096,
+            "model_type": "Vision",
+        });
+        let model = CustomModel::new("nick", &cfg, &crate::config::Config::default());
+        let md = model.to_metadata();
+        assert_eq!(md.family, "My Local Model");
+        assert_eq!(md.context_length, 4096);
+        assert_eq!(md.model_type, ModelType::Vision);
+    }
+}

--- a/src/models/mod.rs
+++ b/src/models/mod.rs
@@ -15,6 +15,7 @@ use_channel!("MODEL");
 pub static MODEL_REGISTRY: LazyLock<base::ModelFactory> = LazyLock::new(|| {
     let mut factory = base::ModelFactory::new();
     register_all_models(&mut factory);
+    factory.register::<custom::CustomModel>("custom");
     factory
 });
 
@@ -22,8 +23,9 @@ pub static MODEL_REGISTRY: LazyLock<base::ModelFactory> = LazyLock::new(|| {
 
 /// The real `Configured<dyn Model>`: eagerly constructs a live model instance
 /// for every model referenced by the config's `models` map, keyed by its
-/// catalog id (models have no separate instance nickname -- the config key
-/// *is* the catalog id).
+/// instance id (`ModelConfig.model_id`) -- distinct from the registry key
+/// it's constructed from (`ModelConfig.model_type`), so the same catalog
+/// type can be configured more than once.
 pub struct ModelSource {
     constructed: Vec<(String, Box<dyn Model>)>,
     model_proxy: Option<crate::proxy::ProxyHandle>,
@@ -35,18 +37,17 @@ impl ModelSource {
             .models
             .values()
             .filter_map(|model_config| {
-                let cfg = match model_config
+                let mut cfg = model_config.config.clone();
+                if let Some(provider_config) = model_config
                     .provider_id
                     .as_deref()
                     .and_then(|pid| config.get_provider(pid))
                 {
-                    Some(provider_config) => {
-                        serde_json::json!({ "provider_config": provider_config })
-                    }
-                    None => serde_json::json!({}),
-                };
+                    cfg["provider_config"] =
+                        serde_json::to_value(provider_config).unwrap_or_default();
+                }
                 let result = MODEL_REGISTRY.construct(
-                    &model_config.model_id,
+                    &model_config.model_type,
                     &model_config.model_id,
                     &cfg,
                     config,
@@ -69,10 +70,10 @@ impl ModelSource {
         }
     }
 
-    /// Removes and returns the constructed model for `model_id` (the catalog
-    /// id -- matches `ModelConfig.model_id`, which config loading enforces
-    /// equals the outer `config.models` key). `configured_variant` is the
-    /// caller's already-resolved `"format/precision"` string, used (on the
+    /// Removes and returns the constructed model for `model_id` (the
+    /// instance id -- matches `ModelConfig.model_id`, which config loading
+    /// enforces equals the outer `config.models` key). `configured_variant`
+    /// is the caller's already-resolved `"format/precision"` string, used (on the
     /// real, unwrapped provider) to compute the same alias
     /// `resolve_provider_endpoint` will use later, so the route registered
     /// here is keyed exactly how the launched process will address it.
@@ -150,6 +151,9 @@ pub use base::{
     ModelFunction, ModelMetadata, ModelType, ModelVariant,
 };
 
+mod custom;
+pub use custom::CustomModelConfig;
+
 pub(crate) mod context_fit;
 pub use context_fit::{ContextFit, required_gb};
 
@@ -171,6 +175,8 @@ mod tests {
             "granite-3.1-8b-instruct".to_string(),
             ModelConfig {
                 model_id: "granite-3.1-8b-instruct".to_string(),
+                model_type: "granite-3.1-8b-instruct".to_string(),
+                config: serde_json::json!({}),
                 provider_id: None,
                 variant: None,
             },
@@ -179,6 +185,8 @@ mod tests {
             "granite-guardian-3.1-8b".to_string(),
             ModelConfig {
                 model_id: "granite-guardian-3.1-8b".to_string(),
+                model_type: "granite-guardian-3.1-8b".to_string(),
+                config: serde_json::json!({}),
                 provider_id: None,
                 variant: None,
             },
@@ -214,6 +222,8 @@ mod tests {
             "granite-3.1-8b-instruct".to_string(),
             ModelConfig {
                 model_id: "granite-3.1-8b-instruct".to_string(),
+                model_type: "granite-3.1-8b-instruct".to_string(),
+                config: serde_json::json!({}),
                 provider_id: Some("ollama".to_string()),
                 variant: None,
             },
@@ -239,6 +249,8 @@ mod tests {
             "granite-3.1-8b-instruct".to_string(),
             ModelConfig {
                 model_id: "granite-3.1-8b-instruct".to_string(),
+                model_type: "granite-3.1-8b-instruct".to_string(),
+                config: serde_json::json!({}),
                 provider_id: Some("does-not-exist".to_string()),
                 variant: None,
             },
@@ -263,6 +275,8 @@ mod tests {
             "not-a-real-model".to_string(),
             ModelConfig {
                 model_id: "not-a-real-model".to_string(),
+                model_type: "not-a-real-model".to_string(),
+                config: serde_json::json!({}),
                 provider_id: None,
                 variant: None,
             },
@@ -281,6 +295,8 @@ mod tests {
             "granite-3.1-8b-instruct".to_string(),
             ModelConfig {
                 model_id: "granite-3.1-8b-instruct".to_string(),
+                model_type: "granite-3.1-8b-instruct".to_string(),
+                config: serde_json::json!({}),
                 provider_id: None,
                 variant: None,
             },
@@ -329,6 +345,8 @@ mod tests {
             "granite-3.1-8b-instruct".to_string(),
             ModelConfig {
                 model_id: "granite-3.1-8b-instruct".to_string(),
+                model_type: "granite-3.1-8b-instruct".to_string(),
+                config: serde_json::json!({}),
                 provider_id: Some("ollama".to_string()),
                 variant: None,
             },


### PR DESCRIPTION
## Description

This PR adds the ability to set up a custom model outside of the pre-existing catalog. This will be useful for testing non-standard deployments (eg custom names in Ollama, etc) as well as merging granite models with non-granite models in the overall setup.

## Changes

- Add new `CustomModel` with associated config and factory registration
- Extend MODEL_CATALOG factory to allow separate `model_id` (instance id) and `model_type` (registry key)
- Add path escaping in `save`/`load` for files where the model name includes a separator

## Testing

- Unit tests
- Manual testing using Qwen 3.6 35b running on my PGX

## AI Usage

Built with Claude Code using `granite4.2:3b` as Explore sub-agent for offloading

```sh
╔══════════════════════════════════════════════════════════╗
║           GIT AI USAGE ANALYSIS                          ║
╚══════════════════════════════════════════════════════════╝

📊 COMMITS BY AGENT

--- Aggregate ---
Commits                        |      Count
---------------------------------------------
Claude + Sonnet 5 + granite4.2:3b |          5
none                           |          1
---------------------------------------------
TOTAL                          |          6

📊 COMMITS BY USAGE TYPE

--- Aggregate ---
Commits                        |      Count
---------------------------------------------
none                           |          1
draft                          |          0
full                           |          5
---------------------------------------------
TOTAL                          |          6

📈 LINES OF CODE BY AGENT

--- Aggregate ---
Agent                     |    Commits |  Additions |  Deletions
------------------------------------------------------------
Claude + Sonnet 5 + granite4.2:3b |          5 |        946 |        207
none                      |          1 |         26 |         12
------------------------------------------------------------
TOTAL                     |          6 |        972 |        219

📈 LINES OF CODE BY USAGE TYPE

--- Aggregate ---
Usage Type           |    Commits |  Additions |  Deletions
-------------------------------------------------------
none                 |          1 |         26 |         12
draft                |          0 |          0 |          0
full                 |          5 |        946 |        207
-------------------------------------------------------
TOTAL                |          6 |        972 |        219
```