### PR TITLE
fix: Restore cursor on Ctrl-C during prompts

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -448,6 +448,13 @@ impl alog::Formatter for UiFormatter {
 
 #[tokio::main]
 async fn main() {
+    tokio::spawn(async {
+        if tokio::signal::ctrl_c().await.is_ok() {
+            let _ = dialoguer::console::Term::stderr().show_cursor();
+            std::process::exit(130);
+        }
+    });
+
     let cli = Cli::parse();
     let log_level = cli.log_level.clone();
     let log_filters = cli.log_filters.clone();


### PR DESCRIPTION
## Description

Fixes #93 to restore cursor state properly on SIGINT

## Changes

Adds a SIGINT handler that restores the cursor and exits with code 130.

## Testing

Automatic test suite ran fully correct.
Test confirmed by hand to fix the ctrl C during setup bug.

## Related Issue(s)

#93 

## AI Usage

IBM Bob was used to help code this PR