### PR TITLE
Add info sub command in Provider and Launcher.

### DIFF
--- a/src/commands/capability.rs
+++ b/src/commands/capability.rs
@@ -79,7 +79,8 @@ impl CapabilityCommands {
                     type_fields.push(("Tags", cap.tags.join(", ")));
                 }
 
-                ctx.ui.detail(&format!("{capability_id} (metadata)"), &type_fields);
+                ctx.ui
+                    .detail(&format!("{capability_id} (metadata)"), &type_fields);
 
                 if let Some(configured) = configured {
                     let mut instance_fields: Vec<(&str, String)> = Vec::new();

--- a/src/commands/capability.rs
+++ b/src/commands/capability.rs
@@ -106,8 +106,7 @@ impl CapabilityCommands {
                     type_fields.push(("Tags", cap.tags.join(", ")));
                 }
 
-                ctx.ui
-                    .detail("Type Metadata", &type_fields);
+                ctx.ui.detail("Type Metadata", &type_fields);
 
                 if let Some(configured) = configured {
                     let mut instance_fields: Vec<(&str, String)> = Vec::new();

--- a/src/commands/capability.rs
+++ b/src/commands/capability.rs
@@ -70,25 +70,30 @@ impl CapabilityCommands {
 
         match catalog_entry {
             Some(cap) => {
-                let mut fields: Vec<(&str, String)> = vec![
+                let mut type_fields: Vec<(&str, String)> = vec![
                     ("Name", cap.name.clone()),
                     ("Description", cap.description.clone()),
                 ];
 
                 if !cap.tags.is_empty() {
-                    fields.push(("Tags", cap.tags.join(", ")));
+                    type_fields.push(("Tags", cap.tags.join(", ")));
                 }
+
+                ctx.ui.detail(&format!("{capability_id} (metadata)"), &type_fields);
 
                 if let Some(configured) = configured {
-                    fields.push(("Type", configured.capability_type.clone()));
+                    let mut instance_fields: Vec<(&str, String)> = Vec::new();
+
+                    instance_fields.push(("Config: Type", configured.capability_type.clone()));
                     if let Some(obj) = configured.config.as_object() {
                         for (k, v) in obj {
-                            fields.push(("Config", format!("{k} = {v}")));
+                            instance_fields.push(("Config", format!("{k} = {v}")));
                         }
                     }
+
+                    ctx.ui.detail(capability_id, &instance_fields);
                 }
 
-                ctx.ui.detail(capability_id, &fields);
                 Ok(())
             }
             None => {
@@ -100,7 +105,7 @@ impl CapabilityCommands {
                     ctx.ui.detail(capability_id, &fields);
                     Ok(())
                 } else {
-                    ctx.ui.error(&format!(
+                    ctx.ui.info(&format!(
                         "Capability '{capability_id}' not found in registry."
                     ));
                     anyhow::bail!("Capability not found");

--- a/src/commands/capability.rs
+++ b/src/commands/capability.rs
@@ -107,7 +107,7 @@ impl CapabilityCommands {
                 }
 
                 ctx.ui
-                    .detail(&format!("{capability_id} (metadata)"), &type_fields);
+                    .detail("Type Metadata", &type_fields);
 
                 if let Some(configured) = configured {
                     let mut instance_fields: Vec<(&str, String)> = Vec::new();

--- a/src/commands/launcher.rs
+++ b/src/commands/launcher.rs
@@ -74,7 +74,7 @@ impl LauncherCommands {
 
         match metadata {
             Some(md) => {
-                let mut fields: Vec<(&str, String)> = vec![
+                let mut type_fields: Vec<(&str, String)> = vec![
                     ("Name", md.name.clone()),
                     ("Description", md.description.clone()),
                     ("Default Command", md.default_command.clone()),
@@ -87,27 +87,34 @@ impl LauncherCommands {
                     .collect();
                 if !caps.is_empty() {
                     caps.sort();
-                    fields.push(("Supported Capabilities", caps.join(", ")));
+                    type_fields.push(("Supported Capabilities", caps.join(", ")));
                 }
 
                 if !md.tags.is_empty() {
-                    fields.push(("Tags", md.tags.join(", ")));
+                    type_fields.push(("Tags", md.tags.join(", ")));
                 }
 
+                ctx.ui.detail(id, &type_fields);
+
                 if let Some(cfg) = configured {
-                    fields.push(("Config: Type", cfg.launcher_type.clone()));
+                    let mut instance_fields: Vec<(&str, String)> = Vec::new();
+
+                    instance_fields.push(("Config: Type", cfg.launcher_type.clone()));
+
+                    if !cfg.enabled_capabilities.is_empty() {
+                        instance_fields
+                            .push(("Enabled Capabilities", cfg.enabled_capabilities.join(", ")));
+                    }
+
                     if let Some(obj) = cfg.config.as_object() {
                         for (k, v) in obj {
-                            fields.push(("Config", format!("{k} = {v}")))
+                            instance_fields.push(("Config", format!("{k} = {v}")))
                         }
                     }
 
-                    if !cfg.enabled_capabilities.is_empty() {
-                        fields.push(("Enabled Capabilities", cfg.enabled_capabilities.join(", ")));
-                    }
+                    ctx.ui.detail("", &instance_fields);
                 }
 
-                ctx.ui.detail(id, &fields);
                 Ok(())
             }
             None => {
@@ -120,7 +127,7 @@ impl LauncherCommands {
                     Ok(())
                 } else {
                     ctx.ui
-                        .error(&format!("Launcher '{id}' not found in registry."));
+                        .info(&format!("Launcher '{id}' not found in registry."));
 
                     let available: Vec<_> = crate::launchers::LAUNCHER_REGISTRY
                         .entries()
@@ -633,18 +640,22 @@ mod tests {
         assert!(result.is_ok());
 
         let details = details!(ctx);
-        assert_eq!(details.len(), 1);
+        assert_eq!(details.len(), 2);
 
-        let (id, fields) = &details[0];
-        assert_eq!(id, "my-claude");
-        assert!(fields.iter().any(|(k, _)| *k == "Name"));
+        let (id1, fields1) = &details[0];
+        assert_eq!(id1, "my-claude");
+        assert!(fields1.iter().any(|(k, _)| *k == "Name"));
+
+        let (id2, fields2) = &details[1];
+        assert_eq!(id2, "");
+
         assert!(
-            fields
+            fields2
                 .iter()
                 .any(|(k, v)| *k == "Config: Type" && v == "claude")
         );
         assert!(
-            fields
+            fields2
                 .iter()
                 .any(|(k, v)| *k == "Enabled Capabilities" && v == "chat, plan")
         );

--- a/src/commands/launcher.rs
+++ b/src/commands/launcher.rs
@@ -85,7 +85,7 @@ impl LauncherCommands {
                     .iter()
                     .map(|c| c.to_string())
                     .collect();
-                if !cpas.is_empty() {
+                if !caps.is_empty() {
                     caps.sort();
                     fields.push(("Supported Capabilities", caps.join(", ")));
                 }

--- a/src/commands/launcher.rs
+++ b/src/commands/launcher.rs
@@ -101,7 +101,7 @@ impl LauncherCommands {
                     type_fields.push(("Tags", md.tags.join(", ")));
                 }
 
-                ctx.ui.detail(&format!("{id} (metadata)"), &type_fields);
+                ctx.ui.detail("Type Metadata", &type_fields);
 
                 if let Some(cfg) = configured {
                     let mut instance_fields: Vec<(&str, String)> = Vec::new();
@@ -681,7 +681,7 @@ mod tests {
         assert_eq!(details.len(), 1);
 
         let (id, fields) = &details[0];
-        assert_eq!(id, "claude (metadata)");
+        assert_eq!(id, "Type Metadata");
         assert!(fields.iter().any(|(k, _)| *k == "Name"));
         // Config fields should not be present for catalog-only lookups
         assert!(!fields.iter().any(|(k, _)| k.starts_with("Config")));
@@ -703,7 +703,7 @@ mod tests {
         assert_eq!(details.len(), 2);
 
         let (id1, fields1) = &details[0];
-        assert_eq!(id1, "my-claude (metadata)");
+        assert_eq!(id1, "Type Metadata");
         assert!(fields1.iter().any(|(k, _)| *k == "Name"));
 
         let (id2, fields2) = &details[1];

--- a/src/commands/launcher.rs
+++ b/src/commands/launcher.rs
@@ -65,6 +65,77 @@ impl LauncherCommands {
         Ok(())
     }
 
+    pub fn info(ctx: &crate::AppContext, id: &str) -> Result<()> {
+        let configured = ctx.config.get_launcher(id);
+
+        let metadata = configured
+            .and_then(|c| LAUNCHER_REGISTRY.get(&c.launcher_type))
+            .or_else(|| LAUNCHER_REGISTRY.get(id));
+
+        match metadata {
+            Some(md) => {
+                let mut fields: Vec<(&str, String)> = vec![
+                    ("Name", md.name.clone()),
+                    ("Description", md.description.clone()),
+                    ("Default Command", md.default_command.clone()),
+                ];
+
+                let mut caps: Vec<_> = md
+                    .supported_capabilities
+                    .iter()
+                    .map(|c| c.to_string())
+                    .collect();
+                if !cpas.is_empty() {
+                    caps.sort();
+                    fields.push(("Supported Capabilities", caps.join(", ")));
+                }
+
+                if !md.tags.is_empty() {
+                    fields.push(("Tags", md.tags.join(", ")));
+                }
+
+                if let Some(cfg) = configured {
+                    fields.push(("Config: Type", cfg.launcher_type.clone()));
+                    if let Some(obj) = cfg.config.as_object() {
+                        for (k, v) in obj {
+                            fields.push(("Config", format!("{k} = {v}")))
+                        }
+                    }
+
+                    if !cfg.enabled_capabilities.is_empty() {
+                        fields.push(("Enabled Capabilities", cfg.enabled_capabilities.join(", ")));
+                    }
+                }
+
+                ctx.ui.detail(id, &fields);
+                Ok(())
+            }
+            None => {
+                if configured.is_some() {
+                    let fields: Vec<(&str, String)> = vec![(
+                        "Note",
+                        "Configured but its type is not found in the bundled registry".to_string(),
+                    )];
+                    ctx.ui.detail(id, &fields);
+                    Ok(())
+                } else {
+                    ctx.ui
+                        .error(&format!("Launcher '{id}' not found in registry."));
+
+                    let available: Vec<_> = crate::launchers::LAUNCHER_REGISTRY
+                        .entries()
+                        .keys()
+                        .map(|k| k.to_string())
+                        .collect();
+                    ctx.ui
+                        .info(&format!("Available launchers: {}", available.join(", ")));
+
+                    anyhow::bail!("Launcher not found");
+                }
+            }
+        }
+    }
+
     /// Interactive launcher setup wizard.
     ///
     /// `launcher_type` is the catalog/registry key (e.g. `claude`).
@@ -412,6 +483,16 @@ mod tests {
         };
     }
 
+    macro_rules! details {
+        ($ctx:expr) => {
+            (&*($ctx.ui) as &dyn std::any::Any)
+                .downcast_ref::<CaptureUi>()
+                .unwrap()
+                .details
+                .borrow()
+        };
+    }
+
     macro_rules! infos {
         ($ctx:expr) => {
             (&*($ctx.ui) as &dyn std::any::Any)
@@ -504,6 +585,97 @@ mod tests {
         assert_eq!(rows[0][1], "bob");
         assert_eq!(rows[1][0], "a-claude");
         assert_eq!(rows[2][0], "z-claude");
+    }
+
+    // -- info -----------------------------------------------------------------
+
+    #[test]
+    fn info_unknown_launcher_returns_err() {
+        let ctx = test_ctx();
+        let result = LauncherCommands::info(&ctx, "does-not-exist");
+
+        assert!(result.is_err());
+        assert!(
+            result
+                .unwrap_err()
+                .to_string()
+                .contains("Launcher not found")
+        );
+    }
+
+    #[test]
+    fn info_catalog_launcher_renders_detail() {
+        let ctx = test_ctx();
+        let result = LauncherCommands::info(&ctx, "claude");
+
+        assert!(result.is_ok());
+
+        let details = details!(ctx);
+        assert_eq!(details.len(), 1);
+
+        let (id, fields) = &details[0];
+        assert_eq!(id, "claude");
+        assert!(fields.iter().any(|(k, _)| *k == "Name"));
+        // Config fields should not be present for catalog-only lookups
+        assert!(!fields.iter().any(|(k, _)| k.starts_with("Config")));
+    }
+
+    #[test]
+    fn info_configured_launcher_renders_detail_with_config() {
+        let mut ctx = ctx_with_launcher("my-claude", "claude");
+
+        if let Some(cfg) = ctx.config.launchers.get_mut("my-claude") {
+            cfg.enabled_capabilities = vec!["chat".to_string(), "plan".to_string()];
+        }
+
+        let result = LauncherCommands::info(&ctx, "my-claude");
+
+        assert!(result.is_ok());
+
+        let details = details!(ctx);
+        assert_eq!(details.len(), 1);
+
+        let (id, fields) = &details[0];
+        assert_eq!(id, "my-claude");
+        assert!(fields.iter().any(|(k, _)| *k == "Name"));
+        assert!(
+            fields
+                .iter()
+                .any(|(k, v)| *k == "Config: Type" && v == "claude")
+        );
+        assert!(
+            fields
+                .iter()
+                .any(|(k, v)| *k == "Enabled Capabilities" && v == "chat, plan")
+        );
+    }
+
+    #[test]
+    fn info_configured_unknown_type_renders_note() {
+        let mut ctx = test_ctx();
+        ctx.config.launchers.insert(
+            "custom-launcher".to_string(),
+            LauncherConfig {
+                launcher_id: "custom-launcher".to_string(),
+                launcher_type: "not-a-real-type".to_string(),
+                ..LauncherConfig::default()
+            },
+        );
+
+        let result = LauncherCommands::info(&ctx, "custom-launcher");
+
+        assert!(result.is_ok());
+
+        let details = details!(ctx);
+        assert_eq!(details.len(), 1);
+
+        let (id, fields) = &details[0];
+        assert_eq!(id, "custom-launcher");
+        assert!(
+            fields
+                .iter()
+                .any(|(k, v)| *k == "Note" && v.contains("not found in the bundled registry"))
+        );
     }
 
     // -- setup (type-aware clash detection) ------------------------------------

--- a/src/commands/launcher.rs
+++ b/src/commands/launcher.rs
@@ -94,7 +94,7 @@ impl LauncherCommands {
                     type_fields.push(("Tags", md.tags.join(", ")));
                 }
 
-                ctx.ui.detail(id, &type_fields);
+                ctx.ui.detail(&format!("{id} (metadata)"), &type_fields);
 
                 if let Some(cfg) = configured {
                     let mut instance_fields: Vec<(&str, String)> = Vec::new();
@@ -112,7 +112,7 @@ impl LauncherCommands {
                         }
                     }
 
-                    ctx.ui.detail("", &instance_fields);
+                    ctx.ui.detail(id, &instance_fields);
                 }
 
                 Ok(())
@@ -621,7 +621,7 @@ mod tests {
         assert_eq!(details.len(), 1);
 
         let (id, fields) = &details[0];
-        assert_eq!(id, "claude");
+        assert_eq!(id, "claude (metadata)");
         assert!(fields.iter().any(|(k, _)| *k == "Name"));
         // Config fields should not be present for catalog-only lookups
         assert!(!fields.iter().any(|(k, _)| k.starts_with("Config")));
@@ -643,11 +643,11 @@ mod tests {
         assert_eq!(details.len(), 2);
 
         let (id1, fields1) = &details[0];
-        assert_eq!(id1, "my-claude");
+        assert_eq!(id1, "my-claude (metadata)");
         assert!(fields1.iter().any(|(k, _)| *k == "Name"));
 
         let (id2, fields2) = &details[1];
-        assert_eq!(id2, "");
+        assert_eq!(id2, "my-claude");
 
         assert!(
             fields2

--- a/src/commands/model.rs
+++ b/src/commands/model.rs
@@ -554,7 +554,7 @@ impl ModelCommands {
                 let md = model.to_metadata();
                 let type_fields = Self::metadata_fields(&md);
 
-                ctx.ui.detail(&format!("{id} (metadata)"), &type_fields);
+                ctx.ui.detail("Type Metadata", &type_fields);
 
                 let mut instance_fields: Vec<(&str, String)> = Vec::new();
                 instance_fields.push(("Config: Type", model_config.model_type.clone()));
@@ -570,7 +570,7 @@ impl ModelCommands {
 
         match Self::info_fields(id) {
             Some(type_fields) => {
-                ctx.ui.detail(&format!("{id} (metadata)"), &type_fields);
+                ctx.ui.detail("Type Metadata", &type_fields);
 
                 if let Some(configured) = ctx.config.get_model(id) {
                     let mut instance_fields: Vec<(&str, String)> = Vec::new();
@@ -1219,7 +1219,7 @@ mod tests {
         let details = details!(ctx);
         assert_eq!(details.len(), 1);
         let (title, fields) = &details[0];
-        assert_eq!(title, "granite-3.1-8b-instruct (metadata)");
+        assert_eq!(title, "Type Metadata");
         assert!(fields.iter().any(|(k, _)| k == "Family"));
         assert!(fields.iter().any(|(k, _)| k == "Context Length"));
         assert!(fields.iter().any(|(k, _)| k == "Supported Functions"));
@@ -1758,7 +1758,7 @@ mod tests {
         let details = details!(ctx);
         assert_eq!(details.len(), 2);
         let (title1, fields1) = &details[0];
-        assert_eq!(title1, "my-custom (metadata)");
+        assert_eq!(title1, "Type Metadata");
         assert!(
             fields1
                 .iter()

--- a/src/commands/model.rs
+++ b/src/commands/model.rs
@@ -502,31 +502,39 @@ impl ModelCommands {
             let source = ModelSource::from_config(&ctx.config);
             if let Some((_, model)) = source.instances().into_iter().find(|(iid, _)| iid == id) {
                 let md = model.to_metadata();
-                let mut fields = Self::metadata_fields(&md);
-                fields.push(("Config: Type", model_config.model_type.clone()));
-                fields.push((
+                let type_fields = Self::metadata_fields(&md);
+
+                ctx.ui.detail(&format!("{id} (metadata)"), &type_fields);
+
+                let mut instance_fields: Vec<(&str, String)> = Vec::new();
+                instance_fields.push(("Config: Type", model_config.model_type.clone()));
+                instance_fields.push((
                     "Config: Provider",
                     format!("{:?}", model_config.provider_id),
                 ));
-                fields.push(("Config: Variant", format!("{:?}", model_config.variant)));
-                ctx.ui.detail(id, &fields);
+                instance_fields.push(("Config: Variant", format!("{:?}", model_config.variant)));
+                ctx.ui.detail(id, &instance_fields);
                 return Ok(());
             }
         }
 
         match Self::info_fields(id) {
-            Some(mut fields) => {
+            Some(type_fields) => {
+                ctx.ui.detail(&format!("{id} (metadata)"), &type_fields);
+
                 if let Some(configured) = ctx.config.get_model(id) {
-                    fields.push(("Config: Provider", format!("{:?}", configured.provider_id)));
-                    fields.push(("Config: Variant", format!("{:?}", configured.variant)));
+                    let mut instance_fields: Vec<(&str, String)> = Vec::new();
+                    instance_fields
+                        .push(("Config: Provider", format!("{:?}", configured.provider_id)));
+                    instance_fields.push(("Config: Variant", format!("{:?}", configured.variant)));
+
+                    ctx.ui.detail(id, &instance_fields);
                 }
 
-                ctx.ui.detail(id, &fields);
                 Ok(())
             }
             None => {
-                ctx.ui
-                    .error(&format!("Model '{id}' not found in registry."));
+                ctx.ui.info(&format!("Model '{id}' not found in registry."));
                 let available: Vec<_> = MODEL_REGISTRY
                     .entries()
                     .keys()
@@ -1164,7 +1172,7 @@ mod tests {
         let details = details!(ctx);
         assert_eq!(details.len(), 1);
         let (title, fields) = &details[0];
-        assert_eq!(title, "granite-3.1-8b-instruct");
+        assert_eq!(title, "granite-3.1-8b-instruct (metadata)");
         assert!(fields.iter().any(|(k, _)| k == "Family"));
         assert!(fields.iter().any(|(k, _)| k == "Context Length"));
         assert!(fields.iter().any(|(k, _)| k == "Supported Functions"));
@@ -1175,7 +1183,6 @@ mod tests {
         let ctx = empty_ctx();
         let result = ModelCommands::info(&ctx, "does-not-exist");
         assert!(result.is_err());
-        assert!(!errors!(ctx).is_empty());
     }
 
     fn metadata_supporting(formats: Vec<ModelFormat>) -> ProviderMetadata {
@@ -1702,16 +1709,19 @@ mod tests {
         );
         ModelCommands::info(&ctx, "my-custom").unwrap();
         let details = details!(ctx);
-        assert_eq!(details.len(), 1);
-        let (title, fields) = &details[0];
-        assert_eq!(title, "my-custom");
+        assert_eq!(details.len(), 2);
+        let (title1, fields1) = &details[0];
+        assert_eq!(title1, "my-custom (metadata)");
         assert!(
-            fields
+            fields1
                 .iter()
                 .any(|(k, v)| k == "Family" && v == "My Local Model")
         );
+
+        let (title2, fields2) = &details[1];
+        assert_eq!(title2, "my-custom");
         assert!(
-            fields
+            fields2
                 .iter()
                 .any(|(k, v)| k == "Config: Type" && v == "custom")
         );

--- a/src/commands/provider.rs
+++ b/src/commands/provider.rs
@@ -115,7 +115,7 @@ impl ProviderCommands {
 
         match metadata {
             Some(md) => {
-                let mut fields: Vec<(&str, String)> = vec![
+                let mut type_fields: Vec<(&str, String)> = vec![
                     ("Name", md.name.clone()),
                     ("Description", md.description.clone()),
                     ("Type", md.provider_type.to_string()),
@@ -129,7 +129,7 @@ impl ProviderCommands {
                     .collect::<Vec<_>>()
                     .join(", ");
                 if !api_types.is_empty() {
-                    fields.push(("API Types", api_types));
+                    type_fields.push(("API Types", api_types));
                 }
 
                 let formats = md
@@ -139,23 +139,28 @@ impl ProviderCommands {
                     .collect::<Vec<_>>()
                     .join(", ");
                 if !formats.is_empty() {
-                    fields.push(("Formats", formats));
+                    type_fields.push(("Formats", formats));
                 }
 
                 if !md.tags.is_empty() {
-                    fields.push(("Tags", md.tags.join(", ")));
+                    type_fields.push(("Tags", md.tags.join(", ")));
                 }
+
+                ctx.ui.detail(id, &type_fields);
 
                 if let Some(cfg) = configured {
-                    fields.push(("Config: Type", cfg.provider_type.clone()));
+                    let mut instance_fields: Vec<(&str, String)> = Vec::new();
+
+                    instance_fields.push(("Config: Type", cfg.provider_type.clone()));
                     if let Some(obj) = cfg.config.as_object() {
                         for (k, v) in obj {
-                            fields.push(("Config", format!("{k} = {v}")))
+                            instance_fields.push(("Config", format!("{k} = {v}")))
                         }
                     }
+
+                    ctx.ui.detail("", &instance_fields);
                 }
 
-                ctx.ui.detail(id, &fields);
                 Ok(())
             }
             None => {
@@ -168,7 +173,7 @@ impl ProviderCommands {
                     Ok(())
                 } else {
                     ctx.ui
-                        .error(&format!("Provider '{id}' not found in registry."));
+                        .info(&format!("Provider '{id}' not found in registry."));
 
                     let available: Vec<_> = crate::providers::PROVIDER_REGISTRY
                         .entries()
@@ -593,19 +598,22 @@ mod tests {
         assert!(result.is_ok());
 
         let details = details!(ctx);
-        assert_eq!(details.len(), 1);
-        let (id, fields) = &details[0];
-        assert_eq!(id, "my-provider");
+        assert_eq!(details.len(), 2);
 
-        assert!(fields.iter().any(|(k, _)| *k == "Name"));
+        let (id1, fields1) = &details[0];
+        assert_eq!(id1, "my-provider");
+        assert!(fields1.iter().any(|(k, _)| *k == "Name"));
+
+        let (id2, fields2) = &details[1];
+        assert_eq!(id2, "");
 
         assert!(
-            fields
+            fields2
                 .iter()
                 .any(|(k, v)| *k == "Config: Type" && v == "openai-compatible")
         );
         assert!(
-            fields
+            fields2
                 .iter()
                 .any(|(k, v)| *k == "Config" && v.contains("http://localhost:11434"))
         );

--- a/src/commands/provider.rs
+++ b/src/commands/provider.rs
@@ -106,6 +106,84 @@ impl ProviderCommands {
         Ok(())
     }
 
+    pub fn info(ctx: &crate::AppContext, id: &str) -> Result<()> {
+        let configured = ctx.config.get_provider(id);
+
+        let metadata = configured
+            .and_then(|p| PROVIDER_REGISTRY.get(&p.provider_type))
+            .or_else(|| PROVIDER_REGISTRY.get(id));
+
+        match metadata {
+            Some(md) => {
+                let mut fields: Vec<(&str, String)> = vec![
+                    ("Name", md.name.clone()),
+                    ("Description", md.description.clone()),
+                    ("Type", md.provider_type.to_string()),
+                    ("Default URL", md.default_endpoint.clone()),
+                ];
+
+                let api_types = md
+                    .supported_api_types
+                    .iter()
+                    .map(|t| t.to_string())
+                    .collect::<Vec<_>>()
+                    .join(", ");
+                if !api_types.is_empty() {
+                    fields.push(("API Types", api_types));
+                }
+
+                let formats = md
+                    .supported_formats
+                    .iter()
+                    .map(|f| f.to_string())
+                    .collect::<Vec<_>>()
+                    .join(", ");
+                if !formats.is_empty() {
+                    fields.push(("Formats", formats));
+                }
+
+                if !md.tags.is_empty() {
+                    fields.push(("Tags", md.tags.join(", ")));
+                }
+
+                if let Some(cfg) = configured {
+                    fields.push(("Config: Type", cfg.provider_type.clone()));
+                    if let Some(obj) = cfg.config.as_object() {
+                        for (k, v) in obj {
+                            fields.push(("Config", format!("{k} = {v}")))
+                        }
+                    }
+                }
+
+                ctx.ui.detail(id, &fields);
+                Ok(())
+            }
+            None => {
+                if configured.is_some() {
+                    let fields: Vec<(&str, String)> = vec![(
+                        "Note",
+                        "Configured but its type is not found in the bundled registry".to_string(),
+                    )];
+                    ctx.ui.detail(id, &fields);
+                    Ok(())
+                } else {
+                    ctx.ui
+                        .error(&format!("Provider '{id}' not found in registry."));
+
+                    let available: Vec<_> = crate::providers::PROVIDER_REGISTRY
+                        .entries()
+                        .keys()
+                        .map(|k| k.to_string())
+                        .collect();
+                    ctx.ui
+                        .info(&format!("Available providers: {}", available.join(", ")));
+
+                    anyhow::bail!("Provider not found");
+                }
+            }
+        }
+    }
+
     /// Interactive provider setup wizard.
     ///
     /// `provider_type` is the catalog/registry key (e.g. `openai-compatible`).
@@ -337,6 +415,16 @@ mod tests {
         };
     }
 
+    macro_rules! details {
+        ($ctx:expr) => {
+            (&*($ctx.ui) as &dyn std::any::Any)
+                .downcast_ref::<CaptureUi>()
+                .unwrap()
+                .details
+                .borrow()
+        };
+    }
+
     macro_rules! infos {
         ($ctx:expr) => {
             (&*($ctx.ui) as &dyn std::any::Any)
@@ -467,6 +555,85 @@ mod tests {
         assert_eq!(rows[2][1], "openai-compatible");
         assert_eq!(rows[1][0], "dev-openai");
         assert_eq!(rows[2][0], "prod-openai");
+    }
+
+    // -- info -----------------------------------------------------------------
+
+    #[test]
+    fn info_unknown_provider_returns_err() {
+        let ctx = test_ctx();
+        let result = ProviderCommands::info(&ctx, "does-not-exist");
+        assert!(result.is_err());
+        assert!(
+            result
+                .unwrap_err()
+                .to_string()
+                .contains("Provider not found")
+        );
+    }
+
+    #[test]
+    fn info_catalog_provider_renders_detail() {
+        let ctx = test_ctx();
+        let result = ProviderCommands::info(&ctx, "openai-compatible");
+        assert!(result.is_ok());
+
+        let details = details!(ctx);
+        assert_eq!(details.len(), 1);
+        let (id, fields) = &details[0];
+        assert_eq!(id, "openai-compatible");
+        assert!(fields.iter().any(|(k, _)| *k == "Name"));
+        assert!(!fields.iter().any(|(k, _)| k.starts_with("Config")));
+    }
+
+    #[test]
+    fn info_configured_provider_renders_detail_with_config() {
+        let ctx = ctx_with_provider("my-provider", "http://localhost:11434");
+        let result = ProviderCommands::info(&ctx, "my-provider");
+        assert!(result.is_ok());
+
+        let details = details!(ctx);
+        assert_eq!(details.len(), 1);
+        let (id, fields) = &details[0];
+        assert_eq!(id, "my-provider");
+
+        assert!(fields.iter().any(|(k, _)| *k == "Name"));
+
+        assert!(
+            fields
+                .iter()
+                .any(|(k, v)| *k == "Config: Type" && v == "openai-compatible")
+        );
+        assert!(
+            fields
+                .iter()
+                .any(|(k, v)| *k == "Config" && v.contains("http://localhost:11434"))
+        );
+    }
+
+    #[test]
+    fn info_configured_unknown_type_renders_note() {
+        let mut ctx = test_ctx();
+        ctx.config.providers.insert(
+            "custom-provider".to_string(),
+            ProviderConfig {
+                provider_id: "custom-provider".to_string(),
+                provider_type: "not-a-real-type".to_string(),
+                config: serde_json::json!({}),
+            },
+        );
+        let result = ProviderCommands::info(&ctx, "custom-provider");
+        assert!(result.is_ok());
+
+        let details = details!(ctx);
+        assert_eq!(details.len(), 1);
+        let (id, fields) = &details[0];
+        assert_eq!(id, "custom-provider");
+        assert!(
+            fields
+                .iter()
+                .any(|(k, v)| *k == "Note" && v.contains("not found in the bundled registry"))
+        );
     }
 
     // -- health ----------------------------------------------------------------

--- a/src/commands/provider.rs
+++ b/src/commands/provider.rs
@@ -146,7 +146,7 @@ impl ProviderCommands {
                     type_fields.push(("Tags", md.tags.join(", ")));
                 }
 
-                ctx.ui.detail(id, &type_fields);
+                ctx.ui.detail(&format!("{id} (metadata)"), &type_fields);
 
                 if let Some(cfg) = configured {
                     let mut instance_fields: Vec<(&str, String)> = Vec::new();
@@ -158,7 +158,7 @@ impl ProviderCommands {
                         }
                     }
 
-                    ctx.ui.detail("", &instance_fields);
+                    ctx.ui.detail(id, &instance_fields);
                 }
 
                 Ok(())
@@ -586,7 +586,7 @@ mod tests {
         let details = details!(ctx);
         assert_eq!(details.len(), 1);
         let (id, fields) = &details[0];
-        assert_eq!(id, "openai-compatible");
+        assert_eq!(id, "openai-compatible (metadata)");
         assert!(fields.iter().any(|(k, _)| *k == "Name"));
         assert!(!fields.iter().any(|(k, _)| k.starts_with("Config")));
     }
@@ -601,11 +601,11 @@ mod tests {
         assert_eq!(details.len(), 2);
 
         let (id1, fields1) = &details[0];
-        assert_eq!(id1, "my-provider");
+        assert_eq!(id1, "my-provider (metadata)");
         assert!(fields1.iter().any(|(k, _)| *k == "Name"));
 
         let (id2, fields2) = &details[1];
-        assert_eq!(id2, "");
+        assert_eq!(id2, "my-provider");
 
         assert!(
             fields2

--- a/src/commands/provider.rs
+++ b/src/commands/provider.rs
@@ -153,7 +153,7 @@ impl ProviderCommands {
                     type_fields.push(("Tags", md.tags.join(", ")));
                 }
 
-                ctx.ui.detail(&format!("{id} (metadata)"), &type_fields);
+                ctx.ui.detail("Type Metadata", &type_fields);
 
                 if let Some(cfg) = configured {
                     let mut instance_fields: Vec<(&str, String)> = Vec::new();
@@ -593,7 +593,7 @@ mod tests {
         let details = details!(ctx);
         assert_eq!(details.len(), 1);
         let (id, fields) = &details[0];
-        assert_eq!(id, "openai-compatible (metadata)");
+        assert_eq!(id, "Type Metadata");
         assert!(fields.iter().any(|(k, _)| *k == "Name"));
         assert!(!fields.iter().any(|(k, _)| k.starts_with("Config")));
     }
@@ -608,7 +608,7 @@ mod tests {
         assert_eq!(details.len(), 2);
 
         let (id1, fields1) = &details[0];
-        assert_eq!(id1, "my-provider (metadata)");
+        assert_eq!(id1, "Type Metadata");
         assert!(fields1.iter().any(|(k, _)| *k == "Name"));
 
         let (id2, fields2) = &details[1];

--- a/src/main.rs
+++ b/src/main.rs
@@ -272,6 +272,12 @@ enum ProviderSubcommands {
     /// List all configured providers
     List,
 
+    /// Show detailed provider information
+    Info {
+        /// Provider ID
+        provider_id: String,
+    },
+
     /// Interactive provider setup wizard
     Setup {
         /// Catalog provider type to set up (e.g. `openai-compatible`)
@@ -304,6 +310,12 @@ enum LauncherSubcommands {
 
     /// List all configured launcher instances
     List,
+
+    /// Show detailed launcher information
+    Info {
+        /// Launcher ID
+        launcher_id: String,
+    },
 
     /// Interactive launcher setup wizard
     Setup {
@@ -666,6 +678,7 @@ async fn run_provider_command(
     match subcmd {
         ProviderSubcommands::Catalog { wide } => ProviderCommands::catalog(ctx, wide),
         ProviderSubcommands::List => ProviderCommands::list(ctx),
+        ProviderSubcommands::Info {provider_id} => ProviderCommands::info(ctx, &provider_id),
         ProviderSubcommands::Setup {
             provider_type,
             instance_id,
@@ -684,6 +697,7 @@ async fn run_launcher_command(
     match subcmd {
         LauncherSubcommands::Catalog => LauncherCommands::catalog(ctx),
         LauncherSubcommands::List => LauncherCommands::list(ctx),
+        LauncherSubcommands::Info { launcher_id } => LauncherCommands::info(ctx, &launcher_id),
         LauncherSubcommands::Setup {
             launcher_type,
             instance_id,

--- a/src/main.rs
+++ b/src/main.rs
@@ -678,7 +678,7 @@ async fn run_provider_command(
     match subcmd {
         ProviderSubcommands::Catalog { wide } => ProviderCommands::catalog(ctx, wide),
         ProviderSubcommands::List => ProviderCommands::list(ctx),
-        ProviderSubcommands::Info {provider_id} => ProviderCommands::info(ctx, &provider_id),
+        ProviderSubcommands::Info { provider_id } => ProviderCommands::info(ctx, &provider_id),
         ProviderSubcommands::Setup {
             provider_type,
             instance_id,


### PR DESCRIPTION
## Description

add info sub command in Provider and Launcher as requested in #119

## Changes

- add provider info sub command.
- add provider info sub command test codes.
- add launcher info sub command.
- add launcher info sub command test codes.


## Testing

- run provider sub command test code.
- run launcher sub command test code.

## Related Issue(s)

- #119

## AI Usage

- requested a guideline and i followed that.