### PR TITLE
Coder sub agent

### DIFF
--- a/src/capabilities/base.rs
+++ b/src/capabilities/base.rs
@@ -148,6 +148,7 @@ pub enum ToolName {
 pub enum KnownSubAgent {
     Explore,
     Plan,
+    Code,
 }
 
 /// Result payload for `BindingType::SubAgent`: a named sub-agent's prompt,

--- a/src/capabilities/mod.rs
+++ b/src/capabilities/mod.rs
@@ -12,6 +12,7 @@ pub static CAPABILITY_REGISTRY: LazyLock<base::CapabilityFactory> = LazyLock::ne
     factory.register::<agent_model::AgentModelCapability>("agent-model");
     factory.register::<vision_mcp::VisionMCPCapability>("vision-mcp");
     factory.register::<sub_agent::SubAgentCapability>("sub-agent");
+    factory.register::<sub_agent_code::CodeSubAgentCapability>("sub-agent-code");
     factory.register::<sub_agent_explore::ExploreSubAgentCapability>("sub-agent-explore");
     factory.register::<sub_agent_plan::PlanSubAgentCapability>("sub-agent-plan");
     factory
@@ -93,6 +94,9 @@ pub use vision_mcp::{VisionMCPCapability, VisionMCPCapabilityConfig};
 
 mod sub_agent;
 pub use sub_agent::{SubAgentCapability, SubAgentCapabilityConfig};
+
+mod sub_agent_code;
+pub use sub_agent_code::{CodeSubAgentCapability, CodeSubAgentCapabilityConfig};
 
 mod sub_agent_explore;
 pub use sub_agent_explore::{ExploreSubAgentCapability, ExploreSubAgentCapabilityConfig};

--- a/src/capabilities/sub_agent.rs
+++ b/src/capabilities/sub_agent.rs
@@ -3,170 +3,343 @@
 //! agent can delegate to independently of whichever model the main session
 //! uses. See `docs/specs/0021-sub-agent-capability.md`.
 
-use crate::capabilities::base::{
-    AgentModelBinding, Binding, BindingRequest, BindingType, Capability, CapabilityMetadata,
-    Dependency, HasCapabilityMetadata, SubAgentBinding, SubAgentBindingRequest, ToolName,
-};
-use crate::capabilities::requirement::ModelRequirement;
-use crate::models::{ConfiguredModel, ModelFunction};
-use crate::registry::ConfigConstructable;
-use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
 use serde_valid::Validate;
-use std::collections::HashSet;
 
-/*-- SubAgentCapabilityConfig ------------------------------------------------------*/
+/*-- Macro: declare_sub_agent_basic -----------------------------------------------*/
 
-#[derive(Debug, Clone, Serialize, Deserialize, Default, schemars::JsonSchema, Validate)]
-pub struct SubAgentCapabilityConfig {
-    /// Shown to the main agent so it can decide when to delegate to this
-    /// sub-agent -- the same role Claude Code's own subagent `description`
-    /// field plays.
-    #[validate(min_length = 1)]
-    pub description: String,
-    /// The sub-agent's system prompt.
-    #[validate(min_length = 1)]
-    pub prompt: String,
-    /// Tool allow-list. Empty (the default) means "inherit all tools."
-    #[serde(default)]
-    pub tools: Vec<ToolName>,
-    /// Key into the configured models map (the user-chosen instance ID) for
-    /// the model this sub-agent runs on.
-    #[validate(min_length = 1)]
-    pub model_id: String,
-}
-
-/*-- SubAgentCapability -------------------------------------------------------------*/
-
-pub struct SubAgentCapability {
-    instance_id: String,
-    config: SubAgentCapabilityConfig,
-    configured_model: ConfiguredModel,
-}
-
-impl ConfigConstructable for SubAgentCapability {
-    type Config = SubAgentCapabilityConfig;
-
-    /// Constructs the capability by resolving its model through
-    /// `ConfiguredModel`, exactly like `AgentModelCapability::new` -- so
-    /// `model.provider()` works at bind time and, when a usage-tracking
-    /// session is active, the model is transparently tracked.
-    fn new(
-        instance_id: &str,
-        cfg: &serde_json::Value,
-        global_config: &crate::config::Config,
-    ) -> Self {
-        let config: SubAgentCapabilityConfig =
-            serde_json::from_value(cfg.clone()).unwrap_or_default();
-        let configured_model = ConfiguredModel::resolve(&config.model_id, global_config);
-        Self {
-            instance_id: instance_id.to_string(),
-            config,
-            configured_model,
+/// Declares a sub-agent capability with a static prompt and static tools.
+/// Config only has `description` and `model_id`.
+#[macro_export]
+macro_rules! declare_sub_agent_basic {
+    (
+        $name_struct:ident
+        $config_struct:ident
+        $name_cap:expr;
+        $description_cap:expr;
+        [$($tag:expr),* $(,)?]
+        $prompt_expr:expr;
+        $tools_expr:expr;
+        $known_type:expr
+    ) => {
+        #[derive(Debug, Clone, Serialize, Deserialize, Default, schemars::JsonSchema, Validate)]
+        pub struct $config_struct {
+            /// Shown to the main agent so it can decide when to delegate to this
+            /// sub-agent.
+            #[validate(min_length = 1)]
+            pub description: String,
+            /// Key into the configured models map (the user-chosen instance ID) for
+            /// the model this sub-agent runs on.
+            #[validate(min_length = 1)]
+            pub model_id: String,
         }
-    }
-}
 
-impl crate::registry::Named for SubAgentCapability {
-    fn instance_id(&self) -> &str {
-        &self.instance_id
-    }
-}
-
-#[async_trait]
-impl Capability for SubAgentCapability {
-    fn name(&self) -> &str {
-        "Sub-Agent"
-    }
-
-    fn description(&self) -> &str {
-        "Defines a named sub-agent (prompt, tool allow-list, and model) that a launched coding agent can delegate to."
-    }
-
-    fn dependencies(&self) -> Vec<Dependency> {
-        vec![Dependency::Model {
-            config_key: "model_id".to_string(),
-            requirement: ModelRequirement {
-                supported_functions: vec![ModelFunction::Chat, ModelFunction::ToolCalling],
-                ..Default::default()
-            },
-            resolved_id: Some(self.config.model_id.clone()),
-            required: true,
-        }]
-    }
-
-    fn binding_types(&self) -> HashSet<BindingType> {
-        HashSet::from([BindingType::SubAgent])
-    }
-
-    async fn bind(&self, request: BindingRequest) -> anyhow::Result<Binding> {
-        let api_type = match request {
-            BindingRequest::SubAgent(SubAgentBindingRequest { api_type }) => api_type,
-            other => anyhow::bail!(
-                "SubAgentCapability does not handle {:?} binding requests",
-                other.binding_type()
-            ),
-        };
-        let model_id = &self.config.model_id;
-
-        let (provider, endpoint, model_name) = self.configured_model.resolve_provider_endpoint(
-            model_id,
-            api_type.clone(),
-            ModelFunction::Chat,
-            ModelFunction::Chat,
-        )?;
-
-        Ok(Binding::SubAgent(SubAgentBinding {
-            description: self.config.description.clone(),
-            prompt: self.config.prompt.clone(),
-            tools: self.config.tools.clone(),
-            model: AgentModelBinding {
-                api_type,
-                provider_name: provider.instance_id().to_string(),
-                base_url: provider.base_url().to_string(),
-                model_name,
-                endpoint_path: endpoint.path().to_string(),
-                api_key: provider.api_key().cloned(),
-                verify_ssl: provider.verify_ssl(),
-                context_length: Some(self.configured_model.model.context_length()),
-            },
-            known_type: None,
-        }))
-    }
-}
-
-impl HasCapabilityMetadata for SubAgentCapability {
-    fn metadata() -> CapabilityMetadata {
-        CapabilityMetadata {
-            name: "Sub-Agent".to_string(),
-            description: "Defines a named sub-agent (prompt, tool allow-list, and model) that a launched coding agent can delegate to.".to_string(),
-            dependencies: vec![Dependency::Model {
-                config_key: "model_id".to_string(),
-                requirement: ModelRequirement {
-                    supported_functions: vec![ModelFunction::Chat, ModelFunction::ToolCalling],
-                    ..Default::default()
-                },
-                resolved_id: None,
-                required: true,
-            }],
-            tags: vec!["agent".to_string(), "sub-agent".to_string()],
-            supported_binding_types: HashSet::from([BindingType::SubAgent]),
+        pub struct $name_struct {
+            instance_id: String,
+            config: $config_struct,
+            configured_model: $crate::models::ConfiguredModel,
+            pub prompt: String,
+            pub tools: Vec<$crate::capabilities::base::ToolName>,
         }
-    }
+
+        impl $crate::registry::ConfigConstructable for $name_struct {
+            type Config = $config_struct;
+
+            fn new(
+                instance_id: &str,
+                cfg: &serde_json::Value,
+                global_config: &$crate::config::Config,
+            ) -> Self {
+                let config: $config_struct =
+                    serde_json::from_value(cfg.clone()).unwrap_or_default();
+                let configured_model = $crate::models::ConfiguredModel::resolve(&config.model_id, global_config);
+                let prompt = $prompt_expr;
+                let tools = $tools_expr;
+                Self {
+                    instance_id: instance_id.to_string(),
+                    config,
+                    configured_model,
+                    prompt,
+                    tools,
+                }
+            }
+        }
+
+        impl $crate::registry::Named for $name_struct {
+            fn instance_id(&self) -> &str {
+                &self.instance_id
+            }
+        }
+
+        #[async_trait::async_trait]
+        impl $crate::capabilities::Capability for $name_struct {
+            fn name(&self) -> &str {
+                $name_cap
+            }
+
+            fn description(&self) -> &str {
+                $description_cap
+            }
+
+            fn dependencies(&self) -> Vec<$crate::capabilities::Dependency> {
+                vec![$crate::capabilities::Dependency::Model {
+                    config_key: "model_id".to_string(),
+                    requirement: $crate::capabilities::ModelRequirement {
+                        supported_functions: vec![$crate::models::ModelFunction::Chat, $crate::models::ModelFunction::ToolCalling],
+                        ..Default::default()
+                    },
+                    resolved_id: Some(self.config.model_id.clone()),
+                    required: true,
+                }]
+            }
+
+            fn binding_types(&self) -> std::collections::HashSet<$crate::capabilities::base::BindingType> {
+                std::collections::HashSet::from([$crate::capabilities::base::BindingType::SubAgent])
+            }
+
+            async fn bind(&self, request: $crate::capabilities::base::BindingRequest) -> anyhow::Result<$crate::capabilities::base::Binding> {
+                let api_type = match request {
+                    $crate::capabilities::base::BindingRequest::SubAgent($crate::capabilities::base::SubAgentBindingRequest { api_type }) => api_type,
+                    other => anyhow::bail!(
+                        "{} does not handle {:?} binding requests",
+                        stringify!($name_struct),
+                        other.binding_type()
+                    ),
+                };
+                let model_id = &self.config.model_id;
+                let (provider, endpoint, model_name) = self.configured_model.resolve_provider_endpoint(
+                    model_id,
+                    api_type.clone(),
+                    $crate::models::ModelFunction::Chat,
+                    $crate::models::ModelFunction::Chat,
+                )?;
+                Ok($crate::capabilities::base::Binding::SubAgent($crate::capabilities::base::SubAgentBinding {
+                    description: self.config.description.clone(),
+                    prompt: self.prompt.clone(),
+                    tools: self.tools.clone(),
+                    model: $crate::capabilities::base::AgentModelBinding {
+                        api_type,
+                        provider_name: provider.instance_id().to_string(),
+                        base_url: provider.base_url().to_string(),
+                        model_name,
+                        endpoint_path: endpoint.path().to_string(),
+                        api_key: provider.api_key().cloned(),
+                        verify_ssl: provider.verify_ssl(),
+                        context_length: Some(self.configured_model.model.context_length()),
+                    },
+                    known_type: $known_type,
+                }))
+            }
+        }
+
+        impl $crate::capabilities::base::HasCapabilityMetadata for $name_struct {
+            fn metadata() -> $crate::capabilities::base::CapabilityMetadata {
+                $crate::capabilities::base::CapabilityMetadata {
+                    name: $name_cap.to_string(),
+                    description: $description_cap.to_string(),
+                    dependencies: vec![$crate::capabilities::Dependency::Model {
+                        config_key: "model_id".to_string(),
+                        requirement: $crate::capabilities::ModelRequirement {
+                            supported_functions: vec![$crate::models::ModelFunction::Chat, $crate::models::ModelFunction::ToolCalling],
+                            ..Default::default()
+                        },
+                        resolved_id: None,
+                        required: true,
+                    }],
+                    tags: vec![$($tag.to_string()),*],
+                    supported_binding_types: std::collections::HashSet::from([$crate::capabilities::base::BindingType::SubAgent]),
+                }
+            }
+        }
+    };
 }
+
+/*-- Macro: declare_sub_agent_full ------------------------------------------------*/
+
+/// Declares a sub-agent capability with configurable prompt and tools.
+#[macro_export]
+macro_rules! declare_sub_agent_full {
+    (
+        $name_struct:ident
+        $config_struct:ident
+        $name_cap:expr;
+        $description_cap:expr;
+        [$($tag:expr),* $(,)?]
+        $known_type:expr;
+        {$($config_fields:tt)*}
+    ) => {
+        #[derive(Debug, Clone, Serialize, Deserialize, Default, schemars::JsonSchema, Validate)]
+        pub struct $config_struct {
+            /// Shown to the main agent so it can decide when to delegate to this
+            /// sub-agent.
+            #[validate(min_length = 1)]
+            pub description: String,
+            /// Key into the configured models map (the user-chosen instance ID) for
+            /// the model this sub-agent runs on.
+            #[validate(min_length = 1)]
+            pub model_id: String,
+            $($config_fields)*
+        }
+
+        pub struct $name_struct {
+            instance_id: String,
+            config: $config_struct,
+            configured_model: $crate::models::ConfiguredModel,
+            pub prompt: String,
+            pub tools: Vec<$crate::capabilities::base::ToolName>,
+        }
+
+        impl $crate::registry::ConfigConstructable for $name_struct {
+            type Config = $config_struct;
+
+            fn new(
+                instance_id: &str,
+                cfg: &serde_json::Value,
+                global_config: &$crate::config::Config,
+            ) -> Self {
+                let config: $config_struct =
+                    serde_json::from_value(cfg.clone()).unwrap_or_default();
+                let configured_model = $crate::models::ConfiguredModel::resolve(&config.model_id, global_config);
+                let prompt = config.prompt.clone();
+                let tools = config.tools.clone();
+                Self {
+                    instance_id: instance_id.to_string(),
+                    config,
+                    configured_model,
+                    prompt,
+                    tools,
+                }
+            }
+        }
+
+        impl $crate::registry::Named for $name_struct {
+            fn instance_id(&self) -> &str {
+                &self.instance_id
+            }
+        }
+
+        #[async_trait::async_trait]
+        impl $crate::capabilities::Capability for $name_struct {
+            fn name(&self) -> &str {
+                $name_cap
+            }
+
+            fn description(&self) -> &str {
+                $description_cap
+            }
+
+            fn dependencies(&self) -> Vec<$crate::capabilities::Dependency> {
+                vec![$crate::capabilities::Dependency::Model {
+                    config_key: "model_id".to_string(),
+                    requirement: $crate::capabilities::ModelRequirement {
+                        supported_functions: vec![$crate::models::ModelFunction::Chat, $crate::models::ModelFunction::ToolCalling],
+                        ..Default::default()
+                    },
+                    resolved_id: Some(self.config.model_id.clone()),
+                    required: true,
+                }]
+            }
+
+            fn binding_types(&self) -> std::collections::HashSet<$crate::capabilities::base::BindingType> {
+                std::collections::HashSet::from([$crate::capabilities::base::BindingType::SubAgent])
+            }
+
+            async fn bind(&self, request: $crate::capabilities::base::BindingRequest) -> anyhow::Result<$crate::capabilities::base::Binding> {
+                let api_type = match request {
+                    $crate::capabilities::base::BindingRequest::SubAgent($crate::capabilities::base::SubAgentBindingRequest { api_type }) => api_type,
+                    other => anyhow::bail!(
+                        "{} does not handle {:?} binding requests",
+                        stringify!($name_struct),
+                        other.binding_type()
+                    ),
+                };
+                let model_id = &self.config.model_id;
+                let (provider, endpoint, model_name) = self.configured_model.resolve_provider_endpoint(
+                    model_id,
+                    api_type.clone(),
+                    $crate::models::ModelFunction::Chat,
+                    $crate::models::ModelFunction::Chat,
+                )?;
+                Ok($crate::capabilities::base::Binding::SubAgent($crate::capabilities::base::SubAgentBinding {
+                    description: self.config.description.clone(),
+                    prompt: self.prompt.clone(),
+                    tools: self.tools.clone(),
+                    model: $crate::capabilities::base::AgentModelBinding {
+                        api_type,
+                        provider_name: provider.instance_id().to_string(),
+                        base_url: provider.base_url().to_string(),
+                        model_name,
+                        endpoint_path: endpoint.path().to_string(),
+                        api_key: provider.api_key().cloned(),
+                        verify_ssl: provider.verify_ssl(),
+                        context_length: Some(self.configured_model.model.context_length()),
+                    },
+                    known_type: $known_type,
+                }))
+            }
+        }
+
+        impl $crate::capabilities::base::HasCapabilityMetadata for $name_struct {
+            fn metadata() -> $crate::capabilities::base::CapabilityMetadata {
+                $crate::capabilities::base::CapabilityMetadata {
+                    name: $name_cap.to_string(),
+                    description: $description_cap.to_string(),
+                    dependencies: vec![$crate::capabilities::Dependency::Model {
+                        config_key: "model_id".to_string(),
+                        requirement: $crate::capabilities::ModelRequirement {
+                            supported_functions: vec![$crate::models::ModelFunction::Chat, $crate::models::ModelFunction::ToolCalling],
+                            ..Default::default()
+                        },
+                        resolved_id: None,
+                        required: true,
+                    }],
+                    tags: vec![$($tag.to_string()),*],
+                    supported_binding_types: std::collections::HashSet::from([$crate::capabilities::base::BindingType::SubAgent]),
+                }
+            }
+        }
+    };
+}
+
+/*-- SubAgentCapability ------------------------------------------------------------*/
+
+// Configuration for the generic sub-agent capability. The prompt and tools
+// are configurable via JSON, leaving only description and model_id.
+declare_sub_agent_full!(
+    SubAgentCapability
+    SubAgentCapabilityConfig
+    "Sub-Agent";
+    "Defines a named sub-agent (prompt, tool allow-list, and model) that a launched coding agent can delegate to.";
+    ["agent", "sub-agent"]
+    None;
+    {
+        /// The sub-agent's system prompt.
+        #[validate(min_length = 1)]
+        pub prompt: String,
+        /// Tool allow-list. Empty (the default) means "inherit all tools."
+        #[serde(default)]
+        pub tools: Vec<crate::capabilities::base::ToolName>,
+    }
+);
 
 /*-- tests -------------------------------------------------------------------------*/
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::capabilities::base::{
+        Binding, BindingRequest, BindingType, Capability, Dependency, HasCapabilityMetadata,
+        SubAgentBindingRequest, ToolName,
+    };
     use crate::config::{Config, ModelConfig};
-    use crate::models::Model;
+    use crate::models::{Model, ModelFunction};
     use crate::providers::{
         ApiEndpoint, ApiType, HealthStatus, ModelFormat, Provider, ProviderError,
     };
-    use crate::registry::Secret;
+    use crate::registry::{ConfigConstructable, Secret};
+    use async_trait::async_trait;
     use std::collections::HashMap;
+    use std::collections::HashSet;
     use std::sync::Arc;
 
     #[derive(Clone, Default)]
@@ -301,9 +474,6 @@ mod tests {
         }
     }
 
-    /// Builds a `SubAgentCapability` with a real registry model id (so
-    /// construction succeeds) and then swaps in a test double model/provider,
-    /// mirroring `agent_model.rs`'s test pattern.
     fn capability_with_test_model(
         functions: Vec<ModelFunction>,
         provider: FakeProvider,
@@ -338,6 +508,8 @@ mod tests {
                 }),
                 None,
             ),
+            prompt: cap.prompt,
+            tools: cap.tools,
         }
     }
 
@@ -378,6 +550,8 @@ mod tests {
                 }),
                 None,
             ),
+            prompt: cap.prompt,
+            tools: cap.tools,
         };
 
         let binding = cap.bind(request(ApiType::Anthropic)).await.unwrap();

--- a/src/capabilities/sub_agent.rs
+++ b/src/capabilities/sub_agent.rs
@@ -18,16 +18,13 @@ macro_rules! declare_sub_agent_basic {
         $name_cap:expr;
         $description_cap:expr;
         [$($tag:expr),* $(,)?]
+        $description_expr:expr;
         $prompt_expr:expr;
         $tools_expr:expr;
         $known_type:expr
     ) => {
         #[derive(Debug, Clone, Serialize, Deserialize, Default, schemars::JsonSchema, Validate)]
         pub struct $config_struct {
-            /// Shown to the main agent so it can decide when to delegate to this
-            /// sub-agent.
-            #[validate(min_length = 1)]
-            pub description: String,
             /// Key into the configured models map (the user-chosen instance ID) for
             /// the model this sub-agent runs on.
             #[validate(min_length = 1)]
@@ -38,7 +35,11 @@ macro_rules! declare_sub_agent_basic {
             instance_id: String,
             config: $config_struct,
             configured_model: $crate::models::ConfiguredModel,
+            /// Description shown to the parent agent for deciding when to delegate.
+            pub description: String,
+            /// Static prompt for this sub-agent.
             pub prompt: String,
+            /// Static tool allow-list for this sub-agent.
             pub tools: Vec<$crate::capabilities::base::ToolName>,
         }
 
@@ -53,12 +54,14 @@ macro_rules! declare_sub_agent_basic {
                 let config: $config_struct =
                     serde_json::from_value(cfg.clone()).unwrap_or_default();
                 let configured_model = $crate::models::ConfiguredModel::resolve(&config.model_id, global_config);
+                let description = $description_expr;
                 let prompt = $prompt_expr;
                 let tools = $tools_expr;
                 Self {
                     instance_id: instance_id.to_string(),
                     config,
                     configured_model,
+                    description,
                     prompt,
                     tools,
                 }
@@ -114,7 +117,7 @@ macro_rules! declare_sub_agent_basic {
                     $crate::models::ModelFunction::Chat,
                 )?;
                 Ok($crate::capabilities::base::Binding::SubAgent($crate::capabilities::base::SubAgentBinding {
-                    description: self.config.description.clone(),
+                    description: self.description.clone(),
                     prompt: self.prompt.clone(),
                     tools: self.tools.clone(),
                     model: $crate::capabilities::base::AgentModelBinding {
@@ -171,7 +174,8 @@ macro_rules! declare_sub_agent_full {
         #[derive(Debug, Clone, Serialize, Deserialize, Default, schemars::JsonSchema, Validate)]
         pub struct $config_struct {
             /// Shown to the main agent so it can decide when to delegate to this
-            /// sub-agent.
+            /// sub-agent -- the same role Claude Code's own subagent `description`
+            /// field plays.
             #[validate(min_length = 1)]
             pub description: String,
             /// Key into the configured models map (the user-chosen instance ID) for
@@ -185,7 +189,11 @@ macro_rules! declare_sub_agent_full {
             instance_id: String,
             config: $config_struct,
             configured_model: $crate::models::ConfiguredModel,
+            /// Description shown to the parent agent for deciding when to delegate.
+            pub description: String,
+            /// Configurable prompt for this sub-agent.
             pub prompt: String,
+            /// Configurable tool allow-list for this sub-agent.
             pub tools: Vec<$crate::capabilities::base::ToolName>,
         }
 
@@ -200,12 +208,14 @@ macro_rules! declare_sub_agent_full {
                 let config: $config_struct =
                     serde_json::from_value(cfg.clone()).unwrap_or_default();
                 let configured_model = $crate::models::ConfiguredModel::resolve(&config.model_id, global_config);
+                let description = config.description.clone();
                 let prompt = config.prompt.clone();
                 let tools = config.tools.clone();
                 Self {
                     instance_id: instance_id.to_string(),
                     config,
                     configured_model,
+                    description,
                     prompt,
                     tools,
                 }
@@ -261,7 +271,7 @@ macro_rules! declare_sub_agent_full {
                     $crate::models::ModelFunction::Chat,
                 )?;
                 Ok($crate::capabilities::base::Binding::SubAgent($crate::capabilities::base::SubAgentBinding {
-                    description: self.config.description.clone(),
+                    description: self.description.clone(),
                     prompt: self.prompt.clone(),
                     tools: self.tools.clone(),
                     model: $crate::capabilities::base::AgentModelBinding {
@@ -508,6 +518,7 @@ mod tests {
                 }),
                 None,
             ),
+            description: cap.description,
             prompt: cap.prompt,
             tools: cap.tools,
         }
@@ -550,6 +561,7 @@ mod tests {
                 }),
                 None,
             ),
+            description: cap.description,
             prompt: cap.prompt,
             tools: cap.tools,
         };

--- a/src/capabilities/sub_agent_code.rs
+++ b/src/capabilities/sub_agent_code.rs
@@ -6,7 +6,7 @@ use crate::capabilities::base::KnownSubAgent;
 use crate::capabilities::base::ToolName;
 use crate::declare_sub_agent_basic;
 
-const DESCRIPTION: &str = "Use this sub-agent to accomplish a narrowly scoped coding task. The task should have clear file references, architectural guidance, and outcome descriptions. The task should not include modifying the local development environment.";
+const DESCRIPTION: &str = "Use this sub-agent to accomplish a narrowly scoped coding task. The task description must have clear file references, architectural guidance, and outcome descriptions. The task should not include modifying the local development environment.";
 const PROMPT: &str = "You are a coding specialist. You excel at performing development tasks precisely. You require fully scoped tasks and execute them efficiently as specified.
 
 === CRITICAL: LOCAL-ONLY MODE ===

--- a/src/capabilities/sub_agent_code.rs
+++ b/src/capabilities/sub_agent_code.rs
@@ -209,6 +209,8 @@ mod tests {
             "granite-3.1-8b-instruct".to_string(),
             ModelConfig {
                 model_id: "granite-3.1-8b-instruct".to_string(),
+                model_type: "granite-3.1-8b-instruct".to_string(),
+                config: serde_json::json!({}),
                 provider_id: None,
                 variant: None,
             },
@@ -247,6 +249,8 @@ mod tests {
             "granite-3.1-8b-instruct".to_string(),
             ModelConfig {
                 model_id: "granite-3.1-8b-instruct".to_string(),
+                model_type: "granite-3.1-8b-instruct".to_string(),
+                config: serde_json::json!({}),
                 provider_id: None,
                 variant: None,
             },
@@ -281,7 +285,13 @@ mod tests {
         assert_eq!(binding.prompt, PROMPT.to_string());
         assert_eq!(
             binding.tools,
-            vec![ToolName::FileRead, ToolName::Search, ToolName::Shell,]
+            vec![
+                ToolName::FileRead,
+                ToolName::Search,
+                ToolName::Shell,
+                ToolName::FileWrite,
+                ToolName::FileEdit,
+            ]
         );
         assert_eq!(binding.model.base_url, "http://localhost:11434");
         assert_eq!(binding.model.model_name, "granite-3.1-8b-instruct");

--- a/src/capabilities/sub_agent_code.rs
+++ b/src/capabilities/sub_agent_code.rs
@@ -1,0 +1,323 @@
+//! `CodeSubAgentCapability`: defines a named coding sub-agent
+use serde::{Deserialize, Serialize};
+use serde_valid::Validate;
+
+use crate::capabilities::base::KnownSubAgent;
+use crate::capabilities::base::ToolName;
+use crate::declare_sub_agent_basic;
+
+const DESCRIPTION: &str = "Use this sub-agent to accomplish a narrowly scoped coding task. The task should have clear file references, architectural guidance, and outcome descriptions. The task should not include modifying the local development environment.";
+const PROMPT: &str = "You are a coding specialist. You excel at performing development tasks precisely. You require fully scoped tasks and execute them efficiently as specified.
+
+=== CRITICAL: LOCAL-ONLY MODE ===
+This is a READ/WRITE task for local files only. You are STRICTLY PROHIBITED from:
+- Modifying anything outside of the current workspace
+- Searching the internet for anything
+- Modifying the local environment
+- Running ANY commands that change system state outside of the current workspace
+
+Your role is EXCLUSIVELY to write/modify code and run shell commands to verify your progress towards the stated development goals.
+
+Your strengths:
+- Implement code changes in the local project
+- Run project-appropriate shell tools to validate your changes
+- Add/modify tests where necessary to ensure your changes are working correctly and will not regress in the future
+
+Guidelines [file search / glob, search / grep, shell]:
+- Use file search tools when you know the specific file path you need to read
+- Use shell tools for read-only operations (eg: ls, git status, git log, git diff, find, grep, cat, head, tail, git status, git log, git diff) when exploring the codebase to understand the scope of the changes you need to make
+- Use shell tools for write operations (eg: mkdir, touch, rm, cp, mv) only when modifying files in the local workspace
+- Use shell tools for build, execution, and testing (eg: python, pytest, uv run, npm run, make, cargo) when validating the state of your development task
+- NEVER use shell tools to modify the local development environment (git add, git commit, npm install, pip install, git add, git commit, npm install, pip install)
+
+NOTE: You are meant to be a fast agent that accomplishes your task as quickly as possible. In order to achieve this you must:
+- Make efficient use of the tools that you have at your disposal: be smart about how you broadly you search the codebase versus modifying where directed
+
+When complete, report back with a concise description of the changes made and tests run to validate the changes.";
+
+declare_sub_agent_basic!(
+    CodeSubAgentCapability
+    CodeSubAgentCapabilityConfig
+    "Code Sub-Agent";
+    "Defines a named coding sub-agent (static prompt, fixed tools, and model) that a launched coding agent can delegate to.";
+    ["agent", "code"]
+    DESCRIPTION.to_string();
+    PROMPT.to_string();
+    vec![ToolName::FileRead, ToolName::Search, ToolName::Shell, ToolName::FileWrite, ToolName::FileEdit];
+    Some(KnownSubAgent::Code)
+);
+
+/*-- tests -------------------------------------------------------------------*/
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::capabilities::base::{
+        Binding, BindingRequest, BindingType, Capability, Dependency, HasCapabilityMetadata,
+        SubAgentBindingRequest,
+    };
+    use crate::config::{Config, ModelConfig};
+    use crate::models::{Model, ModelFunction};
+    use crate::providers::{
+        ApiEndpoint, ApiType, HealthStatus, ModelFormat, Provider, ProviderError,
+    };
+    use crate::registry::ConfigConstructable;
+    use crate::registry::Secret;
+    use async_trait::async_trait;
+    use std::collections::HashMap;
+    use std::collections::HashSet;
+    use std::sync::Arc;
+
+    #[derive(Clone, Default)]
+    struct FakeProvider {
+        instance_id: String,
+        base_url: String,
+        api_key: Option<Secret>,
+        verify_ssl: bool,
+        api_types: Vec<ApiType>,
+        endpoints: HashMap<ModelFunction, Vec<ApiEndpoint>>,
+        alias: Option<String>,
+    }
+
+    impl ConfigConstructable for FakeProvider {
+        type Config = crate::registry::NoConfig;
+        fn new(_: &str, _: &serde_json::Value, _: &crate::config::Config) -> Self {
+            unimplemented!("not used in tests")
+        }
+    }
+
+    impl crate::registry::Named for FakeProvider {
+        fn instance_id(&self) -> &str {
+            &self.instance_id
+        }
+    }
+
+    #[async_trait]
+    impl Provider for FakeProvider {
+        fn name(&self) -> &str {
+            "Fake Provider"
+        }
+        fn function_endpoints(&self) -> HashMap<ModelFunction, Vec<ApiEndpoint>> {
+            self.endpoints.clone()
+        }
+        fn supported_api_types(&self) -> Vec<ApiType> {
+            self.api_types.clone()
+        }
+        fn base_url(&self) -> &str {
+            &self.base_url
+        }
+        fn api_key(&self) -> Option<&Secret> {
+            self.api_key.as_ref()
+        }
+        fn verify_ssl(&self) -> bool {
+            self.verify_ssl
+        }
+        fn supported_formats(&self) -> Vec<ModelFormat> {
+            vec![]
+        }
+        fn model_alias(&self, _variant: Option<&crate::models::ModelVariant>) -> Option<String> {
+            self.alias.clone()
+        }
+        async fn health_check(&self) -> Result<HealthStatus, ProviderError> {
+            unimplemented!("not used in tests")
+        }
+    }
+
+    fn ok_provider() -> FakeProvider {
+        let mut endpoints = HashMap::new();
+        endpoints.insert(
+            ModelFunction::Chat,
+            vec![ApiEndpoint::OpenAIChat, ApiEndpoint::AnthropicMessages],
+        );
+        FakeProvider {
+            instance_id: "my-ollama".to_string(),
+            base_url: "http://localhost:11434".to_string(),
+            api_key: None,
+            verify_ssl: true,
+            api_types: vec![ApiType::OpenAI, ApiType::Anthropic],
+            endpoints,
+            alias: None,
+        }
+    }
+
+    struct TestModel {
+        supported_functions: Vec<ModelFunction>,
+        provider: FakeProvider,
+    }
+
+    impl ConfigConstructable for TestModel {
+        type Config = crate::registry::NoConfig;
+        fn new(_: &str, _: &serde_json::Value, _: &crate::config::Config) -> Self {
+            unimplemented!("not used in tests")
+        }
+    }
+
+    impl crate::registry::Named for TestModel {
+        fn instance_id(&self) -> &str {
+            "granite-3.1-8b-instruct"
+        }
+    }
+
+    impl Model for TestModel {
+        fn family(&self) -> &str {
+            "Test"
+        }
+        fn version(&self) -> &str {
+            "1.0"
+        }
+        fn size(&self) -> u64 {
+            1
+        }
+        fn context_length(&self) -> u64 {
+            4096
+        }
+        fn model_type(&self) -> &crate::models::ModelType {
+            &crate::models::ModelType::Text
+        }
+        fn huggingface_repo(&self) -> &str {
+            "test/test"
+        }
+        fn native_dtype(&self) -> &str {
+            "bfloat16"
+        }
+        fn architecture(&self) -> &crate::models::ModelArchitecture {
+            unimplemented!("not used in tests")
+        }
+        fn variants(&self) -> &[crate::models::ModelVariant] {
+            &[]
+        }
+        fn description(&self) -> Option<&str> {
+            None
+        }
+        fn tags(&self) -> &[String] {
+            &[]
+        }
+        fn supported_functions(&self) -> &[ModelFunction] {
+            &self.supported_functions
+        }
+        fn provider(&self) -> anyhow::Result<Box<dyn Provider>> {
+            Ok(Box::new(self.provider.clone()))
+        }
+    }
+
+    fn code_capability_with_test_model(
+        functions: Vec<ModelFunction>,
+        provider: FakeProvider,
+    ) -> CodeSubAgentCapability {
+        let mut config = Config::default();
+        config.models.insert(
+            "granite-3.1-8b-instruct".to_string(),
+            ModelConfig {
+                model_id: "granite-3.1-8b-instruct".to_string(),
+                provider_id: None,
+                variant: None,
+            },
+        );
+        let cap = CodeSubAgentCapability::new(
+            "coder",
+            &serde_json::json!({
+                "model_id": "granite-3.1-8b-instruct",
+            }),
+            &config,
+        );
+        CodeSubAgentCapability {
+            instance_id: cap.instance_id,
+            config: cap.config,
+            configured_model: crate::models::ConfiguredModel::for_test(
+                Arc::new(TestModel {
+                    supported_functions: functions,
+                    provider,
+                }),
+                None,
+            ),
+            description: cap.description,
+            prompt: cap.prompt,
+            tools: cap.tools,
+        }
+    }
+
+    fn request(api_type: ApiType) -> BindingRequest {
+        BindingRequest::SubAgent(SubAgentBindingRequest { api_type })
+    }
+
+    #[tokio::test]
+    async fn bind_succeeds_and_carries_description_prompt_and_tools() {
+        let mut config = Config::default();
+        config.models.insert(
+            "granite-3.1-8b-instruct".to_string(),
+            ModelConfig {
+                model_id: "granite-3.1-8b-instruct".to_string(),
+                provider_id: None,
+                variant: None,
+            },
+        );
+        let cap = CodeSubAgentCapability::new(
+            "coder",
+            &serde_json::json!({
+                "model_id": "granite-3.1-8b-instruct",
+            }),
+            &config,
+        );
+        let cap = CodeSubAgentCapability {
+            instance_id: cap.instance_id,
+            config: cap.config,
+            configured_model: crate::models::ConfiguredModel::for_test(
+                Arc::new(TestModel {
+                    supported_functions: vec![ModelFunction::Chat],
+                    provider: ok_provider(),
+                }),
+                None,
+            ),
+            description: cap.description,
+            prompt: cap.prompt,
+            tools: cap.tools,
+        };
+
+        let binding = cap.bind(request(ApiType::Anthropic)).await.unwrap();
+        let Binding::SubAgent(binding) = binding else {
+            panic!("expected SubAgent binding")
+        };
+        assert_eq!(binding.description, DESCRIPTION);
+        assert_eq!(binding.prompt, PROMPT.to_string());
+        assert_eq!(
+            binding.tools,
+            vec![ToolName::FileRead, ToolName::Search, ToolName::Shell,]
+        );
+        assert_eq!(binding.model.base_url, "http://localhost:11434");
+        assert_eq!(binding.model.model_name, "granite-3.1-8b-instruct");
+        assert_eq!(binding.model.api_type, ApiType::Anthropic);
+    }
+
+    #[test]
+    fn binding_types_reports_sub_agent() {
+        let cap = code_capability_with_test_model(vec![ModelFunction::Chat], ok_provider());
+        assert_eq!(cap.binding_types(), HashSet::from([BindingType::SubAgent]));
+    }
+
+    #[test]
+    fn dependencies_carry_resolved_model_id() {
+        let cap = code_capability_with_test_model(vec![ModelFunction::Chat], ok_provider());
+        let deps = cap.dependencies();
+        assert_eq!(deps.len(), 1);
+        assert!(deps.iter().any(|d| matches!(
+            d,
+            Dependency::Model { resolved_id: Some(id), .. } if id == "granite-3.1-8b-instruct"
+        )));
+    }
+
+    #[test]
+    fn metadata_reports_supported_binding_types_and_wildcard_dependency() {
+        let meta = CodeSubAgentCapability::metadata();
+        assert_eq!(
+            meta.supported_binding_types,
+            HashSet::from([BindingType::SubAgent])
+        );
+        assert!(meta.dependencies.iter().any(|d| matches!(
+            d,
+            Dependency::Model {
+                resolved_id: None,
+                ..
+            }
+        )));
+    }
+}

--- a/src/capabilities/sub_agent_explore.rs
+++ b/src/capabilities/sub_agent_explore.rs
@@ -9,6 +9,7 @@ use crate::capabilities::base::KnownSubAgent;
 use crate::capabilities::base::ToolName;
 use crate::declare_sub_agent_basic;
 
+const EXPLORE_DESCRIPTION: &str = "Thoroughly search and explore the codebase to find files, read implementations, and understand patterns. Use when the user needs to find specific files, understand code structure, or locate implementations.";
 // CITE: https://github.com/Piebald-AI/claude-code-system-prompts/blob/main/system-prompts/agent-prompt-explore.md
 const EXPLORE_PROMPT: &str = "You are a file search specialist. You excel at thoroughly navigating and exploring codebases.
 
@@ -48,6 +49,7 @@ declare_sub_agent_basic!(
     "Explore Sub-Agent";
     "Defines a named exploration sub-agent (static prompt, fixed tools, and model) that a launched coding agent can delegate to.";
     ["agent", "explore"]
+    EXPLORE_DESCRIPTION.to_string();
     EXPLORE_PROMPT.to_string();
     vec![ToolName::FileRead, ToolName::Search, ToolName::Shell];
     Some(KnownSubAgent::Explore)
@@ -224,7 +226,6 @@ mod tests {
         let cap = ExploreSubAgentCapability::new(
             "explorer",
             &serde_json::json!({
-                "description": "Explores code",
                 "model_id": "granite-3.1-8b-instruct",
             }),
             &config,
@@ -239,6 +240,7 @@ mod tests {
                 }),
                 None,
             ),
+            description: cap.description,
             prompt: cap.prompt,
             tools: cap.tools,
         }
@@ -264,7 +266,6 @@ mod tests {
         let cap = ExploreSubAgentCapability::new(
             "explorer",
             &serde_json::json!({
-                "description": "Explores code",
                 "model_id": "granite-3.1-8b-instruct",
             }),
             &config,
@@ -279,6 +280,7 @@ mod tests {
                 }),
                 None,
             ),
+            description: cap.description,
             prompt: cap.prompt,
             tools: cap.tools,
         };
@@ -287,7 +289,7 @@ mod tests {
         let Binding::SubAgent(binding) = binding else {
             panic!("expected SubAgent binding")
         };
-        assert_eq!(binding.description, "Explores code");
+        assert_eq!(binding.description, EXPLORE_DESCRIPTION);
         assert_eq!(binding.prompt, EXPLORE_PROMPT.to_string());
         assert_eq!(
             binding.tools,

--- a/src/capabilities/sub_agent_explore.rs
+++ b/src/capabilities/sub_agent_explore.rs
@@ -2,42 +2,12 @@
 //! prompt and fixed tool allow-list (FileRead, Search, Shell), and a `Model`/`Provider`
 //! of its own. The prompt has a placeholder that the user can fill in later.
 
-// Standard
-use serde_valid::Validate;
-use std::collections::HashSet;
-
-// Third Party
-use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
+use serde_valid::Validate;
 
-// Local
-use crate::capabilities::ModelRequirement;
-use crate::capabilities::base::{
-    AgentModelBinding, Binding, BindingRequest, BindingType, Capability, CapabilityMetadata,
-    Dependency, HasCapabilityMetadata, KnownSubAgent, SubAgentBinding, SubAgentBindingRequest,
-    ToolName,
-};
-use crate::models::{ConfiguredModel, ModelFunction};
-use crate::registry::ConfigConstructable;
-
-/*-- ExploreSubAgentCapabilityConfig --------------------------------------------*/
-
-/// Configuration for the explore sub-agent capability. Unlike `SubAgentCapability`,
-/// the prompt and tools are static (not configurable via JSON), leaving only the
-/// description (what the sub-agent does) and model_id as configurable.
-#[derive(Debug, Clone, Serialize, Deserialize, Default, schemars::JsonSchema, Validate)]
-pub struct ExploreSubAgentCapabilityConfig {
-    /// Shown to the main agent so it can decide when to delegate to this
-    /// explore sub-agent.
-    #[validate(min_length = 1)]
-    pub description: String,
-    /// Key into the configured models map (the user-chosen instance ID) for
-    /// the model this sub-agent runs on.
-    #[validate(min_length = 1)]
-    pub model_id: String,
-}
-
-/*-- ExploreSubAgentCapability -----------------------------------------------*/
+use crate::capabilities::base::KnownSubAgent;
+use crate::capabilities::base::ToolName;
+use crate::declare_sub_agent_basic;
 
 // CITE: https://github.com/Piebald-AI/claude-code-system-prompts/blob/main/system-prompts/agent-prompt-explore.md
 const EXPLORE_PROMPT: &str = "You are a file search specialist. You excel at thoroughly navigating and exploring codebases.
@@ -72,149 +42,36 @@ NOTE: You are meant to be a fast agent that returns output as quickly as possibl
 
 Complete the user's search request efficiently and report your findings clearly.";
 
-pub struct ExploreSubAgentCapability {
-    instance_id: String,
-    config: ExploreSubAgentCapabilityConfig,
-    configured_model: ConfiguredModel,
-    /// Static prompt for the explore sub-agent (placeholder for now; user can
-    /// override by editing this field later).
-    pub prompt: String,
-    /// Static tool allow-list for the explore sub-agent.
-    pub tools: Vec<ToolName>,
-}
-
-impl ConfigConstructable for ExploreSubAgentCapability {
-    type Config = ExploreSubAgentCapabilityConfig;
-
-    /// Constructs the capability by resolving its model through
-    /// `ConfiguredModel`, exactly like `AgentModelCapability::new` -- so
-    /// `model.provider()` works at bind time and, when a usage-tracking
-    /// session is active, the model is transparently tracked.
-    fn new(
-        instance_id: &str,
-        cfg: &serde_json::Value,
-        global_config: &crate::config::Config,
-    ) -> Self {
-        let config: ExploreSubAgentCapabilityConfig =
-            serde_json::from_value(cfg.clone()).unwrap_or_default();
-        let configured_model = ConfiguredModel::resolve(&config.model_id, global_config);
-
-        // Static prompt
-        // TODO: Make prompt a template that should be expanded by the launcher
-        let prompt = EXPLORE_PROMPT.to_string();
-        // Static tools: FileRead, Search, Shell
-        let tools = vec![ToolName::FileRead, ToolName::Search, ToolName::Shell];
-
-        Self {
-            instance_id: instance_id.to_string(),
-            config,
-            configured_model,
-            prompt,
-            tools,
-        }
-    }
-}
-
-impl crate::registry::Named for ExploreSubAgentCapability {
-    fn instance_id(&self) -> &str {
-        &self.instance_id
-    }
-}
-
-#[async_trait]
-impl Capability for ExploreSubAgentCapability {
-    fn name(&self) -> &str {
-        "Explore Sub-Agent"
-    }
-
-    fn description(&self) -> &str {
-        "Defines a named exploration sub-agent (static prompt, fixed tools, and model) that a launched coding agent can delegate to."
-    }
-
-    fn dependencies(&self) -> Vec<Dependency> {
-        vec![Dependency::Model {
-            config_key: "model_id".to_string(),
-            requirement: ModelRequirement {
-                supported_functions: vec![ModelFunction::Chat, ModelFunction::ToolCalling],
-                ..Default::default()
-            },
-            resolved_id: Some(self.config.model_id.clone()),
-            required: true,
-        }]
-    }
-
-    fn binding_types(&self) -> HashSet<BindingType> {
-        HashSet::from([BindingType::SubAgent])
-    }
-
-    async fn bind(&self, request: BindingRequest) -> anyhow::Result<Binding> {
-        let api_type = match request {
-            BindingRequest::SubAgent(SubAgentBindingRequest { api_type }) => api_type,
-            other => anyhow::bail!(
-                "ExploreSubAgentCapability does not handle {:?} binding requests",
-                other.binding_type()
-            ),
-        };
-        let model_id = &self.config.model_id;
-
-        let (provider, endpoint, model_name) = self.configured_model.resolve_provider_endpoint(
-            model_id,
-            api_type.clone(),
-            ModelFunction::Chat,
-            ModelFunction::Chat,
-        )?;
-
-        Ok(Binding::SubAgent(SubAgentBinding {
-            description: self.config.description.clone(),
-            prompt: self.prompt.clone(),
-            tools: self.tools.clone(),
-            model: AgentModelBinding {
-                api_type,
-                provider_name: provider.instance_id().to_string(),
-                base_url: provider.base_url().to_string(),
-                model_name,
-                endpoint_path: endpoint.path().to_string(),
-                api_key: provider.api_key().cloned(),
-                verify_ssl: provider.verify_ssl(),
-                context_length: Some(self.configured_model.model.context_length()),
-            },
-            known_type: Some(KnownSubAgent::Explore),
-        }))
-    }
-}
-
-impl HasCapabilityMetadata for ExploreSubAgentCapability {
-    fn metadata() -> CapabilityMetadata {
-        CapabilityMetadata {
-            name: "Explore Sub-Agent".to_string(),
-            description: "Defines a named exploration sub-agent (static prompt, fixed tools, and model) that a launched coding agent can delegate to.".to_string(),
-            dependencies: vec![Dependency::Model {
-                config_key: "model_id".to_string(),
-                requirement: ModelRequirement {
-                    supported_functions: vec![ModelFunction::Chat, ModelFunction::ToolCalling],
-                    ..Default::default()
-                },
-                resolved_id: None,
-                required: true,
-            }],
-            tags: vec!["agent".to_string(), "explore".to_string()],
-            supported_binding_types: HashSet::from([BindingType::SubAgent]),
-        }
-    }
-}
+declare_sub_agent_basic!(
+    ExploreSubAgentCapability
+    ExploreSubAgentCapabilityConfig
+    "Explore Sub-Agent";
+    "Defines a named exploration sub-agent (static prompt, fixed tools, and model) that a launched coding agent can delegate to.";
+    ["agent", "explore"]
+    EXPLORE_PROMPT.to_string();
+    vec![ToolName::FileRead, ToolName::Search, ToolName::Shell];
+    Some(KnownSubAgent::Explore)
+);
 
 /*-- tests -------------------------------------------------------------------*/
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::capabilities::base::{
+        Binding, BindingRequest, BindingType, Capability, Dependency, HasCapabilityMetadata,
+        SubAgentBindingRequest,
+    };
     use crate::config::{Config, ModelConfig};
-    use crate::models::Model;
+    use crate::models::{Model, ModelFunction};
     use crate::providers::{
         ApiEndpoint, ApiType, HealthStatus, ModelFormat, Provider, ProviderError,
     };
+    use crate::registry::ConfigConstructable;
     use crate::registry::Secret;
+    use async_trait::async_trait;
     use std::collections::HashMap;
+    use std::collections::HashSet;
     use std::sync::Arc;
 
     #[derive(Clone, Default)]
@@ -349,9 +206,6 @@ mod tests {
         }
     }
 
-    /// Builds an `ExploreSubAgentCapability` with a real registry model id (so
-    /// construction succeeds) and then swaps in a test double model/provider,
-    /// mirroring the test pattern from `sub_agent.rs`.
     fn explore_capability_with_test_model(
         functions: Vec<ModelFunction>,
         provider: FakeProvider,

--- a/src/capabilities/sub_agent_plan.rs
+++ b/src/capabilities/sub_agent_plan.rs
@@ -3,42 +3,12 @@
 //! WebFetch, WebSearch -- everything read-only, no FileWrite/FileEdit), and a
 //! `Model`/`Provider` of its own. Mirrors `ExploreSubAgentCapability`.
 
-// Standard
-use serde_valid::Validate;
-use std::collections::HashSet;
-
-// Third Party
-use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
+use serde_valid::Validate;
 
-// Local
-use crate::capabilities::ModelRequirement;
-use crate::capabilities::base::{
-    AgentModelBinding, Binding, BindingRequest, BindingType, Capability, CapabilityMetadata,
-    Dependency, HasCapabilityMetadata, KnownSubAgent, SubAgentBinding, SubAgentBindingRequest,
-    ToolName,
-};
-use crate::models::{ConfiguredModel, ModelFunction};
-use crate::registry::ConfigConstructable;
-
-/*-- PlanSubAgentCapabilityConfig --------------------------------------------*/
-
-/// Configuration for the plan sub-agent capability. Unlike `SubAgentCapability`,
-/// the prompt and tools are static (not configurable via JSON), leaving only the
-/// description (what the sub-agent does) and model_id as configurable.
-#[derive(Debug, Clone, Serialize, Deserialize, Default, schemars::JsonSchema, Validate)]
-pub struct PlanSubAgentCapabilityConfig {
-    /// Shown to the main agent so it can decide when to delegate to this
-    /// plan sub-agent.
-    #[validate(min_length = 1)]
-    pub description: String,
-    /// Key into the configured models map (the user-chosen instance ID) for
-    /// the model this sub-agent runs on.
-    #[validate(min_length = 1)]
-    pub model_id: String,
-}
-
-/*-- PlanSubAgentCapability -----------------------------------------------*/
+use crate::capabilities::base::KnownSubAgent;
+use crate::capabilities::base::ToolName;
+use crate::declare_sub_agent_basic;
 
 const PLAN_PROMPT: &str = "You are a software architect and planning specialist. Your role is to explore the codebase and design implementation plans.
 
@@ -91,156 +61,43 @@ List 3-5 files most critical for implementing this plan:
 
 REMEMBER: You can ONLY explore and plan. You CANNOT and MUST NOT write, edit, or modify any files. You do NOT have access to file editing tools.";
 
-pub struct PlanSubAgentCapability {
-    instance_id: String,
-    config: PlanSubAgentCapabilityConfig,
-    configured_model: ConfiguredModel,
-    /// Static prompt for the plan sub-agent (placeholder for now; user can
-    /// override by editing this field later).
-    pub prompt: String,
-    /// Static tool allow-list for the plan sub-agent.
-    pub tools: Vec<ToolName>,
-}
-
-impl ConfigConstructable for PlanSubAgentCapability {
-    type Config = PlanSubAgentCapabilityConfig;
-
-    /// Constructs the capability by resolving its model through
-    /// `ConfiguredModel`, exactly like `AgentModelCapability::new` -- so
-    /// `model.provider()` works at bind time and, when a usage-tracking
-    /// session is active, the model is transparently tracked.
-    fn new(
-        instance_id: &str,
-        cfg: &serde_json::Value,
-        global_config: &crate::config::Config,
-    ) -> Self {
-        let config: PlanSubAgentCapabilityConfig =
-            serde_json::from_value(cfg.clone()).unwrap_or_default();
-        let configured_model = ConfiguredModel::resolve(&config.model_id, global_config);
-
-        // Static prompt
-        // TODO: Make prompt a template that should be expanded by the launcher
-        let prompt = PLAN_PROMPT.to_string();
-        // Static tools: everything read-only (no FileWrite/FileEdit)
-        let tools = vec![
-            ToolName::FileRead,
-            ToolName::Search,
-            ToolName::FileSearch,
-            ToolName::Shell,
-            ToolName::WebFetch,
-            ToolName::WebSearch,
-        ];
-
-        Self {
-            instance_id: instance_id.to_string(),
-            config,
-            configured_model,
-            prompt,
-            tools,
-        }
-    }
-}
-
-impl crate::registry::Named for PlanSubAgentCapability {
-    fn instance_id(&self) -> &str {
-        &self.instance_id
-    }
-}
-
-#[async_trait]
-impl Capability for PlanSubAgentCapability {
-    fn name(&self) -> &str {
-        "Plan Sub-Agent"
-    }
-
-    fn description(&self) -> &str {
-        "Defines a named planning sub-agent (static prompt, fixed read-only tools, and model) that a launched coding agent can delegate implementation-plan design to."
-    }
-
-    fn dependencies(&self) -> Vec<Dependency> {
-        vec![Dependency::Model {
-            config_key: "model_id".to_string(),
-            requirement: ModelRequirement {
-                supported_functions: vec![ModelFunction::Chat, ModelFunction::ToolCalling],
-                ..Default::default()
-            },
-            resolved_id: Some(self.config.model_id.clone()),
-            required: true,
-        }]
-    }
-
-    fn binding_types(&self) -> HashSet<BindingType> {
-        HashSet::from([BindingType::SubAgent])
-    }
-
-    async fn bind(&self, request: BindingRequest) -> anyhow::Result<Binding> {
-        let api_type = match request {
-            BindingRequest::SubAgent(SubAgentBindingRequest { api_type }) => api_type,
-            other => anyhow::bail!(
-                "PlanSubAgentCapability does not handle {:?} binding requests",
-                other.binding_type()
-            ),
-        };
-        let model_id = &self.config.model_id;
-
-        let (provider, endpoint, model_name) = self.configured_model.resolve_provider_endpoint(
-            model_id,
-            api_type.clone(),
-            ModelFunction::Chat,
-            ModelFunction::Chat,
-        )?;
-
-        Ok(Binding::SubAgent(SubAgentBinding {
-            description: self.config.description.clone(),
-            prompt: self.prompt.clone(),
-            tools: self.tools.clone(),
-            model: AgentModelBinding {
-                api_type,
-                provider_name: provider.instance_id().to_string(),
-                base_url: provider.base_url().to_string(),
-                model_name,
-                endpoint_path: endpoint.path().to_string(),
-                api_key: provider.api_key().cloned(),
-                verify_ssl: provider.verify_ssl(),
-                context_length: Some(self.configured_model.model.context_length()),
-            },
-            known_type: Some(KnownSubAgent::Plan),
-        }))
-    }
-}
-
-impl HasCapabilityMetadata for PlanSubAgentCapability {
-    fn metadata() -> CapabilityMetadata {
-        CapabilityMetadata {
-            name: "Plan Sub-Agent".to_string(),
-            description: "Defines a named planning sub-agent (static prompt, fixed read-only tools, and model) that a launched coding agent can delegate implementation-plan design to.".to_string(),
-            dependencies: vec![Dependency::Model {
-                config_key: "model_id".to_string(),
-                requirement: ModelRequirement {
-                    supported_functions: vec![ModelFunction::Chat, ModelFunction::ToolCalling],
-                    ..Default::default()
-                },
-                resolved_id: None,
-                required: true,
-            }],
-            tags: vec!["agent".to_string(), "plan".to_string()],
-            supported_binding_types: HashSet::from([BindingType::SubAgent]),
-        }
-    }
-}
+declare_sub_agent_basic!(
+    PlanSubAgentCapability
+    PlanSubAgentCapabilityConfig
+    "Plan Sub-Agent";
+    "Defines a named planning sub-agent (static prompt, fixed read-only tools, and model) that a launched coding agent can delegate implementation-plan design to.";
+    ["agent", "plan"]
+    PLAN_PROMPT.to_string();
+    vec![
+        ToolName::FileRead,
+        ToolName::Search,
+        ToolName::FileSearch,
+        ToolName::Shell,
+        ToolName::WebFetch,
+        ToolName::WebSearch,
+    ];
+    Some(KnownSubAgent::Plan)
+);
 
 /*-- tests -------------------------------------------------------------------*/
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::capabilities::base::{
+        Binding, BindingRequest, BindingType, Capability, Dependency, HasCapabilityMetadata,
+        SubAgentBindingRequest,
+    };
     use crate::config::{Config, ModelConfig};
-    use crate::models::Model;
+    use crate::models::{Model, ModelFunction};
     use crate::providers::{
         ApiEndpoint, ApiType, HealthStatus, ModelFormat, Provider, ProviderError,
     };
+    use crate::registry::ConfigConstructable;
     use crate::registry::Secret;
+    use async_trait::async_trait;
     use std::collections::HashMap;
+    use std::collections::HashSet;
     use std::sync::Arc;
 
     #[derive(Clone, Default)]
@@ -375,9 +232,6 @@ mod tests {
         }
     }
 
-    /// Builds a `PlanSubAgentCapability` with a real registry model id (so
-    /// construction succeeds) and then swaps in a test double model/provider,
-    /// mirroring the test pattern from `sub_agent_explore.rs`.
     fn plan_capability_with_test_model(
         functions: Vec<ModelFunction>,
         provider: FakeProvider,

--- a/src/capabilities/sub_agent_plan.rs
+++ b/src/capabilities/sub_agent_plan.rs
@@ -10,6 +10,7 @@ use crate::capabilities::base::KnownSubAgent;
 use crate::capabilities::base::ToolName;
 use crate::declare_sub_agent_basic;
 
+const PLAN_DESCRIPTION: &str = "Explore the codebase and design detailed implementation plans. Use when the user needs a structured plan with steps, file references, and architectural decisions before implementation.";
 const PLAN_PROMPT: &str = "You are a software architect and planning specialist. Your role is to explore the codebase and design implementation plans.
 
 === CRITICAL: READ-ONLY MODE - NO FILE MODIFICATIONS ===
@@ -67,6 +68,7 @@ declare_sub_agent_basic!(
     "Plan Sub-Agent";
     "Defines a named planning sub-agent (static prompt, fixed read-only tools, and model) that a launched coding agent can delegate implementation-plan design to.";
     ["agent", "plan"]
+    PLAN_DESCRIPTION.to_string();
     PLAN_PROMPT.to_string();
     vec![
         ToolName::FileRead,
@@ -250,7 +252,6 @@ mod tests {
         let cap = PlanSubAgentCapability::new(
             "planner",
             &serde_json::json!({
-                "description": "Plans changes",
                 "model_id": "granite-3.1-8b-instruct",
             }),
             &config,
@@ -265,6 +266,7 @@ mod tests {
                 }),
                 None,
             ),
+            description: cap.description,
             prompt: cap.prompt,
             tools: cap.tools,
         }
@@ -290,7 +292,6 @@ mod tests {
         let cap = PlanSubAgentCapability::new(
             "planner",
             &serde_json::json!({
-                "description": "Plans changes",
                 "model_id": "granite-3.1-8b-instruct",
             }),
             &config,
@@ -305,6 +306,7 @@ mod tests {
                 }),
                 None,
             ),
+            description: cap.description,
             prompt: cap.prompt,
             tools: cap.tools,
         };
@@ -313,7 +315,7 @@ mod tests {
         let Binding::SubAgent(binding) = binding else {
             panic!("expected SubAgent binding")
         };
-        assert_eq!(binding.description, "Plans changes");
+        assert_eq!(binding.description, PLAN_DESCRIPTION);
         assert_eq!(binding.prompt, PLAN_PROMPT.to_string());
         assert_eq!(
             binding.tools,

--- a/src/launchers/opencode.rs
+++ b/src/launchers/opencode.rs
@@ -469,7 +469,7 @@ impl OpenCodeLauncher {
                 let mapped_name = match binding.known_type {
                     Some(KnownSubAgent::Explore) => "explore".to_string(),
                     Some(KnownSubAgent::Plan) => "plan".to_string(),
-                    None => name.clone(),
+                    _ => name.clone(),
                 };
                 (mapped_name, entry)
             })

--- a/src/models/huggingface.rs
+++ b/src/models/huggingface.rs
@@ -6,12 +6,24 @@
 //! `"owner/repo"` id is also accepted for robustness, though generated data
 //! always uses a full URL.
 
+// Third Party
+use alog::{MessageLevel, alog_channel, use_channel};
+
+use_channel!("HUGFC");
+
 /// Extract `"owner/repo"` from a HF repo URL, a HF blob URL, or a bare repo
 /// id. Returns `None` if `url` doesn't look like a HuggingFace reference
 /// (e.g. an `ollama.com` library URL).
 pub fn hf_repo_id(url: &str) -> Option<&str> {
-    let rest = if url.starts_with("http") {
+    alog_channel!(MessageLevel::Debug2, "Analyzing URL: {}", url);
+    let rest = if url.starts_with("https://huggingface.co/") {
         url.strip_prefix("https://huggingface.co/")?
+    } else if url.starts_with("huggingface.co/") {
+        url.strip_prefix("huggingface.co/")?
+    } else if url.starts_with("https://hf.co/") {
+        url.strip_prefix("https://hf.co/")?
+    } else if url.starts_with("hf.co/") {
+        url.strip_prefix("hf.co/")?
     } else {
         url
     };
@@ -23,15 +35,6 @@ pub fn hf_repo_id(url: &str) -> Option<&str> {
         return None;
     }
     Some(&rest[..owner.len() + 1 + repo.len()])
-}
-
-/// Extract the filename from a HF blob URL. Returns `None` for bare repo
-/// ids or any URL that isn't a `.../blob/...` reference.
-pub fn hf_blob_filename(url: &str) -> Option<&str> {
-    if !url.contains("huggingface.co") || !url.contains("/blob/") {
-        return None;
-    }
-    url.rsplit('/').next().filter(|f| !f.is_empty())
 }
 
 /*-- tests -------------------------------------------------------------------*/
@@ -69,20 +72,5 @@ mod tests {
     #[test]
     fn hf_repo_id_rejects_non_hf_url() {
         assert_eq!(hf_repo_id("https://ollama.com/library/granite4:1b"), None);
-    }
-
-    #[test]
-    fn hf_blob_filename_from_blob_url() {
-        assert_eq!(
-            hf_blob_filename(
-                "https://huggingface.co/ibm-granite/granite-speech-4.1-2b-GGUF/blob/main/granite-speech-4.1-2b-Q4_K_M.gguf"
-            ),
-            Some("granite-speech-4.1-2b-Q4_K_M.gguf")
-        );
-    }
-
-    #[test]
-    fn hf_blob_filename_none_for_bare_repo() {
-        assert_eq!(hf_blob_filename("ibm-granite/granite-speech-4.1-2b"), None);
     }
 }


### PR DESCRIPTION
## Description

This PR adds another new sub-agent to act as the generic Coder delegate

## Changes

- Create generic sub-agent macro for adding known sub-agents
- Refactor existing sub-agents to use macro
- Add Code sub-agent
- Make `description` a static attribute for known sub-agents since this is given to the model

## Testing

- Unit tests
- Tested existing sub-agents with `claude` to ensure delegation works as expected
- Code sub-agent is tested using Qwen3.6-35b as a custom model to back it

## Related Issue(s)

Closes #96

## AI Usage

```sh
╔══════════════════════════════════════════════════════════╗
║           GIT AI USAGE ANALYSIS                          ║
╚══════════════════════════════════════════════════════════╝

📊 COMMITS BY AGENT

--- Aggregate ---
Commits                        |      Count
---------------------------------------------
none                           |         28
pi + Qwen3.6-35b               |          7
Claude + Sonnet 5 + granite4.2:3b |          5
OpenCode + GraniteXXX          |          2
Qwen3.6-35b                    |          2
OpenCode + Qwen3.6-35b         |          1
pi + qwen3.6-35b               |          1
Claude + Sonnet 5              |          1
OpenCode + Qwemn3.6-35b        |          1
Claude                         |          1
---------------------------------------------
TOTAL                          |         49

📊 COMMITS BY USAGE TYPE

--- Aggregate ---
Commits                        |      Count
---------------------------------------------
none                           |         28
draft                          |          1
full                           |         20
---------------------------------------------
TOTAL                          |         49

📈 LINES OF CODE BY AGENT

--- Aggregate ---
Agent                     |    Commits |  Additions |  Deletions
------------------------------------------------------------
none                      |         28 |       2687 |        541
pi + Qwen3.6-35b          |          7 |        657 |         50
Claude + Sonnet 5 + granite4.2:3b |          5 |        946 |        207
OpenCode + GraniteXXX     |          2 |          3 |          3
Qwen3.6-35b               |          2 |         25 |         37
OpenCode + Qwen3.6-35b    |          1 |         29 |         13
pi + qwen3.6-35b          |          1 |         42 |          6
Claude + Sonnet 5         |          1 |         64 |         64
OpenCode + Qwemn3.6-35b   |          1 |        364 |        482
Claude                    |          1 |        130 |          0
------------------------------------------------------------
TOTAL                     |         49 |       4947 |       1403

📈 LINES OF CODE BY USAGE TYPE

--- Aggregate ---
Usage Type           |    Commits |  Additions |  Deletions
-------------------------------------------------------
none                 |         28 |       2687 |        541
draft                |          1 |        364 |        482
full                 |         20 |       1896 |        380
-------------------------------------------------------
TOTAL                |         49 |       4947 |       1403
```