### PR TITLE
feat: Add WSL/Windows fallback logic

### DIFF
--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -102,6 +102,17 @@ pub struct LauncherConfig {
 }
 
 impl Config {
+    /// Detect if running under Windows Subsystem for Linux by checking
+    /// `/proc/version` for WSL markers.
+    fn is_wsl() -> bool {
+        std::fs::read_to_string("/proc/version")
+            .map(|s| {
+                let lower = s.to_lowercase();
+                lower.contains("microsoft") || lower.contains("wsl")
+            })
+            .unwrap_or(false)
+    }
+
     fn config_dir() -> Result<PathBuf> {
         let val_res = std::env::var("GRANITE_CLI_HOME");
 
@@ -122,6 +133,39 @@ impl Config {
             }
 
             return Ok(path);
+        }
+
+        // When running under WSL, always use the Windows AppData path so
+        // config is shared between WSL and native Windows invocations,
+        // regardless of how the binary was compiled. Under WSL the C: drive
+        // is mounted at /mnt/c, so C:\Users\<user>\AppData\Roaming maps to
+        // /mnt/c/Users/<user>/AppData/Roaming. We query the Windows username
+        // via cmd.exe because it may differ from the WSL login name.
+        if Self::is_wsl() {
+            let windows_username = std::process::Command::new("cmd.exe")
+                .arg("/C")
+                .arg("echo")
+                .arg("%USERNAME%")
+                .output()
+                .ok()
+                .and_then(|out| {
+                    String::from_utf8(out.stdout)
+                        .ok()
+                        .map(|s| s.trim().to_string())
+                        .filter(|s| !s.is_empty())
+                });
+
+            if let Some(username) = windows_username {
+                let path = PathBuf::from("/mnt/c")
+                    .join("Users")
+                    .join(username)
+                    .join("AppData")
+                    .join("Roaming")
+                    .join("granite-cli");
+                return Ok(path);
+            }
+
+            anyhow::bail!("Running under WSL but could not determine Windows username via cmd.exe");
         }
 
         let default_dir = dirs::config_dir().ok_or_else(|| {

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -101,6 +101,119 @@ pub struct LauncherConfig {
     pub config: serde_json::Value,
 }
 
+/// Convert a Windows path string to a WSL path.
+///
+/// `C:\Users\gabel\AppData\Roaming\granite-cli\launchers` →
+/// `/mnt/c/Users/gabel/AppData/Roaming/granite-cli/launchers`
+fn windows_to_wsl(path: &str) -> Option<String> {
+    let path = path.trim();
+    // Match Windows drive letters: X:\... or X:/...
+    let bytes = path.as_bytes();
+    if bytes.len() < 3 || bytes[1] != b':' || bytes[2] != b'\\' && bytes[2] != b'/' {
+        return None;
+    }
+    let drive = &path[..1].to_lowercase();
+    let rest = &path[2..];
+    let normalized = rest.replace('\\', "/");
+    Some(format!("/mnt/{}/{}", drive, normalized))
+}
+
+/// Convert a WSL path to a Windows path.
+///
+/// `/mnt/c/Users/gabel/AppData/Roaming/granite-cli\launchers` →
+/// `C:\Users\gabel\AppData\Roaming\granite-cli\launchers`
+fn wsl_to_windows(path: &str) -> Option<String> {
+    let path = path.trim();
+    if !path.starts_with("/mnt/") {
+        return None;
+    }
+    let remainder = &path[5..];
+    let mut parts = remainder.splitn(2, '/');
+    let drive = parts.next()?.to_uppercase();
+    let rest = parts.next()?;
+    let normalized = rest.replace('/', "\\");
+    Some(format!("{}:\\{}", drive, normalized))
+}
+
+/// Recursively walk a serde_json::Value and translate path strings.
+///
+/// When `to_wsl` is true, converts Windows paths → WSL paths.
+/// When `to_wsl` is false, converts WSL paths → Windows paths.
+fn translate_paths_in_value(value: &serde_json::Value, to_wsl: bool) -> serde_json::Value {
+    match value {
+        serde_json::Value::String(s) => {
+            let translated = if to_wsl {
+                windows_to_wsl(s)
+            } else {
+                wsl_to_windows(s)
+            };
+            match translated {
+                Some(t) => serde_json::Value::String(t),
+                None => value.clone(),
+            }
+        }
+        serde_json::Value::Array(arr) => {
+            serde_json::Value::Array(arr.iter().map(|v| translate_paths_in_value(v, to_wsl)).collect())
+        }
+        serde_json::Value::Object(map) => {
+            let new_map: serde_json::Map<String, serde_json::Value> = map
+                .iter()
+                .map(|(k, v)| (k.clone(), translate_paths_in_value(v, to_wsl)))
+                .collect();
+            serde_json::Value::Object(new_map)
+        }
+        other => other.clone(),
+    }
+}
+
+/// Translate all path strings in a serde_json::Value config object.
+///
+/// When running under WSL, Windows paths stored in config files are
+/// converted to WSL paths so they work at runtime. On save, the reverse
+/// conversion restores Windows-native paths for disk persistence.
+fn translate_paths_in_config(config: &mut serde_json::Value, to_wsl: bool) {
+    config["command_path"] = translate_paths_in_value(&config["command_path"], to_wsl);
+    if let Some(overrides) = config.get_mut("provider_overrides") {
+        *overrides = translate_paths_in_value(overrides, to_wsl);
+    }
+    if let Some(overrides) = config.get_mut("model_overrides") {
+        *overrides = translate_paths_in_value(overrides, to_wsl);
+    }
+    if let Some(overrides) = config.get_mut("base_path") {
+        *overrides = translate_paths_in_value(overrides, to_wsl);
+    }
+}
+
+/// Trait for config types that carry a serde_json::Value config field.
+/// Used to apply path translation generically across all config types.
+trait ConfigPathTranslator {
+    fn config_mut(&mut self) -> Option<&mut serde_json::Value>;
+}
+
+impl ConfigPathTranslator for ModelConfig {
+    fn config_mut(&mut self) -> Option<&mut serde_json::Value> {
+        Some(&mut self.config)
+    }
+}
+
+impl ConfigPathTranslator for ProviderConfig {
+    fn config_mut(&mut self) -> Option<&mut serde_json::Value> {
+        Some(&mut self.config)
+    }
+}
+
+impl ConfigPathTranslator for CapabilityConfig {
+    fn config_mut(&mut self) -> Option<&mut serde_json::Value> {
+        Some(&mut self.config)
+    }
+}
+
+impl ConfigPathTranslator for LauncherConfig {
+    fn config_mut(&mut self) -> Option<&mut serde_json::Value> {
+        Some(&mut self.config)
+    }
+}
+
 impl Config {
     /// Detect if running under Windows Subsystem for Linux by checking
     /// `/proc/version` for WSL markers.
@@ -246,7 +359,7 @@ impl Config {
         Ok(())
     }
 
-    fn load_dir<K: std::hash::Hash + Eq + ToString, V: serde::de::DeserializeOwned + ConfigId>(
+    fn load_dir<K: std::hash::Hash + Eq + ToString, V: serde::de::DeserializeOwned + ConfigId + ConfigPathTranslator>(
         dir: &Path,
         into_key: impl Fn(&str) -> K + Copy,
     ) -> Result<HashMap<K, V>> {
@@ -262,7 +375,10 @@ impl Config {
                     .file_stem()
                     .map(|s| s.to_string_lossy().to_string())
                     .unwrap_or_default();
-                if let Ok(config) = Self::load_yaml_from_file::<V>(&path) {
+                if let Ok(mut config) = Self::load_yaml_from_file::<V>(&path) {
+                    if let Some(cfg) = config.config_mut() {
+                        translate_paths_in_config(cfg, true);
+                    }
                     let id = config.config_id().to_string();
                     let file_id = Self::id_from_filename(&file_name);
                     if id != file_id {
@@ -327,30 +443,46 @@ impl Config {
 
         // Save individual model files
         for (id, model) in &self.models {
+            let mut model = model.clone();
+            if let Some(cfg) = model.config_mut() {
+                translate_paths_in_config(cfg, false);
+            }
             let path = Self::models_dir()?.join(format!("{}.yaml", Self::id_to_filename(id)));
             alog_channel!(MessageLevel::Debug3, "Saving to {:#?}", path);
-            Self::save_yaml_to_file(&path, model)?;
+            Self::save_yaml_to_file(&path, &model)?;
         }
 
         // Save individual provider files
         for (id, provider) in &self.providers {
+            let mut provider = provider.clone();
+            if let Some(cfg) = provider.config_mut() {
+                translate_paths_in_config(cfg, false);
+            }
             let path = Self::providers_dir()?.join(format!("{}.yaml", Self::id_to_filename(id)));
             alog_channel!(MessageLevel::Debug3, "Saving to {:#?}", path);
-            Self::save_yaml_to_file(&path, provider)?;
+            Self::save_yaml_to_file(&path, &provider)?;
         }
 
         // Save individual capability files
         for (id, capability) in &self.capabilities {
+            let mut capability = capability.clone();
+            if let Some(cfg) = capability.config_mut() {
+                translate_paths_in_config(cfg, false);
+            }
             let path = Self::capabilities_dir()?.join(format!("{}.yaml", Self::id_to_filename(id)));
             alog_channel!(MessageLevel::Debug3, "Saving to {:#?}", path);
-            Self::save_yaml_to_file(&path, capability)?;
+            Self::save_yaml_to_file(&path, &capability)?;
         }
 
         // Save individual launcher files
         for (id, launcher) in &self.launchers {
+            let mut launcher = launcher.clone();
+            if let Some(cfg) = launcher.config_mut() {
+                translate_paths_in_config(cfg, false);
+            }
             let path = Self::launchers_dir()?.join(format!("{}.yaml", Self::id_to_filename(id)));
             alog_channel!(MessageLevel::Debug3, "Saving to {:#?}", path);
-            Self::save_yaml_to_file(&path, launcher)?;
+            Self::save_yaml_to_file(&path, &launcher)?;
         }
 
         Ok(())

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -101,10 +101,13 @@ pub struct LauncherConfig {
     pub config: serde_json::Value,
 }
 
+/*-- Windows / WSL ----------------------------------------------------------*/
+
 /// Convert a Windows path string to a WSL path.
 ///
 /// `C:\Users\gabel\AppData\Roaming\granite-cli\launchers` →
 /// `/mnt/c/Users/gabel/AppData/Roaming/granite-cli/launchers`
+#[allow(dead_code)]
 fn windows_to_wsl(path: &str) -> Option<String> {
     let path = path.trim();
     // Match Windows drive letters: X:\... or X:/...
@@ -115,14 +118,14 @@ fn windows_to_wsl(path: &str) -> Option<String> {
     let drive = &path[..1].to_lowercase();
     let rest = &path[2..];
     let normalized = rest.replace('\\', "/");
-    Some(format!("/mnt/{}/{}", drive, normalized))
+    Some(format!("/mnt/{drive}/{normalized}"))
 }
 
 /// Convert a WSL path to a Windows path.
 ///
 /// `/mnt/c/Users/gabel/AppData/Roaming/granite-cli\launchers` →
 /// `C:\Users\gabel\AppData\Roaming\granite-cli\launchers`
-fn wsl_to_windows(path: &str) -> Option<String> {
+pub fn translate_wsl_to_windows(path: &str) -> Option<String> {
     let path = path.trim();
     if !path.starts_with("/mnt/") {
         return None;
@@ -132,29 +135,32 @@ fn wsl_to_windows(path: &str) -> Option<String> {
     let drive = parts.next()?.to_uppercase();
     let rest = parts.next()?;
     let normalized = rest.replace('/', "\\");
-    Some(format!("{}:\\{}", drive, normalized))
+    Some(format!("{drive}:\\{normalized}"))
 }
 
 /// Recursively walk a serde_json::Value and translate path strings.
 ///
 /// When `to_wsl` is true, converts Windows paths → WSL paths.
 /// When `to_wsl` is false, converts WSL paths → Windows paths.
+#[allow(dead_code)]
 fn translate_paths_in_value(value: &serde_json::Value, to_wsl: bool) -> serde_json::Value {
     match value {
         serde_json::Value::String(s) => {
             let translated = if to_wsl {
                 windows_to_wsl(s)
             } else {
-                wsl_to_windows(s)
+                translate_wsl_to_windows(s)
             };
             match translated {
                 Some(t) => serde_json::Value::String(t),
                 None => value.clone(),
             }
         }
-        serde_json::Value::Array(arr) => {
-            serde_json::Value::Array(arr.iter().map(|v| translate_paths_in_value(v, to_wsl)).collect())
-        }
+        serde_json::Value::Array(arr) => serde_json::Value::Array(
+            arr.iter()
+                .map(|v| translate_paths_in_value(v, to_wsl))
+                .collect(),
+        ),
         serde_json::Value::Object(map) => {
             let new_map: serde_json::Map<String, serde_json::Value> = map
                 .iter()
@@ -171,6 +177,7 @@ fn translate_paths_in_value(value: &serde_json::Value, to_wsl: bool) -> serde_js
 /// When running under WSL, Windows paths stored in config files are
 /// converted to WSL paths so they work at runtime. On save, the reverse
 /// conversion restores Windows-native paths for disk persistence.
+#[cfg(not(windows))]
 fn translate_paths_in_config(config: &mut serde_json::Value, to_wsl: bool) {
     config["command_path"] = translate_paths_in_value(&config["command_path"], to_wsl);
     if let Some(overrides) = config.get_mut("provider_overrides") {
@@ -183,6 +190,10 @@ fn translate_paths_in_config(config: &mut serde_json::Value, to_wsl: bool) {
         *overrides = translate_paths_in_value(overrides, to_wsl);
     }
 }
+
+/// No-op stub for native Windows builds where paths never need translation.
+#[cfg(windows)]
+fn translate_paths_in_config(_config: &mut serde_json::Value, _to_wsl: bool) {}
 
 /// Trait for config types that carry a serde_json::Value config field.
 /// Used to apply path translation generically across all config types.
@@ -214,16 +225,33 @@ impl ConfigPathTranslator for LauncherConfig {
     }
 }
 
+/*-- Core Config ------------------------------------------------------------*/
+
 impl Config {
-    /// Detect if running under Windows Subsystem for Linux by checking
-    /// `/proc/version` for WSL markers.
+    /// Detect if running under Windows Subsystem for Linux.
+    ///
+    /// We check multiple indicators because PE binaries running under WSL
+    /// may not have reliable access to `/proc/version` (the Windows libc
+    /// runtime used by PE binaries doesn't translate `/proc` the same way
+    /// Linux processes do). We prefer the `/proc/sys/kernel/osrelease` file
+    /// which WSL consistently exposes, then fall back to `/proc/version`.
     fn is_wsl() -> bool {
-        std::fs::read_to_string("/proc/version")
-            .map(|s| {
-                let lower = s.to_lowercase();
-                lower.contains("microsoft") || lower.contains("wsl")
-            })
-            .unwrap_or(false)
+        // Method 1: Check /proc/sys/kernel/osrelease (works for PE binaries under WSL)
+        if let Ok(s) = std::fs::read_to_string("/proc/sys/kernel/osrelease") {
+            let lower = s.to_lowercase();
+            if lower.contains("microsoft") || lower.contains("wsl") {
+                return true;
+            }
+        }
+        // Method 2: Check /proc/version (works for native Linux binaries)
+        if let Ok(s) = std::fs::read_to_string("/proc/version") {
+            let lower = s.to_lowercase();
+            if lower.contains("microsoft") || lower.contains("wsl") {
+                return true;
+            }
+        }
+        // Method 3: Check for WSL_DISTRO_NAME environment variable
+        std::env::var("WSL_DISTRO_NAME").is_ok()
     }
 
     fn config_dir() -> Result<PathBuf> {
@@ -254,6 +282,10 @@ impl Config {
         // is mounted at /mnt/c, so C:\Users\<user>\AppData\Roaming maps to
         // /mnt/c/Users/<user>/AppData/Roaming. We query the Windows username
         // via cmd.exe because it may differ from the WSL login name.
+        //
+        // The path format depends on the compile target: ELF binaries (Linux
+        // builds) see WSL paths like `/mnt/c/...`, while PE binaries (Windows
+        // builds) see native Windows paths like `C:\Users\...`.
         if Self::is_wsl() {
             let windows_username = std::process::Command::new("cmd.exe")
                 .arg("/C")
@@ -269,13 +301,27 @@ impl Config {
                 });
 
             if let Some(username) = windows_username {
-                let path = PathBuf::from("/mnt/c")
-                    .join("Users")
-                    .join(username)
-                    .join("AppData")
-                    .join("Roaming")
-                    .join("granite-cli");
-                return Ok(path);
+                #[cfg(windows)]
+                {
+                    // PE binary: use native Windows path
+                    let path = PathBuf::from("C:\\Users")
+                        .join(&username)
+                        .join("AppData")
+                        .join("Roaming")
+                        .join("granite-cli");
+                    return Ok(path);
+                }
+                #[cfg(not(windows))]
+                {
+                    // ELF binary: use WSL mount path
+                    let path = PathBuf::from("/mnt/c")
+                        .join("Users")
+                        .join(&username)
+                        .join("AppData")
+                        .join("Roaming")
+                        .join("granite-cli");
+                    return Ok(path);
+                }
             }
 
             anyhow::bail!("Running under WSL but could not determine Windows username via cmd.exe");
@@ -359,7 +405,10 @@ impl Config {
         Ok(())
     }
 
-    fn load_dir<K: std::hash::Hash + Eq + ToString, V: serde::de::DeserializeOwned + ConfigId + ConfigPathTranslator>(
+    fn load_dir<
+        K: std::hash::Hash + Eq + ToString,
+        V: serde::de::DeserializeOwned + ConfigId + ConfigPathTranslator,
+    >(
         dir: &Path,
         into_key: impl Fn(&str) -> K + Copy,
     ) -> Result<HashMap<K, V>> {

--- a/src/launchers/base.rs
+++ b/src/launchers/base.rs
@@ -151,12 +151,11 @@ pub(crate) async fn run_command(
     // in WSL) fail with os error 193 ("%1 is not a valid Win32 application")
     // when spawned directly. In those cases, fall back to invoking through
     // `cmd.exe /C`, which handles PE format compatibility correctly.
-    let (binary_fallback, args_fallback, overlay_fallback) = (
-        binary.clone(),
-        args.to_vec(),
-        overlay.to_vec(),
-    );
-    let status = tokio::task::spawn_blocking(move || -> anyhow::Result<std::process::ExitStatus> {
+    #[cfg(windows)]
+    let (binary_fallback, args_fallback, overlay_fallback) =
+        (binary.clone(), args.to_vec(), overlay.to_vec());
+
+    tokio::task::spawn_blocking(move || -> anyhow::Result<std::process::ExitStatus> {
         let mut spawn_cmd = cmd;
 
         // In WSL, the parent's CWD may be a WSL path that gets translated to
@@ -203,8 +202,7 @@ pub(crate) async fn run_command(
 
         Ok(child.wait()?)
     })
-    .await?;
-    status
+    .await?
 }
 
 /// Metadata describing a launcher implementation (type-level, catalog entry).

--- a/src/launchers/base.rs
+++ b/src/launchers/base.rs
@@ -90,6 +90,43 @@ pub trait Launcher: crate::registry::Named + Send + Sync {
     }
 }
 
+/// Translate WSL paths to Windows paths in env var values.
+///
+/// When running a native Windows binary from WSL (e.g., `opencode.exe`),
+/// env vars like `OPENCODE_CONFIG` may contain WSL paths (`/mnt/c/Users/...`)
+/// that the PE binary cannot understand. Convert them to Windows format.
+fn translate_env_for_windows(binary: &PathBuf, env: &[EnvBinding]) -> Vec<EnvBinding> {
+    // Only translate when the target is a Windows PE binary (ends in .exe)
+    alog_channel!(MessageLevel::Debug2, "Translating for binary {:#?}", binary);
+    if !binary.to_string_lossy().to_lowercase().ends_with(".exe") {
+        return env.to_vec();
+    }
+    let mut out: Vec<_> = env
+        .iter()
+        .map(|b| {
+            let value = crate::config::translate_wsl_to_windows(&b.value)
+                .unwrap_or_else(|| b.value.clone());
+            EnvBinding {
+                key: b.key.clone(),
+                value,
+            }
+        })
+        .collect();
+    // In order for WSL env vars to be seen by Windows, they need to be added
+    // to the special WSLENV variable
+    let wslenv = out
+        .iter()
+        .map(|b| b.key.clone())
+        .collect::<Vec<_>>()
+        .join(":");
+    out.push(EnvBinding {
+        key: "WSLENV".to_string(),
+        value: wslenv,
+    });
+    alog_channel!(MessageLevel::Debug3, "Translated env vars: {:#?}", out);
+    out
+}
+
 /// Resolve a command and run it, handling dry_run and exit status.
 ///
 /// This is the shared utility that both the default `Launcher::launch` and
@@ -136,9 +173,12 @@ pub(crate) async fn run_command(
         }
     }
 
+    // Translate WSL paths in env vars when spawning a native Windows binary.
+    let translated_overlay = translate_env_for_windows(&binary, overlay);
+
     let mut cmd = std::process::Command::new(&binary);
     cmd.args(args);
-    for binding in overlay {
+    for binding in &translated_overlay {
         cmd.env(&binding.key, &binding.value);
     }
 
@@ -153,7 +193,7 @@ pub(crate) async fn run_command(
     // `cmd.exe /C`, which handles PE format compatibility correctly.
     #[cfg(windows)]
     let (binary_fallback, args_fallback, overlay_fallback) =
-        (binary.clone(), args.to_vec(), overlay.to_vec());
+        (binary.clone(), args.to_vec(), translated_overlay);
 
     tokio::task::spawn_blocking(move || -> anyhow::Result<std::process::ExitStatus> {
         let mut spawn_cmd = cmd;

--- a/src/launchers/base.rs
+++ b/src/launchers/base.rs
@@ -146,10 +146,65 @@ pub(crate) async fn run_command(
     // thread until the subprocess exits, which would otherwise starve the
     // async runtime -- notably the usage-tracking proxy server, which needs
     // scheduler time concurrently with the child running.
-    tokio::task::spawn_blocking(move || -> anyhow::Result<std::process::ExitStatus> {
-        Ok(cmd.spawn()?.wait()?)
+    //
+    // On Windows, some PE binaries (notably from official release builds run
+    // in WSL) fail with os error 193 ("%1 is not a valid Win32 application")
+    // when spawned directly. In those cases, fall back to invoking through
+    // `cmd.exe /C`, which handles PE format compatibility correctly.
+    let (binary_fallback, args_fallback, overlay_fallback) = (
+        binary.clone(),
+        args.to_vec(),
+        overlay.to_vec(),
+    );
+    let status = tokio::task::spawn_blocking(move || -> anyhow::Result<std::process::ExitStatus> {
+        let mut spawn_cmd = cmd;
+
+        // In WSL, the parent's CWD may be a WSL path that gets translated to
+        // a UNC path for Windows processes. If the binary is on a Windows
+        // drive, set the CWD to that drive's root to avoid the UNC issue.
+        #[cfg(windows)]
+        if let Some(drive) = binary_fallback.parent().and_then(|p| {
+            p.to_str().and_then(|s| {
+                let chars: Vec<char> = s.chars().collect();
+                if chars.len() >= 2 && chars[1] == ':' {
+                    Some(format!("{}\\", &s[..2]))
+                } else {
+                    None
+                }
+            })
+        }) {
+            spawn_cmd.current_dir(drive);
+        }
+
+        let mut child = match spawn_cmd.spawn() {
+            Ok(child) => child,
+            #[allow(unreachable_code)]
+            Err(e) => {
+                #[cfg(windows)]
+                if let Some(193) = e.raw_os_error() {
+                    let mut shell = std::process::Command::new("cmd.exe");
+                    shell.arg("/C");
+                    // Build the full command string for cmd.exe
+                    let mut cmd_str = String::new();
+                    cmd_str.push_str(&binary_fallback.to_string_lossy());
+                    for arg in &args_fallback {
+                        cmd_str.push(' ');
+                        cmd_str.push_str(arg);
+                    }
+                    shell.arg(&cmd_str);
+                    for binding in &overlay_fallback {
+                        shell.env(&binding.key, &binding.value);
+                    }
+                    return shell.spawn()?.wait().map_err(anyhow::Error::from);
+                }
+                return Err(e.into());
+            }
+        };
+
+        Ok(child.wait()?)
     })
-    .await?
+    .await?;
+    status
 }
 
 /// Metadata describing a launcher implementation (type-level, catalog entry).
@@ -184,7 +239,7 @@ pub struct LaunchContext {
 }
 
 /// A single environment variable binding contributed to the subprocess overlay.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct EnvBinding {
     pub key: String,
     pub value: String,

--- a/src/utils/shell.rs
+++ b/src/utils/shell.rs
@@ -15,6 +15,9 @@ use std::path::PathBuf;
 ///    `which::which`.
 /// 4. If `command_path` is `None`, fall back to `PATH` lookup using
 ///    `default_command`.
+/// 5. On Windows, if the initial resolution returns a non-PE binary
+///    (e.g. a Linux ELF in WSL), retry with a `.exe` suffix appended
+///    to the command name so the launcher picks up the Windows variant.
 ///
 /// This lets users set `command_path` to a bare name like `"claude"` and
 /// still have the launcher succeed as long as that name is on `PATH` —
@@ -45,7 +48,26 @@ pub fn resolve_shell_command(
         anyhow::bail!("explicit path '{}' does not exist", p.display());
     }
 
-    which::which(explicit).map_err(|_| {
+    let result = which::which(explicit);
+
+    #[cfg(windows)]
+    {
+        // In WSL, `which` may resolve to a Linux ELF binary when we're
+        // running a Windows process (granite-cli.exe).  Such a binary will
+        // fail at spawn time with error 193 ("not a valid Win32
+        // application").  Retry with a `.exe` suffix to pick up the
+        // Windows variant on PATH.
+        if let Ok(ref path) = result {
+            if !path.to_string_lossy().to_lowercase().ends_with(".exe") {
+                let exe_name = format!("{}.exe", explicit);
+                if let Ok(exe_path) = which::which(&exe_name) {
+                    return Ok(exe_path);
+                }
+            }
+        }
+    }
+
+    result.map_err(|_| {
         anyhow::anyhow!(
             "command '{explicit}' not found on PATH (explicit path did not exist either)"
         )


### PR DESCRIPTION
## Description

There's a complex relationship between WSL and native-Windows. The compiled binaries in WSL can't run in native windows, but native windows binaries can run in WSL. How paths are parsed is compile-specific: if the binary is WSL- native, it uses unix paths, but if it's windows-native, even if run in WSL, it uses windows native paths.

The changes here are designed to enable the prebuilt windows binaries to run in both WSL and PowerShell. They cleanly enable running a windows-native OpenCode install (or other launcher) from either host shell. What they _don't_ enable (yet) is running a WSL-native launcher wrapped in granite-cli.exe from PowerShell. This is a reasonable limitation for now.

## Testing

- Built from WSL targeting native Windows

  ```sh
  cargo build --target x86_64-pc-windows-gnu --release
  ```

- Installed windows-native OpenCode through Chocolaty
- Configured `opencode` launcher to run with windows-native opencode.exe path
- Ran windows-native `granite-cli.exe launch opencode` from PowerShell (works as expected)
- Ran windows-native `granite-cli.exe launch opencode` from WSL (works as expected)
- Ran WSL-native `granite-cli launch opencode` from WSL (works as expected)

## AI Usage

This PR was built using OpenCode + Qwen3.6-35b on my Windows box. Commits were made with functionality review, but not code review. I will thoroughly review during PR.