### PR TITLE
Feat: opencode full usage tracking

### DIFF
--- a/src/launchers/opencode.rs
+++ b/src/launchers/opencode.rs
@@ -3,10 +3,12 @@
 //! Unlike `pi`, OpenCode's config sources are additive: `OPENCODE_CONFIG`
 //! points at one extra file that gets merged into the chain (loaded after the
 //! global config, before the project config) rather than a whole directory to
-//! redirect wholesale. So this launcher never touches the user's own
-//! `opencode.json`, credentials, or session store -- it only ever writes its
-//! own small generated file under `GRANITE_CLI_HOME` and points
-//! `OPENCODE_CONFIG` at it.
+//! redirect wholesale. This launcher reads the user's global and project
+//! `opencode.json` configs to discover configured providers, registers them on
+//! the session proxy for usage tracking, then writes its own small generated
+//! file under `GRANITE_CLI_HOME` and points `OPENCODE_CONFIG` at it. The
+//! generated config includes granite-cli providers plus any user providers
+//! merged in with their `baseURL` redirected to the proxy.
 
 // Standard
 use std::collections::HashSet;
@@ -26,6 +28,7 @@ use crate::capabilities::{
 use crate::launchers::base::{EnvBinding, LaunchContext, Launcher, LauncherMetadata, run_command};
 use crate::launchers::shared::mcp_cli::mcp_binding_request;
 use crate::providers::ApiType;
+use crate::proxy::ProxyHandle;
 use crate::registry::ConfigConstructable;
 use crate::utils::resolve_shell_command;
 use crate::utils::ui::Ui;
@@ -67,6 +70,11 @@ pub struct OpenCodeLauncher {
     /// its own `provider.<name>` entry and is referenced directly as
     /// `<provider>/<model>` in `agent.<name>.model` -- no mini-router needed.
     bound_sub_agents: Vec<(String, SubAgentBinding)>,
+    /// The session-scoped model proxy, if one was booted for this launch
+    /// (see `run_launch`) -- present whenever usage tracking or sub-agent
+    /// routing is needed. Used to redirect provider baseURLs so all traffic
+    /// flows through the proxy for usage accounting.
+    model_proxy: Option<ProxyHandle>,
 }
 
 impl ConfigConstructable for OpenCodeLauncher {
@@ -75,7 +83,7 @@ impl ConfigConstructable for OpenCodeLauncher {
     fn new(
         instance_id: &str,
         cfg: &serde_json::Value,
-        _global_config: &crate::config::Config,
+        global_config: &crate::config::Config,
     ) -> Self {
         let config: OpenCodeLauncherConfig =
             serde_json::from_value(cfg.clone()).unwrap_or_default();
@@ -85,6 +93,7 @@ impl ConfigConstructable for OpenCodeLauncher {
             bound_agent_model: None,
             bound_mcp_bindings: vec![],
             bound_sub_agents: vec![],
+            model_proxy: global_config.model_proxy.clone(),
         }
     }
 }
@@ -248,6 +257,14 @@ impl Launcher for OpenCodeLauncher {
     /// injecting it ahead of an arbitrary subcommand (e.g. `models`,
     /// `agent`) would either be rejected or silently misparsed. The config
     /// key is documented to apply uniformly across all of those surfaces.
+    ///
+    /// When usage tracking is active (proxy is running), discovers all
+    /// providers the user has configured in their global and project
+    /// `opencode.json` files and any env-based providers, registers them on
+    /// the proxy, and merges them into the generated config with their
+    /// `baseURL` redirected to the proxy. This ensures all model calls
+    /// (granite-cli managed and user-configured) flow through the proxy for
+    /// usage accounting.
     async fn launch(
         &self,
         args: &[String],
@@ -258,16 +275,43 @@ impl Launcher for OpenCodeLauncher {
             || !self.bound_mcp_bindings.is_empty()
             || !self.bound_sub_agents.is_empty()
         {
-            let mut providers = serde_json::Map::new();
+            // Build granite-cli provider entries
+            let mut granite_providers = serde_json::Map::new();
             for (index, (binding, model_names)) in self.provider_groups().iter().enumerate() {
                 let entry =
                     self.provider_entry(binding, model_names, &provider_api_key_env(index))?;
-                providers.insert(binding.provider_name.clone(), entry);
+                granite_providers.insert(binding.provider_name.clone(), entry);
             }
+
+            // Discover and register user providers for usage tracking
+            if let Some(proxy_handle) = &self.model_proxy {
+                // Discover user's configured providers from their config files
+                if let Some(user_providers) = Self::discover_user_providers(ctx) {
+                    // Register on proxy so the proxy can route and track them
+                    self.register_user_providers_on_proxy(proxy_handle, &user_providers);
+                    granite_providers = self.merge_user_providers_into_config(
+                        &user_providers,
+                        &Self::discover_env_providers(),
+                        &granite_providers,
+                    );
+                } else {
+                    // No user config providers — discover env-based ones
+                    let env_providers = Self::discover_env_providers();
+                    if !env_providers.is_empty() {
+                        self.register_user_providers_on_proxy(proxy_handle, &env_providers);
+                        granite_providers = self.merge_user_providers_into_config(
+                            &serde_json::Map::new(),
+                            &env_providers,
+                            &granite_providers,
+                        );
+                    }
+                }
+            }
+
             let agent = self.build_agent_config(ui);
             let config = generate_config(
                 self.bound_agent_model.as_ref(),
-                providers,
+                granite_providers,
                 agent,
                 &self.bound_mcp_bindings,
             );
@@ -333,13 +377,21 @@ impl OpenCodeLauncher {
     /// single provider instance may back both the main model and one or more
     /// sub-agents' models, all of which must land in the same generated
     /// `provider.<name>` entry rather than clobbering each other.
+    ///
+    /// When a session proxy is active (usage tracking or sub-agent routing
+    /// enabled), the provider's `baseURL` is overridden to point at the proxy
+    /// so all traffic flows through it for usage accounting. The proxy
+    /// dispatches based on the `"model"` field in each request body, which
+    /// means the provider name is irrelevant for routing -- only the model
+    /// name matters.
     fn provider_entry(
         &self,
         binding: &AgentModelBinding,
         model_names: &[&str],
         api_key_env: &str,
     ) -> anyhow::Result<serde_json::Value> {
-        let mut options = serde_json::json!({ "baseURL": opencode_base_url(binding) });
+        let base_url = self.proxy_base_url(binding);
+        let mut options = serde_json::json!({ "baseURL": base_url });
         if binding
             .api_key
             .as_ref()
@@ -474,6 +526,521 @@ impl OpenCodeLauncher {
                 (mapped_name, entry)
             })
             .collect()
+    }
+
+    /// Returns the baseURL to use for OpenCode provider entries. When a
+    /// session proxy is active (usage tracking enabled), returns the proxy's
+    /// local URL so all traffic flows through it for accounting -- the proxy
+    /// dispatches by the `"model"` field in each request body. Otherwise
+    /// delegates to `opencode_base_url` to compute the provider's real URL.
+    fn proxy_base_url(&self, binding: &AgentModelBinding) -> String {
+        match &self.model_proxy {
+            Some(handle) => handle.local_base_url.clone(),
+            None => opencode_base_url(binding),
+        }
+    }
+
+    /// Resolves `{env:VAR_NAME}` placeholders in a JSON value with the current
+    /// process environment. Leaves unknown variables as empty strings (matching
+    /// OpenCode's own behavior). Recurses into objects and arrays.
+    fn resolve_env_vars(value: &serde_json::Value) -> serde_json::Value {
+        match value {
+            serde_json::Value::String(s) => {
+                if s.starts_with("{env:") && s.ends_with('}') {
+                    let var_name = &s[5..s.len() - 1];
+                    serde_json::Value::String(std::env::var(var_name).unwrap_or_default())
+                } else {
+                    value.clone()
+                }
+            }
+            serde_json::Value::Object(map) => {
+                let resolved: serde_json::Map<_, _> = map
+                    .iter()
+                    .map(|(k, v)| (k.clone(), Self::resolve_env_vars(v)))
+                    .collect();
+                serde_json::Value::Object(resolved)
+            }
+            serde_json::Value::Array(arr) => {
+                let resolved: Vec<_> = arr.iter().map(Self::resolve_env_vars).collect();
+                serde_json::Value::Array(resolved)
+            }
+            other => other.clone(),
+        }
+    }
+
+    /// Loads and parses a user's OpenCode config file (JSON or JSONC).
+    /// Strips `//` and `/* ... */` comments before parsing. Returns `None` if
+    /// the file doesn't exist or can't be parsed.
+    fn load_user_config(path: &Path) -> Option<serde_json::Value> {
+        let content = std::fs::read_to_string(path).ok()?;
+        let content = Self::strip_jsonc_comments(&content);
+        serde_json::from_str(&content).ok()
+    }
+
+    /// Strip JSONC comments from `content`, respecting string literals (doesn't
+    /// strip `//` or `/*` inside quoted strings).
+    fn strip_jsonc_comments(content: &str) -> String {
+        let mut result = String::with_capacity(content.len());
+        let mut chars = content.chars().peekable();
+        let mut in_string = false;
+        let mut escape = false;
+
+        while let Some(c) = chars.next() {
+            if escape {
+                result.push(c);
+                escape = false;
+                continue;
+            }
+            if c == '\\' && in_string {
+                result.push(c);
+                escape = true;
+                continue;
+            }
+            if c == '"' {
+                in_string = !in_string;
+                result.push(c);
+                continue;
+            }
+            if in_string {
+                result.push(c);
+                continue;
+            }
+            if c == '/' {
+                if let Some(&next) = chars.peek() {
+                    if next == '/' {
+                        // Line comment: skip to end of line
+                        while let Some(&ch) = chars.peek() {
+                            if ch == '\n' {
+                                break;
+                            }
+                            chars.next();
+                        }
+                        continue;
+                    } else if next == '*' {
+                        // Block comment: skip to */
+                        chars.next(); // consume '*'
+                        while let Some(ch) = chars.next() {
+                            if ch == '*' {
+                                if chars.peek() == Some(&'/') {
+                                    chars.next();
+                                    break;
+                                }
+                            }
+                        }
+                        continue;
+                    }
+                }
+            }
+            result.push(c);
+        }
+        result
+    }
+
+    /// Extracts the `provider` object from a parsed OpenCode config. Returns
+    /// `None` if the config has no provider key or it's not an object.
+    fn extract_providers(config: &serde_json::Value) -> Option<&serde_json::Map<String, serde_json::Value>> {
+        config.get("provider").and_then(|v| v.as_object())
+    }
+
+    /// Discovers all providers the user has configured in their global and
+    /// project OpenCode configs. Reads `~/.config/opencode/opencode.json`
+    /// (global) and `{working_dir}/opencode.json` (project), extracts
+    /// `provider` entries, and returns the merged provider map (project
+    /// overrides global for conflicting keys).
+    fn discover_user_providers(ctx: &LaunchContext) -> Option<serde_json::Map<String, serde_json::Value>> {
+        let mut providers = serde_json::Map::new();
+
+        // Load global config (~/.config/opencode/opencode.json)
+        if let Some(global_config) = Self::load_global_opencode_config() {
+            let resolved = Self::resolve_env_vars(&global_config);
+            if let Some(global_providers) = Self::extract_providers(&resolved) {
+                for (key, value) in global_providers {
+                    providers.insert(key.clone(), value.clone());
+                }
+            }
+        }
+
+        // Load project config (overwrites global for conflicting keys)
+        let project_path = ctx.working_dir.join("opencode.json");
+        if let Some(project_config) = Self::load_user_config(&project_path) {
+            let resolved = Self::resolve_env_vars(&project_config);
+            if let Some(project_providers) = Self::extract_providers(&resolved) {
+                for (key, value) in project_providers {
+                    providers.insert(key.clone(), value.clone());
+                }
+            }
+        }
+
+        if providers.is_empty() {
+            None
+        } else {
+            Some(providers)
+        }
+    }
+
+    /// Returns the path to OpenCode's global config file.
+    fn global_opencode_config_path() -> Option<PathBuf> {
+        let home = std::env::var("XDG_CONFIG_HOME").ok().or_else(|| {
+            std::env::var("HOME").ok()
+        });
+        let path = match home.as_deref() {
+            Some(xdg) if !xdg.is_empty() => format!("{xdg}/opencode/opencode.json"),
+            _ => format!("/.config/opencode/opencode.json"),
+        };
+        let path = format!("%s{}", path.trim_start_matches('/'));
+        let home_path = home.map(|h| format!("{h}{path}"));
+        home_path.map(PathBuf::from)
+    }
+
+    /// Loads OpenCode's global config file and returns parsed JSON, or None.
+    fn load_global_opencode_config() -> Option<serde_json::Value> {
+        let path = Self::global_opencode_config_path()?;
+        Self::load_user_config(&path)
+    }
+
+    /// Registers discovered user providers on the session proxy so the proxy
+    /// can route and track traffic for them. For each provider with a
+    /// `baseURL`, registers the provider with its known model names and a
+    /// prefix-based fallback route. The prefix is derived from the base URL
+    /// (e.g. "api.openai.com" -> "gpt" prefix, "api.anthropic.com" -> "claude"
+    /// prefix) so that unknown model names from this provider still route
+    /// correctly. Also sets the proxy's default target to the first discovered
+    /// provider if no other default is set.
+    fn register_user_providers_on_proxy(
+        &self,
+        proxy_handle: &ProxyHandle,
+        user_providers: &serde_json::Map<String, serde_json::Value>,
+    ) {
+        for (provider_name, provider_entry) in user_providers {
+            let Some(options) = provider_entry
+                .get("options")
+                .and_then(|o| o.as_object())
+            else {
+                continue;
+            };
+
+            let Some(base_url) = options.get("baseURL")
+                .and_then(|b| b.as_str())
+            else {
+                continue;
+            };
+
+            // Skip if baseURL already points at the proxy
+            if base_url.contains("127.0.0.1") || base_url.contains("localhost") {
+                continue;
+            }
+
+            // Compute a model-name prefix from the base URL for fallback routing
+            let prefix = model_prefix_from_url(base_url);
+
+            // Extract model names from the provider's models map
+            let model_names: Vec<String> = provider_entry
+                .get("models")
+                .and_then(|m| m.as_object())
+                .map(|models| {
+                    models.keys().cloned().collect()
+                })
+                .unwrap_or_default();
+
+            let label = format!("user-provider-{}", provider_name);
+            if let Err(e) = proxy_handle.register_provider(
+                &prefix,
+                base_url.to_string(),
+                model_names,
+                label,
+            ) {
+                alog_channel!(
+                    MessageLevel::Debug3,
+                    "failed to register provider '{}' on proxy: {}",
+                    provider_name,
+                    e
+                );
+            }
+        }
+    }
+
+    /// Discovers env-based providers by checking for known API key environment
+    /// variables. Returns a map of provider name -> provider entry pointing at
+    /// the well-known base URL for each provider. These are providers that
+    /// OpenCode auto-loads when the corresponding env var is set, but don't
+    /// appear explicitly in the user's config files.
+    fn discover_env_providers() -> serde_json::Map<String, serde_json::Value> {
+        let mut providers = serde_json::Map::new();
+
+        // OpenAI
+        if std::env::var("OPENAI_API_KEY").is_ok() {
+            let mut entry = serde_json::Map::new();
+            entry.insert(
+                "npm".to_string(),
+                serde_json::Value::String("@openai/openai".to_string()),
+            );
+            entry.insert(
+                "name".to_string(),
+                serde_json::Value::String("openai".to_string()),
+            );
+            let mut options = serde_json::Map::new();
+            options.insert(
+                "baseURL".to_string(),
+                serde_json::Value::String("https://api.openai.com/v1".to_string()),
+            );
+            options.insert(
+                "apiKey".to_string(),
+                serde_json::Value::String("{env:OPENAI_API_KEY}".to_string()),
+            );
+            entry.insert("options".to_string(), serde_json::Value::Object(options));
+            providers.insert("openai".to_string(), serde_json::Value::Object(entry));
+        }
+
+        // Anthropic
+        if std::env::var("ANTHROPIC_API_KEY").is_ok() {
+            let mut entry = serde_json::Map::new();
+            entry.insert(
+                "npm".to_string(),
+                serde_json::Value::String("@anthropic-ai/anthropic".to_string()),
+            );
+            entry.insert(
+                "name".to_string(),
+                serde_json::Value::String("anthropic".to_string()),
+            );
+            let mut options = serde_json::Map::new();
+            options.insert(
+                "baseURL".to_string(),
+                serde_json::Value::String("https://api.anthropic.com".to_string()),
+            );
+            options.insert(
+                "apiKey".to_string(),
+                serde_json::Value::String("{env:ANTHROPIC_API_KEY}".to_string()),
+            );
+            entry.insert("options".to_string(), serde_json::Value::Object(options));
+            providers.insert("anthropic".to_string(), serde_json::Value::Object(entry));
+        }
+
+        // Google Gemini
+        if std::env::var("GOOGLE_API_KEY").is_ok() {
+            let mut entry = serde_json::Map::new();
+            entry.insert(
+                "npm".to_string(),
+                serde_json::Value::String("@google/generative-ai".to_string()),
+            );
+            entry.insert(
+                "name".to_string(),
+                serde_json::Value::String("google".to_string()),
+            );
+            let mut options = serde_json::Map::new();
+            options.insert(
+                "baseURL".to_string(),
+                serde_json::Value::String("https://generativelanguage.googleapis.com/v1beta".to_string()),
+            );
+            options.insert(
+                "apiKey".to_string(),
+                serde_json::Value::String("{env:GOOGLE_API_KEY}".to_string()),
+            );
+            entry.insert("options".to_string(), serde_json::Value::Object(options));
+            providers.insert("google".to_string(), serde_json::Value::Object(entry));
+        }
+
+        // Groq
+        if std::env::var("GROQ_API_KEY").is_ok() {
+            let mut entry = serde_json::Map::new();
+            entry.insert(
+                "npm".to_string(),
+                serde_json::Value::String("@ai-sdk/openai-compatible".to_string()),
+            );
+            entry.insert(
+                "name".to_string(),
+                serde_json::Value::String("groq".to_string()),
+            );
+            let mut options = serde_json::Map::new();
+            options.insert(
+                "baseURL".to_string(),
+                serde_json::Value::String("https://api.groq.com/openai/v1".to_string()),
+            );
+            options.insert(
+                "apiKey".to_string(),
+                serde_json::Value::String("{env:GROQ_API_KEY}".to_string()),
+            );
+            entry.insert("options".to_string(), serde_json::Value::Object(options));
+            providers.insert("groq".to_string(), serde_json::Value::Object(entry));
+        }
+
+        // OpenRouter
+        if std::env::var("OPENROUTER_API_KEY").is_ok() {
+            let mut entry = serde_json::Map::new();
+            entry.insert(
+                "npm".to_string(),
+                serde_json::Value::String("@ai-sdk/openai-compatible".to_string()),
+            );
+            entry.insert(
+                "name".to_string(),
+                serde_json::Value::String("openrouter".to_string()),
+            );
+            let mut options = serde_json::Map::new();
+            options.insert(
+                "baseURL".to_string(),
+                serde_json::Value::String("https://openrouter.ai/api/v1".to_string()),
+            );
+            options.insert(
+                "apiKey".to_string(),
+                serde_json::Value::String("{env:OPENROUTER_API_KEY}".to_string()),
+            );
+            entry.insert("options".to_string(), serde_json::Value::Object(options));
+            providers.insert("openrouter".to_string(), serde_json::Value::Object(entry));
+        }
+
+        // Cohere
+        if std::env::var("CO_API_KEY").is_ok() {
+            let mut entry = serde_json::Map::new();
+            entry.insert(
+                "npm".to_string(),
+                serde_json::Value::String("@ai-sdk/openai-compatible".to_string()),
+            );
+            entry.insert(
+                "name".to_string(),
+                serde_json::Value::String("cohere".to_string()),
+            );
+            let mut options = serde_json::Map::new();
+            options.insert(
+                "baseURL".to_string(),
+                serde_json::Value::String("https://api.cohere.com/v1".to_string()),
+            );
+            options.insert(
+                "apiKey".to_string(),
+                serde_json::Value::String("{env:CO_API_KEY}".to_string()),
+            );
+            entry.insert("options".to_string(), serde_json::Value::Object(options));
+            providers.insert("cohere".to_string(), serde_json::Value::Object(entry));
+        }
+
+        // Mistral
+        if std::env::var("MISTRAL_API_KEY").is_ok() {
+            let mut entry = serde_json::Map::new();
+            entry.insert(
+                "npm".to_string(),
+                serde_json::Value::String("@ai-sdk/openai-compatible".to_string()),
+            );
+            entry.insert(
+                "name".to_string(),
+                serde_json::Value::String("mistral".to_string()),
+            );
+            let mut options = serde_json::Map::new();
+            options.insert(
+                "baseURL".to_string(),
+                serde_json::Value::String("https://api.mistral.ai/v1".to_string()),
+            );
+            options.insert(
+                "apiKey".to_string(),
+                serde_json::Value::String("{env:MISTRAL_API_KEY}".to_string()),
+            );
+            entry.insert("options".to_string(), serde_json::Value::Object(options));
+            providers.insert("mistral".to_string(), serde_json::Value::Object(entry));
+        }
+
+        providers
+    }
+
+    /// Merges user-discovered and env-based providers into the generated config.
+    /// For each provider, creates a provider entry with `baseURL` pointing at
+    /// the proxy so all traffic flows through it. The proxy knows the real
+    /// upstream URL from `register_user_providers_on_proxy` and forwards
+    /// requests with usage tracking.
+    ///
+    /// Granite-cli provider entries (built from bindings) take precedence: if a
+    /// user also has a provider with the same name, our granite-cli entry
+    /// wins (since it's added to the map after the user entries).
+    fn merge_user_providers_into_config(
+        &self,
+        user_providers: &serde_json::Map<String, serde_json::Value>,
+        env_providers: &serde_json::Map<String, serde_json::Value>,
+        granite_providers: &serde_json::Map<String, serde_json::Value>,
+    ) -> serde_json::Map<String, serde_json::Value> {
+        let mut merged = serde_json::Map::new();
+
+        // Add user-discovered providers (redirected to proxy)
+        for (name, entry) in user_providers {
+            if let Some(entry_value) = entry.as_object() {
+                let mut proxied = entry_value.clone();
+                if let Some(options) = proxied.get_mut("options") {
+                    if let Some(options_obj) = options.as_object_mut() {
+                        if let Some(real_url) = options_obj.get("baseURL").and_then(|b| b.as_str()) {
+                            // Only redirect if it's a real external URL (not already proxy)
+                            if !real_url.contains("127.0.0.1") && !real_url.contains("localhost") {
+                                options_obj.insert(
+                                    "baseURL".to_string(),
+                                    serde_json::Value::String(
+                                        self.model_proxy.as_ref()
+                                            .map(|h| h.local_base_url.clone())
+                                            .unwrap_or_else(|| real_url.to_string()),
+                                    ),
+                                );
+                            }
+                        }
+                    }
+                }
+                merged.insert(name.clone(), serde_json::Value::Object(proxied));
+            }
+        }
+
+        // Add env-based providers (redirected to proxy)
+        for (name, entry) in env_providers {
+            if let Some(entry_value) = entry.as_object() {
+                let mut proxied = entry_value.clone();
+                if let Some(options) = proxied.get_mut("options") {
+                    if let Some(options_obj) = options.as_object_mut() {
+                        let proxy_url = self.model_proxy
+                            .as_ref()
+                            .map(|h| h.local_base_url.clone())
+                            .unwrap_or_else(|| {
+                                options_obj.get("baseURL")
+                                    .and_then(|b| b.as_str())
+                                    .unwrap_or("unknown")
+                                    .to_string()
+                            });
+                        options_obj.insert(
+                            "baseURL".to_string(),
+                            serde_json::Value::String(proxy_url),
+                        );
+                    }
+                }
+                merged.insert(name.clone(), serde_json::Value::Object(proxied));
+            }
+        }
+
+        // Add granite-cli providers (overrides user providers with same name)
+        for (name, entry) in granite_providers {
+            merged.insert(name.clone(), entry.clone());
+        }
+
+        merged
+    }
+}
+
+/// Derives a model-name prefix from a provider's base URL for use in proxy
+/// prefix-based fallback routing. The prefix is the shortest recognizable
+/// substring that uniquely identifies the provider's models, e.g. "gpt" for
+/// OpenAI, "claude" for Anthropic. This allows the proxy to route unknown
+/// model names (e.g. "gpt-4o-turbo") to the correct provider even when the
+/// exact model name wasn't registered in the user's config.
+fn model_prefix_from_url(base_url: &str) -> String {
+    let url = base_url.to_lowercase();
+    if url.contains("openai") || url.contains("api.openai.com") {
+        "gpt".to_string()
+    } else if url.contains("anthropic") || url.contains("api.anthropic.com") {
+        "claude".to_string()
+    } else if url.contains("google") || url.contains("generativelanguage") {
+        "gemini".to_string()
+    } else if url.contains("groq") {
+        "llama".to_string() // Groq commonly hosts Llama models
+    } else if url.contains("openrouter") {
+        "gpt".to_string() // OpenRouter hosts many models; default to gpt prefix
+    } else if url.contains("cohere") {
+        "command".to_string() // Cohere's models start with "command"
+    } else if url.contains("mistral") {
+        "mistral".to_string()
+    } else {
+        // Default: use a common model prefix or the hostname itself
+        url.split('/').find(|s| !s.is_empty() && !s.contains('.') && s.len() <= 20)
+            .unwrap_or("model")
+            .to_string()
     }
 }
 
@@ -1333,5 +1900,222 @@ mod tests {
         assert_eq!(l.bound_sub_agents.len(), 1);
         assert_eq!(l.bound_sub_agents[0].0, "reviewer");
         assert_eq!(l.bound_sub_agents[0].1.model.model_name, "granite4.1:8b");
+    }
+
+    // -- proxy base url --------------------------------------------------------
+
+    #[tokio::test]
+    async fn proxy_base_url_returns_proxy_url_when_model_proxy_is_set() {
+        let b = binding();
+        let server = crate::proxy::ProxyServer::start().unwrap();
+        let mut l = launcher(serde_json::json!({}));
+        l.model_proxy = Some(server.handle.clone());
+        assert_eq!(
+            l.proxy_base_url(&b),
+            server.handle.local_base_url
+        );
+        server.shutdown().await;
+    }
+
+    #[test]
+    fn proxy_base_url_returns_regular_url_when_no_model_proxy() {
+        let b = binding();
+        let l = launcher(serde_json::json!({}));
+        assert_eq!(l.proxy_base_url(&b), opencode_base_url(&b));
+    }
+
+    #[tokio::test]
+    async fn provider_entry_uses_proxy_url_when_model_proxy_is_active() {
+        let server = crate::proxy::ProxyServer::start().unwrap();
+        let mut l = launcher(serde_json::json!({}));
+        l.model_proxy = Some(server.handle.clone());
+        let b = binding();
+        let entry = l
+            .provider_entry(&b, &[b.model_name.as_str()], API_KEY_ENV)
+            .unwrap();
+        assert_eq!(entry["options"]["baseURL"], server.handle.local_base_url);
+        server.shutdown().await;
+    }
+
+    #[test]
+    fn provider_entry_uses_real_url_when_no_model_proxy() {
+        let l = launcher(serde_json::json!({}));
+        let b = binding();
+        let entry = l
+            .provider_entry(&b, &[b.model_name.as_str()], API_KEY_ENV)
+            .unwrap();
+        assert_eq!(entry["options"]["baseURL"], opencode_base_url(&b));
+    }
+
+    #[tokio::test]
+    async fn dry_run_launch_with_proxy_redirects_base_url() {
+        let server = crate::proxy::ProxyServer::start().unwrap();
+        let mut l = bound(serde_json::json!({ "command_path": "ls" }), binding());
+        l.model_proxy = Some(server.handle.clone());
+        let ui = CaptureUi::default();
+        l.launch(&[], &ctx(true), &ui).await.unwrap();
+
+        let infos = ui.infos.borrow();
+        let dump = infos.join("\n");
+        assert!(dump.contains(&server.handle.local_base_url), "{dump}");
+        server.shutdown().await;
+    }
+
+    // -- JSONC parsing -----------------------------------------------------------
+
+    #[test]
+    fn strip_jsonc_comments_strips_line_comments() {
+        let input = r#"{ "key": "value" // trailing comment }"#;
+        let result = OpenCodeLauncher::strip_jsonc_comments(input);
+        assert!(
+            !result.contains("//"),
+            "line comments should be stripped: {result}"
+        );
+        assert!(result.contains("\"value\""), "value should remain");
+    }
+
+    #[test]
+    fn strip_jsonc_comments_strips_block_comments() {
+        let input = r#"{ "key": "value" /* block comment */ }"#;
+        let result = OpenCodeLauncher::strip_jsonc_comments(input);
+        assert!(
+            !result.contains("/*"),
+            "block comments should be stripped: {result}"
+        );
+        assert!(result.contains("\"value\""));
+    }
+
+    #[test]
+    fn strip_jsonc_comments_preserves_comments_in_strings() {
+        let input = r#"{ "key": "// not a comment" }"#;
+        let result = OpenCodeLauncher::strip_jsonc_comments(input);
+        assert!(result.contains("// not a comment"));
+    }
+
+    #[test]
+    fn strip_jsonc_comments_handles_multiline_block_comments() {
+        let input = r#"{
+            "key": "value" /*
+                multiline
+                comment
+            */
+        }"#;
+        let result = OpenCodeLauncher::strip_jsonc_comments(input);
+        assert!(!result.contains("multiline"));
+        assert!(result.contains("\"value\""));
+    }
+
+    // -- env var resolution ------------------------------------------------------
+
+    #[test]
+    fn resolve_env_vars_resolves_string_placeholders() {
+        unsafe { std::env::set_var("TEST_VAR_123", "resolved_value"); }
+        let input = serde_json::json!({ "url": "{env:TEST_VAR_123}" });
+        let result = OpenCodeLauncher::resolve_env_vars(&input);
+        assert_eq!(result["url"], "resolved_value");
+        unsafe { std::env::remove_var("TEST_VAR_123"); }
+    }
+
+    #[test]
+    fn resolve_env_vars_uses_empty_string_for_unset_vars() {
+        unsafe { std::env::remove_var("NONEXISTENT_VAR_XYZ"); }
+        let input = serde_json::json!({ "url": "{env:NONEXISTENT_VAR_XYZ}" });
+        let result = OpenCodeLauncher::resolve_env_vars(&input);
+        assert_eq!(result["url"], "");
+    }
+
+    #[test]
+    fn resolve_env_vars_leaves_non_placeholder_strings_untouched() {
+        let input = serde_json::json!({ "url": "https://example.com" });
+        let result = OpenCodeLauncher::resolve_env_vars(&input);
+        assert_eq!(result["url"], "https://example.com");
+    }
+
+    #[test]
+    fn resolve_env_vars_recurses_into_objects() {
+        unsafe { std::env::set_var("TEST_URL_456", "https://resolved.com/v1"); }
+        let input = serde_json::json!({
+            "provider": {
+                "options": {
+                    "baseURL": "{env:TEST_URL_456}"
+                }
+            }
+        });
+        let result = OpenCodeLauncher::resolve_env_vars(&input);
+        assert_eq!(result["provider"]["options"]["baseURL"], "https://resolved.com/v1");
+        unsafe { std::env::remove_var("TEST_URL_456"); }
+    }
+
+    #[test]
+    fn resolve_env_vars_recurses_into_arrays() {
+        let input = serde_json::json!([1, "{env:HOME}", true]);
+        let result = OpenCodeLauncher::resolve_env_vars(&input);
+        assert_eq!(result[0], 1);
+        assert_eq!(result[1], std::env::var("HOME").unwrap_or_default());
+        assert_eq!(result[2], true);
+    }
+
+    // -- env providers discovery -------------------------------------------------
+
+    #[test]
+    fn discover_env_providers_returns_empty_when_no_keys_set() {
+        // Save original values
+        let saved = [
+            ("OPENAI_API_KEY", std::env::var("OPENAI_API_KEY").ok()),
+            ("ANTHROPIC_API_KEY", std::env::var("ANTHROPIC_API_KEY").ok()),
+            ("GOOGLE_API_KEY", std::env::var("GOOGLE_API_KEY").ok()),
+        ];
+        // Clear the env vars
+        for (key, _) in &saved {
+            unsafe { std::env::remove_var(key); }
+        }
+
+        let providers = OpenCodeLauncher::discover_env_providers();
+        assert!(
+            !providers.contains_key("openai"),
+            "openai should not be discovered"
+        );
+        assert!(
+            !providers.contains_key("anthropic"),
+            "anthropic should not be discovered"
+        );
+        assert!(
+            !providers.contains_key("google"),
+            "google should not be discovered"
+        );
+
+        // Restore original values
+        for (key, orig) in &saved {
+            if let Some(val) = orig {
+                unsafe { std::env::set_var(key, val); }
+            }
+        }
+    }
+
+    // -- user config discovery ---------------------------------------------------
+
+    #[test]
+    fn extract_providers_returns_none_for_missing_provider_key() {
+        let config = serde_json::json!({ "model": "openai/gpt-4o" });
+        assert!(OpenCodeLauncher::extract_providers(&config).is_none());
+    }
+
+    #[test]
+    fn extract_providers_returns_none_for_non_object_provider() {
+        let config = serde_json::json!({ "provider": "invalid" });
+        assert!(OpenCodeLauncher::extract_providers(&config).is_none());
+    }
+
+    #[test]
+    fn extract_providers_returns_some_for_valid_provider_object() {
+        let config = serde_json::json!({
+            "provider": {
+                "openai": { "name": "openai", "options": {} }
+            }
+        });
+        let providers = OpenCodeLauncher::extract_providers(&config);
+        assert!(providers.is_some());
+        let providers = providers.unwrap();
+        assert!(providers.contains_key("openai"));
     }
 }

--- a/src/launchers/opencode.rs
+++ b/src/launchers/opencode.rs
@@ -620,11 +620,9 @@ impl OpenCodeLauncher {
                         // Block comment: skip to */
                         chars.next(); // consume '*'
                         while let Some(ch) = chars.next() {
-                            if ch == '*' {
-                                if chars.peek() == Some(&'/') {
-                                    chars.next();
-                                    break;
-                                }
+                            if ch == '*' && chars.peek() == Some(&'/') {
+                                chars.next();
+                                break;
                             }
                         }
                         continue;
@@ -638,7 +636,9 @@ impl OpenCodeLauncher {
 
     /// Extracts the `provider` object from a parsed OpenCode config. Returns
     /// `None` if the config has no provider key or it's not an object.
-    fn extract_providers(config: &serde_json::Value) -> Option<&serde_json::Map<String, serde_json::Value>> {
+    fn extract_providers(
+        config: &serde_json::Value,
+    ) -> Option<&serde_json::Map<String, serde_json::Value>> {
         config.get("provider").and_then(|v| v.as_object())
     }
 
@@ -647,7 +647,9 @@ impl OpenCodeLauncher {
     /// (global) and `{working_dir}/opencode.json` (project), extracts
     /// `provider` entries, and returns the merged provider map (project
     /// overrides global for conflicting keys).
-    fn discover_user_providers(ctx: &LaunchContext) -> Option<serde_json::Map<String, serde_json::Value>> {
+    fn discover_user_providers(
+        ctx: &LaunchContext,
+    ) -> Option<serde_json::Map<String, serde_json::Value>> {
         let mut providers = serde_json::Map::new();
 
         // Load global config (~/.config/opencode/opencode.json)
@@ -678,18 +680,16 @@ impl OpenCodeLauncher {
         }
     }
 
-    /// Returns the path to OpenCode's global config file.
+    /// Returns the path to OpenCode's global config file:
+    /// `$XDG_CONFIG_HOME/opencode/opencode.json`, falling back to
+    /// `~/.config/opencode/opencode.json`.
     fn global_opencode_config_path() -> Option<PathBuf> {
-        let home = std::env::var("XDG_CONFIG_HOME").ok().or_else(|| {
-            std::env::var("HOME").ok()
-        });
-        let path = match home.as_deref() {
-            Some(xdg) if !xdg.is_empty() => format!("{xdg}/opencode/opencode.json"),
-            _ => format!("/.config/opencode/opencode.json"),
-        };
-        let path = format!("%s{}", path.trim_start_matches('/'));
-        let home_path = home.map(|h| format!("{h}{path}"));
-        home_path.map(PathBuf::from)
+        if let Ok(xdg) = std::env::var("XDG_CONFIG_HOME")
+            && !xdg.is_empty()
+        {
+            return Some(PathBuf::from(xdg).join("opencode").join("opencode.json"));
+        }
+        dirs::home_dir().map(|home| home.join(".config").join("opencode").join("opencode.json"))
     }
 
     /// Loads OpenCode's global config file and returns parsed JSON, or None.
@@ -699,29 +699,23 @@ impl OpenCodeLauncher {
     }
 
     /// Registers discovered user providers on the session proxy so the proxy
-    /// can route and track traffic for them. For each provider with a
-    /// `baseURL`, registers the provider with its known model names and a
-    /// prefix-based fallback route. The prefix is derived from the base URL
-    /// (e.g. "api.openai.com" -> "gpt" prefix, "api.anthropic.com" -> "claude"
-    /// prefix) so that unknown model names from this provider still route
-    /// correctly. Also sets the proxy's default target to the first discovered
-    /// provider if no other default is set.
+    /// can route and track traffic for them. Each provider with a `baseURL`
+    /// is registered under the proxy's `/providers/{name}` path prefix; the
+    /// generated config points the provider's `baseURL` at that prefix (see
+    /// `merge_user_providers_into_config`), so the proxy knows the upstream
+    /// from the URL alone and any model the provider serves routes and
+    /// tracks correctly without granite-cli knowing its name.
     fn register_user_providers_on_proxy(
         &self,
         proxy_handle: &ProxyHandle,
         user_providers: &serde_json::Map<String, serde_json::Value>,
     ) {
         for (provider_name, provider_entry) in user_providers {
-            let Some(options) = provider_entry
-                .get("options")
-                .and_then(|o| o.as_object())
-            else {
+            let Some(options) = provider_entry.get("options").and_then(|o| o.as_object()) else {
                 continue;
             };
 
-            let Some(base_url) = options.get("baseURL")
-                .and_then(|b| b.as_str())
-            else {
+            let Some(base_url) = options.get("baseURL").and_then(|b| b.as_str()) else {
                 continue;
             };
 
@@ -730,25 +724,10 @@ impl OpenCodeLauncher {
                 continue;
             }
 
-            // Compute a model-name prefix from the base URL for fallback routing
-            let prefix = model_prefix_from_url(base_url);
-
-            // Extract model names from the provider's models map
-            let model_names: Vec<String> = provider_entry
-                .get("models")
-                .and_then(|m| m.as_object())
-                .map(|models| {
-                    models.keys().cloned().collect()
-                })
-                .unwrap_or_default();
-
-            let label = format!("user-provider-{}", provider_name);
-            if let Err(e) = proxy_handle.register_provider(
-                &prefix,
-                base_url.to_string(),
-                model_names,
-                label,
-            ) {
+            let label = format!("user-provider-{provider_name}");
+            if let Err(e) =
+                proxy_handle.register_provider(provider_name, base_url.to_string(), label)
+            {
                 alog_channel!(
                     MessageLevel::Debug3,
                     "failed to register provider '{}' on proxy: {}",
@@ -829,7 +808,9 @@ impl OpenCodeLauncher {
             let mut options = serde_json::Map::new();
             options.insert(
                 "baseURL".to_string(),
-                serde_json::Value::String("https://generativelanguage.googleapis.com/v1beta".to_string()),
+                serde_json::Value::String(
+                    "https://generativelanguage.googleapis.com/v1beta".to_string(),
+                ),
             );
             options.insert(
                 "apiKey".to_string(),
@@ -947,6 +928,20 @@ impl OpenCodeLauncher {
     /// Granite-cli provider entries (built from bindings) take precedence: if a
     /// user also has a provider with the same name, our granite-cli entry
     /// wins (since it's added to the map after the user entries).
+    /// The proxy URL a discovered provider's `baseURL` is rewritten to:
+    /// the session proxy's `/providers/{name}` path prefix, from which the
+    /// proxy resolves the real upstream registered in
+    /// `register_user_providers_on_proxy`.
+    fn provider_proxy_url(&self, provider_name: &str) -> Option<String> {
+        self.model_proxy.as_ref().map(|handle| {
+            format!(
+                "{}/providers/{}",
+                handle.local_base_url.trim_end_matches('/'),
+                provider_name
+            )
+        })
+    }
+
     fn merge_user_providers_into_config(
         &self,
         user_providers: &serde_json::Map<String, serde_json::Value>,
@@ -959,22 +954,15 @@ impl OpenCodeLauncher {
         for (name, entry) in user_providers {
             if let Some(entry_value) = entry.as_object() {
                 let mut proxied = entry_value.clone();
-                if let Some(options) = proxied.get_mut("options") {
-                    if let Some(options_obj) = options.as_object_mut() {
-                        if let Some(real_url) = options_obj.get("baseURL").and_then(|b| b.as_str()) {
-                            // Only redirect if it's a real external URL (not already proxy)
-                            if !real_url.contains("127.0.0.1") && !real_url.contains("localhost") {
-                                options_obj.insert(
-                                    "baseURL".to_string(),
-                                    serde_json::Value::String(
-                                        self.model_proxy.as_ref()
-                                            .map(|h| h.local_base_url.clone())
-                                            .unwrap_or_else(|| real_url.to_string()),
-                                    ),
-                                );
-                            }
-                        }
-                    }
+                if let Some(options_obj) = proxied
+                    .get_mut("options")
+                    .and_then(|options| options.as_object_mut())
+                    && let Some(real_url) = options_obj.get("baseURL").and_then(|b| b.as_str())
+                    && !real_url.contains("127.0.0.1")
+                    && !real_url.contains("localhost")
+                    && let Some(proxy_url) = self.provider_proxy_url(name)
+                {
+                    options_obj.insert("baseURL".to_string(), serde_json::Value::String(proxy_url));
                 }
                 merged.insert(name.clone(), serde_json::Value::Object(proxied));
             }
@@ -984,22 +972,12 @@ impl OpenCodeLauncher {
         for (name, entry) in env_providers {
             if let Some(entry_value) = entry.as_object() {
                 let mut proxied = entry_value.clone();
-                if let Some(options) = proxied.get_mut("options") {
-                    if let Some(options_obj) = options.as_object_mut() {
-                        let proxy_url = self.model_proxy
-                            .as_ref()
-                            .map(|h| h.local_base_url.clone())
-                            .unwrap_or_else(|| {
-                                options_obj.get("baseURL")
-                                    .and_then(|b| b.as_str())
-                                    .unwrap_or("unknown")
-                                    .to_string()
-                            });
-                        options_obj.insert(
-                            "baseURL".to_string(),
-                            serde_json::Value::String(proxy_url),
-                        );
-                    }
+                if let Some(options_obj) = proxied
+                    .get_mut("options")
+                    .and_then(|options| options.as_object_mut())
+                    && let Some(proxy_url) = self.provider_proxy_url(name)
+                {
+                    options_obj.insert("baseURL".to_string(), serde_json::Value::String(proxy_url));
                 }
                 merged.insert(name.clone(), serde_json::Value::Object(proxied));
             }
@@ -1011,36 +989,6 @@ impl OpenCodeLauncher {
         }
 
         merged
-    }
-}
-
-/// Derives a model-name prefix from a provider's base URL for use in proxy
-/// prefix-based fallback routing. The prefix is the shortest recognizable
-/// substring that uniquely identifies the provider's models, e.g. "gpt" for
-/// OpenAI, "claude" for Anthropic. This allows the proxy to route unknown
-/// model names (e.g. "gpt-4o-turbo") to the correct provider even when the
-/// exact model name wasn't registered in the user's config.
-fn model_prefix_from_url(base_url: &str) -> String {
-    let url = base_url.to_lowercase();
-    if url.contains("openai") || url.contains("api.openai.com") {
-        "gpt".to_string()
-    } else if url.contains("anthropic") || url.contains("api.anthropic.com") {
-        "claude".to_string()
-    } else if url.contains("google") || url.contains("generativelanguage") {
-        "gemini".to_string()
-    } else if url.contains("groq") {
-        "llama".to_string() // Groq commonly hosts Llama models
-    } else if url.contains("openrouter") {
-        "gpt".to_string() // OpenRouter hosts many models; default to gpt prefix
-    } else if url.contains("cohere") {
-        "command".to_string() // Cohere's models start with "command"
-    } else if url.contains("mistral") {
-        "mistral".to_string()
-    } else {
-        // Default: use a common model prefix or the hostname itself
-        url.split('/').find(|s| !s.is_empty() && !s.contains('.') && s.len() <= 20)
-            .unwrap_or("model")
-            .to_string()
     }
 }
 
@@ -1910,10 +1858,7 @@ mod tests {
         let server = crate::proxy::ProxyServer::start().unwrap();
         let mut l = launcher(serde_json::json!({}));
         l.model_proxy = Some(server.handle.clone());
-        assert_eq!(
-            l.proxy_base_url(&b),
-            server.handle.local_base_url
-        );
+        assert_eq!(l.proxy_base_url(&b), server.handle.local_base_url);
         server.shutdown().await;
     }
 
@@ -1955,8 +1900,7 @@ mod tests {
         let ui = CaptureUi::default();
         l.launch(&[], &ctx(true), &ui).await.unwrap();
 
-        let infos = ui.infos.borrow();
-        let dump = infos.join("\n");
+        let dump = ui.infos.borrow().join("\n");
         assert!(dump.contains(&server.handle.local_base_url), "{dump}");
         server.shutdown().await;
     }
@@ -2009,16 +1953,22 @@ mod tests {
 
     #[test]
     fn resolve_env_vars_resolves_string_placeholders() {
-        unsafe { std::env::set_var("TEST_VAR_123", "resolved_value"); }
+        unsafe {
+            std::env::set_var("TEST_VAR_123", "resolved_value");
+        }
         let input = serde_json::json!({ "url": "{env:TEST_VAR_123}" });
         let result = OpenCodeLauncher::resolve_env_vars(&input);
         assert_eq!(result["url"], "resolved_value");
-        unsafe { std::env::remove_var("TEST_VAR_123"); }
+        unsafe {
+            std::env::remove_var("TEST_VAR_123");
+        }
     }
 
     #[test]
     fn resolve_env_vars_uses_empty_string_for_unset_vars() {
-        unsafe { std::env::remove_var("NONEXISTENT_VAR_XYZ"); }
+        unsafe {
+            std::env::remove_var("NONEXISTENT_VAR_XYZ");
+        }
         let input = serde_json::json!({ "url": "{env:NONEXISTENT_VAR_XYZ}" });
         let result = OpenCodeLauncher::resolve_env_vars(&input);
         assert_eq!(result["url"], "");
@@ -2033,7 +1983,9 @@ mod tests {
 
     #[test]
     fn resolve_env_vars_recurses_into_objects() {
-        unsafe { std::env::set_var("TEST_URL_456", "https://resolved.com/v1"); }
+        unsafe {
+            std::env::set_var("TEST_URL_456", "https://resolved.com/v1");
+        }
         let input = serde_json::json!({
             "provider": {
                 "options": {
@@ -2042,8 +1994,13 @@ mod tests {
             }
         });
         let result = OpenCodeLauncher::resolve_env_vars(&input);
-        assert_eq!(result["provider"]["options"]["baseURL"], "https://resolved.com/v1");
-        unsafe { std::env::remove_var("TEST_URL_456"); }
+        assert_eq!(
+            result["provider"]["options"]["baseURL"],
+            "https://resolved.com/v1"
+        );
+        unsafe {
+            std::env::remove_var("TEST_URL_456");
+        }
     }
 
     #[test]
@@ -2067,7 +2024,9 @@ mod tests {
         ];
         // Clear the env vars
         for (key, _) in &saved {
-            unsafe { std::env::remove_var(key); }
+            unsafe {
+                std::env::remove_var(key);
+            }
         }
 
         let providers = OpenCodeLauncher::discover_env_providers();
@@ -2087,7 +2046,9 @@ mod tests {
         // Restore original values
         for (key, orig) in &saved {
             if let Some(val) = orig {
-                unsafe { std::env::set_var(key, val); }
+                unsafe {
+                    std::env::set_var(key, val);
+                }
             }
         }
     }
@@ -2104,6 +2065,66 @@ mod tests {
     fn extract_providers_returns_none_for_non_object_provider() {
         let config = serde_json::json!({ "provider": "invalid" });
         assert!(OpenCodeLauncher::extract_providers(&config).is_none());
+    }
+
+    #[tokio::test]
+    async fn merge_user_providers_rewrites_base_urls_to_provider_paths() {
+        let server = crate::proxy::ProxyServer::start().unwrap();
+        let mut l = launcher(serde_json::json!({}));
+        l.model_proxy = Some(server.handle.clone());
+
+        let user: serde_json::Map<String, serde_json::Value> = serde_json::json!({
+            "openrouter": {
+                "npm": "@ai-sdk/openai-compatible",
+                "options": { "baseURL": "https://openrouter.ai/api/v1" }
+            },
+            "local-vllm": {
+                "options": { "baseURL": "http://localhost:8000/v1" }
+            },
+            "my-ollama": {
+                "options": { "baseURL": "https://should-be.overridden" }
+            }
+        })
+        .as_object()
+        .unwrap()
+        .clone();
+        let env: serde_json::Map<String, serde_json::Value> = serde_json::json!({
+            "anthropic": {
+                "options": { "baseURL": "https://api.anthropic.com" }
+            }
+        })
+        .as_object()
+        .unwrap()
+        .clone();
+        let granite: serde_json::Map<String, serde_json::Value> = serde_json::json!({
+            "my-ollama": { "options": { "baseURL": "granite-entry" } }
+        })
+        .as_object()
+        .unwrap()
+        .clone();
+
+        let merged = l.merge_user_providers_into_config(&user, &env, &granite);
+
+        let proxy = server
+            .handle
+            .local_base_url
+            .trim_end_matches('/')
+            .to_string();
+        assert_eq!(
+            merged["openrouter"]["options"]["baseURL"],
+            format!("{proxy}/providers/openrouter")
+        );
+        assert_eq!(
+            merged["anthropic"]["options"]["baseURL"],
+            format!("{proxy}/providers/anthropic")
+        );
+        assert_eq!(
+            merged["local-vllm"]["options"]["baseURL"],
+            "http://localhost:8000/v1"
+        );
+        assert_eq!(merged["my-ollama"]["options"]["baseURL"], "granite-entry");
+
+        server.shutdown().await;
     }
 
     #[test]

--- a/src/launchers/opencode.rs
+++ b/src/launchers/opencode.rs
@@ -283,28 +283,23 @@ impl Launcher for OpenCodeLauncher {
                 granite_providers.insert(binding.provider_name.clone(), entry);
             }
 
-            // Discover and register user providers for usage tracking
+            // Discover and register user providers for usage tracking.
+            // Every provider merged into the generated config must also be
+            // registered on the proxy: a provider path the proxy doesn't
+            // recognize is rejected rather than forwarded (see
+            // `target_and_label_for`), so an entry in one set but not the
+            // other would break that provider outright.
             if let Some(proxy_handle) = &self.model_proxy {
-                // Discover user's configured providers from their config files
-                if let Some(user_providers) = Self::discover_user_providers(ctx) {
-                    // Register on proxy so the proxy can route and track them
+                let user_providers = Self::discover_user_providers(ctx).unwrap_or_default();
+                let env_providers = Self::discover_env_providers();
+                if !user_providers.is_empty() || !env_providers.is_empty() {
+                    self.register_user_providers_on_proxy(proxy_handle, &env_providers);
                     self.register_user_providers_on_proxy(proxy_handle, &user_providers);
                     granite_providers = self.merge_user_providers_into_config(
                         &user_providers,
-                        &Self::discover_env_providers(),
+                        &env_providers,
                         &granite_providers,
                     );
-                } else {
-                    // No user config providers — discover env-based ones
-                    let env_providers = Self::discover_env_providers();
-                    if !env_providers.is_empty() {
-                        self.register_user_providers_on_proxy(proxy_handle, &env_providers);
-                        granite_providers = self.merge_user_providers_into_config(
-                            &serde_json::Map::new(),
-                            &env_providers,
-                            &granite_providers,
-                        );
-                    }
                 }
             }
 
@@ -652,24 +647,25 @@ impl OpenCodeLauncher {
     ) -> Option<serde_json::Map<String, serde_json::Value>> {
         let mut providers = serde_json::Map::new();
 
-        // Load global config (~/.config/opencode/opencode.json)
-        if let Some(global_config) = Self::load_global_opencode_config() {
-            let resolved = Self::resolve_env_vars(&global_config);
-            if let Some(global_providers) = Self::extract_providers(&resolved) {
-                for (key, value) in global_providers {
-                    providers.insert(key.clone(), value.clone());
-                }
+        // Load global config (~/.config/opencode/opencode.json). Entries are
+        // kept verbatim -- `{env:VAR}` references included -- so secrets
+        // never land in the generated config; only `baseURL` is resolved,
+        // at proxy-registration time.
+        if let Some(global_config) = Self::load_global_opencode_config()
+            && let Some(global_providers) = Self::extract_providers(&global_config)
+        {
+            for (key, value) in global_providers {
+                providers.insert(key.clone(), value.clone());
             }
         }
 
         // Load project config (overwrites global for conflicting keys)
         let project_path = ctx.working_dir.join("opencode.json");
-        if let Some(project_config) = Self::load_user_config(&project_path) {
-            let resolved = Self::resolve_env_vars(&project_config);
-            if let Some(project_providers) = Self::extract_providers(&resolved) {
-                for (key, value) in project_providers {
-                    providers.insert(key.clone(), value.clone());
-                }
+        if let Some(project_config) = Self::load_user_config(&project_path)
+            && let Some(project_providers) = Self::extract_providers(&project_config)
+        {
+            for (key, value) in project_providers {
+                providers.insert(key.clone(), value.clone());
             }
         }
 
@@ -715,7 +711,8 @@ impl OpenCodeLauncher {
                 continue;
             };
 
-            let Some(base_url) = options.get("baseURL").and_then(|b| b.as_str()) else {
+            let resolved_base_url = options.get("baseURL").map(Self::resolve_env_vars);
+            let Some(base_url) = resolved_base_url.as_ref().and_then(|b| b.as_str()) else {
                 continue;
             };
 
@@ -2076,7 +2073,10 @@ mod tests {
         let user: serde_json::Map<String, serde_json::Value> = serde_json::json!({
             "openrouter": {
                 "npm": "@ai-sdk/openai-compatible",
-                "options": { "baseURL": "https://openrouter.ai/api/v1" }
+                "options": {
+                    "baseURL": "https://openrouter.ai/api/v1",
+                    "apiKey": "{env:OPENROUTER_API_KEY}"
+                }
             },
             "local-vllm": {
                 "options": { "baseURL": "http://localhost:8000/v1" }
@@ -2113,6 +2113,10 @@ mod tests {
         assert_eq!(
             merged["openrouter"]["options"]["baseURL"],
             format!("{proxy}/providers/openrouter")
+        );
+        assert_eq!(
+            merged["openrouter"]["options"]["apiKey"],
+            "{env:OPENROUTER_API_KEY}"
         );
         assert_eq!(
             merged["anthropic"]["options"]["baseURL"],

--- a/src/proxy/server.rs
+++ b/src/proxy/server.rs
@@ -100,8 +100,40 @@ impl ProxyHandle {
         Ok(())
     }
 
+    /// Registers a provider with its known model names and a prefix-based
+    /// fallback route. When a request's `"model"` field doesn't match any
+    /// exact route, the proxy checks if the model name starts with the
+    /// provider's prefix (e.g. "gpt" for OpenAI, "claude" for Anthropic) and
+    /// routes to this provider's target. This ensures traffic for unknown
+    /// models from a known provider still reaches the right upstream and gets
+    /// tracked. Works whether the proxy is already serving traffic or not.
+    pub fn register_provider(
+        &self,
+        provider_name: &str,
+        base_url: String,
+        models: Vec<String>,
+        label: String,
+    ) -> anyhow::Result<()> {
+        let resolved = ResolvedTarget::build(UpstreamTarget {
+            base_url,
+            verify_ssl: true,
+            auth: UpstreamAuth::Passthrough,
+        })?;
+        let mut table = self.state.routing.write().unwrap();
+        // Register known models as exact routes
+        for model in &models {
+            table.routes.insert(model.clone(), resolved.clone());
+            table.labels.insert(model.clone(), label.clone());
+        }
+        // Register the provider prefix for fallback matching
+        table
+            .provider_prefixes
+            .push((provider_name.to_string(), resolved, label));
+        Ok(())
+    }
+
     /// Sets (or replaces) the fallback target used for requests whose
-    /// `"model"` field doesn't match any registered route.
+    /// `"model"` field doesn't match any registered route or provider prefix.
     pub fn set_default(&self, target: UpstreamTarget, label: String) -> anyhow::Result<()> {
         let resolved = ResolvedTarget::build(target)?;
         let mut table = self.state.routing.write().unwrap();
@@ -175,6 +207,7 @@ impl ProxyServer {
             default_label: "default".to_string(),
             routes: HashMap::new(),
             labels: HashMap::new(),
+            provider_prefixes: Vec::new(),
         }));
         let tracker = Arc::new(UsageTracker::new());
         let state = ProxyState { routing, tracker };
@@ -237,6 +270,11 @@ struct RoutingTable {
     default_label: String,
     routes: HashMap<String, ResolvedTarget>,
     labels: HashMap<String, String>,
+    /// Provider prefixes for fallback routing: when a request's model doesn't
+    /// match any exact route, check if it starts with a registered provider's
+    /// prefix (e.g. "gpt" matches OpenAI, "claude" matches Anthropic). The
+    /// first matching provider in insertion order is used.
+    provider_prefixes: Vec<(String, ResolvedTarget, String)>,
 }
 
 impl RoutingTable {
@@ -266,6 +304,16 @@ impl RoutingTable {
                 .cloned()
                 .unwrap_or_else(|| model.clone());
             return (target.clone(), label);
+        }
+        // No exact model match — check provider prefixes as fallback.
+        // E.g. "gpt-4o" matches the "gpt" prefix for OpenAI providers,
+        // "claude-sonnet-4-5" matches "claude" for Anthropic, etc.
+        if let Some(model) = &model {
+            for (prefix, target, label) in &self.provider_prefixes {
+                if model.starts_with(prefix) {
+                    return (target.clone(), label.clone());
+                }
+            }
         }
         let label = model.unwrap_or_else(|| self.default_label.clone());
         (self.default.clone(), label)
@@ -1004,5 +1052,160 @@ mod tests {
         assert_eq!(chat.requests, 1);
         assert_eq!(chat.input_tokens, 5);
         assert_eq!(chat.output_tokens, 9);
+    }
+
+    #[tokio::test]
+    async fn register_provider_registers_known_models_and_prefix_fallback() {
+        let provider_addr = spawn_echo_server().await;
+        let default_addr = spawn_echo_server().await;
+        let server = ProxyServer::start().unwrap();
+
+        // Register a provider with known models and prefix fallback using "gpt" prefix
+        server
+            .handle
+            .register_provider(
+                "gpt",
+                format!("http://{provider_addr}"),
+                vec!["gpt-4o".to_string(), "o1".to_string()],
+                "openai".to_string(),
+            )
+            .unwrap();
+
+        // Known model routes to the provider
+        let client = reqwest::Client::new();
+        let resp = client
+            .post(format!("{}/v1/usage", server.handle.local_base_url))
+            .json(&serde_json::json!({ "model": "gpt-4o" }))
+            .send()
+            .await
+            .unwrap();
+        assert!(resp.status().is_success());
+
+        // Unknown model with matching prefix routes to the provider
+        let resp = client
+            .post(format!("{}/v1/usage", server.handle.local_base_url))
+            .json(&serde_json::json!({ "model": "gpt-4o-mini" }))
+            .send()
+            .await
+            .unwrap();
+        assert!(resp.status().is_success());
+
+        // Model without matching prefix falls through to default
+        server
+            .handle
+            .set_default(
+                target(format!("http://{default_addr}"), UpstreamAuth::Passthrough),
+                "default".to_string(),
+            )
+            .unwrap();
+
+        let resp = client
+            .post(format!("{}/v1/usage", server.handle.local_base_url))
+            .json(&serde_json::json!({ "model": "claude-sonnet" }))
+            .send()
+            .await
+            .unwrap();
+        assert!(resp.status().is_success());
+
+        let snapshot = server.handle.tracker().snapshot();
+        assert!(snapshot.get("gpt-4o").is_some() || snapshot.get("openai").is_some());
+        assert!(snapshot.get("gpt-4o-mini").is_some() || snapshot.get("openai").is_some());
+
+        server.shutdown().await;
+    }
+
+    #[tokio::test]
+    async fn provider_prefix_first_match_wins() {
+        let addr1 = spawn_echo_server().await;
+        let addr2 = spawn_echo_server().await;
+        let server = ProxyServer::start().unwrap();
+
+        // Register two providers with model-name prefixes: "gpt" matches OpenAI, "gemini" matches Google
+        server
+            .handle
+            .register_provider(
+                "gpt",
+                format!("http://{addr1}"),
+                vec!["gpt-4o".to_string()],
+                "openai".to_string(),
+            )
+            .unwrap();
+        server
+            .handle
+            .register_provider(
+                "gemini",
+                format!("http://{addr2}"),
+                vec!["gemini-pro".to_string()],
+                "google".to_string(),
+            )
+            .unwrap();
+
+        let client = reqwest::Client::new();
+
+        // "gpt-4o" matches openai's known model
+        let resp = client
+            .post(format!("{}/v1/usage", server.handle.local_base_url))
+            .json(&serde_json::json!({ "model": "gpt-4o" }))
+            .send()
+            .await
+            .unwrap();
+        assert!(resp.status().is_success());
+
+        // "gpt-4" matches openai's prefix
+        let resp = client
+            .post(format!("{}/v1/usage", server.handle.local_base_url))
+            .json(&serde_json::json!({ "model": "gpt-4" }))
+            .send()
+            .await
+            .unwrap();
+        assert!(resp.status().is_success());
+
+        // "gemini-pro" matches google's known model
+        let resp = client
+            .post(format!("{}/v1/usage", server.handle.local_base_url))
+            .json(&serde_json::json!({ "model": "gemini-pro" }))
+            .send()
+            .await
+            .unwrap();
+        assert!(resp.status().is_success());
+
+        server.shutdown().await;
+    }
+
+    #[tokio::test]
+    async fn proxy_prefix_routing_records_usage_for_fallback_matched_models() {
+        let provider_addr = spawn_echo_server().await;
+        let server = ProxyServer::start().unwrap();
+
+        server
+            .handle
+            .register_provider(
+                "gpt",
+                format!("http://{provider_addr}"),
+                vec!["gpt-4o".to_string()],
+                "openai".to_string(),
+            )
+            .unwrap();
+
+        let client = reqwest::Client::new();
+
+        // Send a request for an unknown model that matches the prefix
+        client
+            .post(format!("{}/v1/usage", server.handle.local_base_url))
+            .json(&serde_json::json!({ "model": "gpt-4o-turbo" }))
+            .send()
+            .await
+            .unwrap();
+
+        let snapshot = server.handle.tracker().snapshot();
+        // Should be tracked under the provider label
+        let openai_stats = snapshot.get("openai");
+        assert!(
+            openai_stats.is_some(),
+            "expected 'openai' in snapshot: {:?}",
+            snapshot
+        );
+
+        server.shutdown().await;
     }
 }

--- a/src/proxy/server.rs
+++ b/src/proxy/server.rs
@@ -100,18 +100,16 @@ impl ProxyHandle {
         Ok(())
     }
 
-    /// Registers a provider with its known model names and a prefix-based
-    /// fallback route. When a request's `"model"` field doesn't match any
-    /// exact route, the proxy checks if the model name starts with the
-    /// provider's prefix (e.g. "gpt" for OpenAI, "claude" for Anthropic) and
-    /// routes to this provider's target. This ensures traffic for unknown
-    /// models from a known provider still reaches the right upstream and gets
-    /// tracked. Works whether the proxy is already serving traffic or not.
+    /// Registers a provider under the path prefix `/providers/{name}`.
+    /// A request arriving on that prefix is forwarded to the provider's
+    /// real upstream with the prefix stripped, so routing is decided by the
+    /// URL the launcher wrote into the tool's config rather than by guessing
+    /// which provider a model name belongs to. Auth is passed through
+    /// untouched. Works whether the proxy is already serving traffic or not.
     pub fn register_provider(
         &self,
         provider_name: &str,
         base_url: String,
-        models: Vec<String>,
         label: String,
     ) -> anyhow::Result<()> {
         let resolved = ResolvedTarget::build(UpstreamTarget {
@@ -120,15 +118,9 @@ impl ProxyHandle {
             auth: UpstreamAuth::Passthrough,
         })?;
         let mut table = self.state.routing.write().unwrap();
-        // Register known models as exact routes
-        for model in &models {
-            table.routes.insert(model.clone(), resolved.clone());
-            table.labels.insert(model.clone(), label.clone());
-        }
-        // Register the provider prefix for fallback matching
         table
-            .provider_prefixes
-            .push((provider_name.to_string(), resolved, label));
+            .providers
+            .insert(provider_name.to_string(), (resolved, label));
         Ok(())
     }
 
@@ -207,7 +199,7 @@ impl ProxyServer {
             default_label: "default".to_string(),
             routes: HashMap::new(),
             labels: HashMap::new(),
-            provider_prefixes: Vec::new(),
+            providers: HashMap::new(),
         }));
         let tracker = Arc::new(UsageTracker::new());
         let state = ProxyState { routing, tracker };
@@ -270,11 +262,12 @@ struct RoutingTable {
     default_label: String,
     routes: HashMap<String, ResolvedTarget>,
     labels: HashMap<String, String>,
-    /// Provider prefixes for fallback routing: when a request's model doesn't
-    /// match any exact route, check if it starts with a registered provider's
-    /// prefix (e.g. "gpt" matches OpenAI, "claude" matches Anthropic). The
-    /// first matching provider in insertion order is used.
-    provider_prefixes: Vec<(String, ResolvedTarget, String)>,
+    /// Providers registered for path-based routing, keyed by name: a request
+    /// whose path starts with `/providers/{name}/` is forwarded to this
+    /// provider's target with the prefix stripped. Decided by URL rather
+    /// than by the request's model name, so models the provider serves but
+    /// granite-cli has never heard of still route and track correctly.
+    providers: HashMap<String, (ResolvedTarget, String)>,
 }
 
 impl RoutingTable {
@@ -293,8 +286,21 @@ impl RoutingTable {
     /// `default_label` is used only when the body has no identifiable
     /// model name at all (non-JSON body, or a missing/non-string `"model"`
     /// field).
-    fn target_and_label_for(&self, body: &[u8]) -> (ResolvedTarget, String) {
+    fn target_and_label_for(
+        &self,
+        path_and_query: &str,
+        body: &[u8],
+    ) -> (ResolvedTarget, String, String) {
         let model = model_from_body(body);
+        if let Some((name, rest)) = split_provider_path(path_and_query)
+            && let Some((target, label)) = self.providers.get(name)
+        {
+            let label = match &model {
+                Some(model) => format!("{label}/{model}"),
+                None => label.clone(),
+            };
+            return (target.clone(), label, rest.to_string());
+        }
         if let Some(model) = &model
             && let Some(target) = self.routes.get(model)
         {
@@ -303,21 +309,24 @@ impl RoutingTable {
                 .get(model)
                 .cloned()
                 .unwrap_or_else(|| model.clone());
-            return (target.clone(), label);
-        }
-        // No exact model match — check provider prefixes as fallback.
-        // E.g. "gpt-4o" matches the "gpt" prefix for OpenAI providers,
-        // "claude-sonnet-4-5" matches "claude" for Anthropic, etc.
-        if let Some(model) = &model {
-            for (prefix, target, label) in &self.provider_prefixes {
-                if model.starts_with(prefix) {
-                    return (target.clone(), label.clone());
-                }
-            }
+            return (target.clone(), label, path_and_query.to_string());
         }
         let label = model.unwrap_or_else(|| self.default_label.clone());
-        (self.default.clone(), label)
+        (self.default.clone(), label, path_and_query.to_string())
     }
+}
+
+/// Splits `/providers/{name}/rest...` into `(name, /rest...)`. Returns
+/// `None` for any other path shape, including a bare `/providers/{name}`
+/// with nothing to forward.
+fn split_provider_path(path_and_query: &str) -> Option<(&str, &str)> {
+    let rest = path_and_query.strip_prefix("/providers/")?;
+    let slash = rest.find('/')?;
+    let (name, remainder) = rest.split_at(slash);
+    if name.is_empty() {
+        return None;
+    }
+    Some((name, remainder))
 }
 
 /// Reads the top-level `"model"` string out of a JSON request body. A
@@ -387,17 +396,13 @@ async fn forward(
     body: Body,
 ) -> anyhow::Result<Response> {
     let body_bytes = axum::body::to_bytes(body, usize::MAX).await?;
-    let (target, label) = {
+    let path_and_query = uri.path_and_query().map(|p| p.as_str()).unwrap_or("/");
+    let (target, label, forward_path) = {
         let table = state.routing.read().unwrap();
-        table.target_and_label_for(&body_bytes)
+        table.target_and_label_for(path_and_query, &body_bytes)
     };
 
-    let path_and_query = uri.path_and_query().map(|p| p.as_str()).unwrap_or("/");
-    let url = format!(
-        "{}{}",
-        target.base_url.trim_end_matches('/'),
-        path_and_query
-    );
+    let url = format!("{}{}", target.base_url.trim_end_matches('/'), forward_path);
 
     let outbound_method = reqwest::Method::from_bytes(method.as_str().as_bytes())?;
     alog_channel!(
@@ -1054,43 +1059,31 @@ mod tests {
         assert_eq!(chat.output_tokens, 9);
     }
 
+    #[test]
+    fn split_provider_path_extracts_name_and_remainder() {
+        assert_eq!(
+            split_provider_path("/providers/openai/v1/usage"),
+            Some(("openai", "/v1/usage"))
+        );
+        assert_eq!(split_provider_path("/providers/openai"), None);
+        assert_eq!(split_provider_path("/providers//v1/usage"), None);
+        assert_eq!(split_provider_path("/v1/usage"), None);
+    }
+
     #[tokio::test]
-    async fn register_provider_registers_known_models_and_prefix_fallback() {
+    async fn register_provider_routes_by_path_prefix_and_strips_it() {
         let provider_addr = spawn_echo_server().await;
         let default_addr = spawn_echo_server().await;
         let server = ProxyServer::start().unwrap();
 
-        // Register a provider with known models and prefix fallback using "gpt" prefix
         server
             .handle
             .register_provider(
-                "gpt",
+                "openai",
                 format!("http://{provider_addr}"),
-                vec!["gpt-4o".to_string(), "o1".to_string()],
                 "openai".to_string(),
             )
             .unwrap();
-
-        // Known model routes to the provider
-        let client = reqwest::Client::new();
-        let resp = client
-            .post(format!("{}/v1/usage", server.handle.local_base_url))
-            .json(&serde_json::json!({ "model": "gpt-4o" }))
-            .send()
-            .await
-            .unwrap();
-        assert!(resp.status().is_success());
-
-        // Unknown model with matching prefix routes to the provider
-        let resp = client
-            .post(format!("{}/v1/usage", server.handle.local_base_url))
-            .json(&serde_json::json!({ "model": "gpt-4o-mini" }))
-            .send()
-            .await
-            .unwrap();
-        assert!(resp.status().is_success());
-
-        // Model without matching prefix falls through to default
         server
             .handle
             .set_default(
@@ -1099,112 +1092,102 @@ mod tests {
             )
             .unwrap();
 
+        // A model granite-cli has never heard of routes via the path prefix;
+        // the echo server only serves /v1/usage, so success proves the
+        // /providers/openai prefix was stripped before forwarding.
+        let client = reqwest::Client::new();
         let resp = client
-            .post(format!("{}/v1/usage", server.handle.local_base_url))
-            .json(&serde_json::json!({ "model": "claude-sonnet" }))
+            .post(format!(
+                "{}/providers/openai/v1/usage",
+                server.handle.local_base_url
+            ))
+            .json(&serde_json::json!({ "model": "gpt-4o-mini" }))
             .send()
             .await
             .unwrap();
         assert!(resp.status().is_success());
 
-        let snapshot = server.handle.tracker().snapshot();
-        assert!(snapshot.get("gpt-4o").is_some() || snapshot.get("openai").is_some());
-        assert!(snapshot.get("gpt-4o-mini").is_some() || snapshot.get("openai").is_some());
+        // An unregistered provider path falls through to the default target
+        // with the path untouched, which the echo server rejects.
+        let resp = client
+            .post(format!(
+                "{}/providers/unknown/v1/usage",
+                server.handle.local_base_url
+            ))
+            .json(&serde_json::json!({ "model": "gpt-4o-mini" }))
+            .send()
+            .await
+            .unwrap();
+        assert!(!resp.status().is_success());
 
         server.shutdown().await;
     }
 
     #[tokio::test]
-    async fn provider_prefix_first_match_wins() {
+    async fn provider_path_routing_separates_two_providers() {
         let addr1 = spawn_echo_server().await;
         let addr2 = spawn_echo_server().await;
         let server = ProxyServer::start().unwrap();
 
-        // Register two providers with model-name prefixes: "gpt" matches OpenAI, "gemini" matches Google
         server
             .handle
-            .register_provider(
-                "gpt",
-                format!("http://{addr1}"),
-                vec!["gpt-4o".to_string()],
-                "openai".to_string(),
-            )
+            .register_provider("openai", format!("http://{addr1}"), "openai".to_string())
             .unwrap();
         server
             .handle
-            .register_provider(
-                "gemini",
-                format!("http://{addr2}"),
-                vec!["gemini-pro".to_string()],
-                "google".to_string(),
-            )
+            .register_provider("google", format!("http://{addr2}"), "google".to_string())
             .unwrap();
 
         let client = reqwest::Client::new();
+        for (provider, model) in [("openai", "gpt-4o"), ("google", "gemini-pro")] {
+            let resp = client
+                .post(format!(
+                    "{}/providers/{provider}/v1/usage",
+                    server.handle.local_base_url
+                ))
+                .json(&serde_json::json!({ "model": model }))
+                .send()
+                .await
+                .unwrap();
+            assert!(resp.status().is_success());
+        }
 
-        // "gpt-4o" matches openai's known model
-        let resp = client
-            .post(format!("{}/v1/usage", server.handle.local_base_url))
-            .json(&serde_json::json!({ "model": "gpt-4o" }))
-            .send()
-            .await
-            .unwrap();
-        assert!(resp.status().is_success());
-
-        // "gpt-4" matches openai's prefix
-        let resp = client
-            .post(format!("{}/v1/usage", server.handle.local_base_url))
-            .json(&serde_json::json!({ "model": "gpt-4" }))
-            .send()
-            .await
-            .unwrap();
-        assert!(resp.status().is_success());
-
-        // "gemini-pro" matches google's known model
-        let resp = client
-            .post(format!("{}/v1/usage", server.handle.local_base_url))
-            .json(&serde_json::json!({ "model": "gemini-pro" }))
-            .send()
-            .await
-            .unwrap();
-        assert!(resp.status().is_success());
+        let snapshot = server.handle.tracker().snapshot();
+        assert!(snapshot.contains_key("openai/gpt-4o"), "{snapshot:?}");
+        assert!(snapshot.contains_key("google/gemini-pro"), "{snapshot:?}");
 
         server.shutdown().await;
     }
 
     #[tokio::test]
-    async fn proxy_prefix_routing_records_usage_for_fallback_matched_models() {
+    async fn provider_path_routing_records_usage_per_provider_and_model() {
         let provider_addr = spawn_echo_server().await;
         let server = ProxyServer::start().unwrap();
 
         server
             .handle
             .register_provider(
-                "gpt",
+                "openrouter",
                 format!("http://{provider_addr}"),
-                vec!["gpt-4o".to_string()],
-                "openai".to_string(),
+                "openrouter".to_string(),
             )
             .unwrap();
 
         let client = reqwest::Client::new();
-
-        // Send a request for an unknown model that matches the prefix
         client
-            .post(format!("{}/v1/usage", server.handle.local_base_url))
-            .json(&serde_json::json!({ "model": "gpt-4o-turbo" }))
+            .post(format!(
+                "{}/providers/openrouter/v1/usage",
+                server.handle.local_base_url
+            ))
+            .json(&serde_json::json!({ "model": "anthropic/claude-sonnet-4" }))
             .send()
             .await
             .unwrap();
 
         let snapshot = server.handle.tracker().snapshot();
-        // Should be tracked under the provider label
-        let openai_stats = snapshot.get("openai");
-        assert!(
-            openai_stats.is_some(),
-            "expected 'openai' in snapshot: {:?}",
-            snapshot
-        );
+        let stats = snapshot.get("openrouter/anthropic/claude-sonnet-4");
+        assert!(stats.is_some(), "expected labeled row in {snapshot:?}");
+        assert_eq!(stats.unwrap().requests, 1);
 
         server.shutdown().await;
     }

--- a/src/proxy/server.rs
+++ b/src/proxy/server.rs
@@ -290,16 +290,17 @@ impl RoutingTable {
         &self,
         path_and_query: &str,
         body: &[u8],
-    ) -> (ResolvedTarget, String, String) {
+    ) -> anyhow::Result<(ResolvedTarget, String, String)> {
         let model = model_from_body(body);
-        if let Some((name, rest)) = split_provider_path(path_and_query)
-            && let Some((target, label)) = self.providers.get(name)
-        {
+        if let Some((name, rest)) = split_provider_path(path_and_query) {
+            let Some((target, label)) = self.providers.get(name) else {
+                anyhow::bail!("no provider registered under '/providers/{name}'");
+            };
             let label = match &model {
                 Some(model) => format!("{label}/{model}"),
                 None => label.clone(),
             };
-            return (target.clone(), label, rest.to_string());
+            return Ok((target.clone(), label, rest.to_string()));
         }
         if let Some(model) = &model
             && let Some(target) = self.routes.get(model)
@@ -309,10 +310,10 @@ impl RoutingTable {
                 .get(model)
                 .cloned()
                 .unwrap_or_else(|| model.clone());
-            return (target.clone(), label, path_and_query.to_string());
+            return Ok((target.clone(), label, path_and_query.to_string()));
         }
         let label = model.unwrap_or_else(|| self.default_label.clone());
-        (self.default.clone(), label, path_and_query.to_string())
+        Ok((self.default.clone(), label, path_and_query.to_string()))
     }
 }
 
@@ -399,7 +400,7 @@ async fn forward(
     let path_and_query = uri.path_and_query().map(|p| p.as_str()).unwrap_or("/");
     let (target, label, forward_path) = {
         let table = state.routing.read().unwrap();
-        table.target_and_label_for(path_and_query, &body_bytes)
+        table.target_and_label_for(path_and_query, &body_bytes)?
     };
 
     let url = format!("{}{}", target.base_url.trim_end_matches('/'), forward_path);
@@ -1107,8 +1108,8 @@ mod tests {
             .unwrap();
         assert!(resp.status().is_success());
 
-        // An unregistered provider path falls through to the default target
-        // with the path untouched, which the echo server rejects.
+        // An unregistered provider path is refused outright rather than
+        // forwarded to the default target with the caller's credentials.
         let resp = client
             .post(format!(
                 "{}/providers/unknown/v1/usage",
@@ -1118,7 +1119,7 @@ mod tests {
             .send()
             .await
             .unwrap();
-        assert!(!resp.status().is_success());
+        assert_eq!(resp.status(), reqwest::StatusCode::BAD_GATEWAY);
 
         server.shutdown().await;
     }


### PR DESCRIPTION
## Description

Adds usage tracking for OpenCode building on the WIP implementation from save/OpenCodeFullUsageTracking branch.
Since OpenCode doesn't have a single url override, the user configured providers bypassed usage tracking. This PR discovers user providers, and registers them to route through the proxy. 

Known limitations: remote/managed config layers and OAuth-authenticated built-in providers are not covered. Project-level opencode.json providers may override the rewrite due to OpenCode's config precedence.

## Changes

The PR is based off of the https://github.com/gabe-l-hart/granite-cli/tree/save/OpenCodeFullUsageTracking branch. In addition, provider routing was changed to be based on url path instead of model name prefix. This avoids situations where a gpt selected model in openrouter would be sent to openai api. Also fixed path formatting bug in the config discovery and added new tests.

## Testing

Full test suite passed, and ran manual tests with OpenCode and OpenRouter calls to gpt and gemini models.

## Related Issue(s)

Fixes #86 

## AI Usage

IBM Bob was used to implement the code in this PR.