### PR TITLE
fix: route terminal and plain warning to stderr

### DIFF
--- a/src/utils/ui/backends/markdown.rs
+++ b/src/utils/ui/backends/markdown.rs
@@ -60,10 +60,10 @@ impl Ui for MarkdownOutput {
         println!("{msg}");
     }
     fn warn(&self, msg: &str) {
-        println!("> [!Warning]\n> {msg}");
+        println!("> [!warning]\n> {msg}");
     }
     fn error(&self, msg: &str) {
-        eprintln!("Error: {msg}");
+        eprintln!("> [!critical]\n> {msg}");
     }
 
     fn select(&self, _prompt: &str, _items: &[String], _default: usize) -> anyhow::Result<usize> {

--- a/src/utils/ui/backends/markdown.rs
+++ b/src/utils/ui/backends/markdown.rs
@@ -60,7 +60,7 @@ impl Ui for MarkdownOutput {
         println!("{msg}");
     }
     fn warn(&self, msg: &str) {
-        println!("Warning: {msg}");
+        println!("> [!Warning]\n> {msg}");
     }
     fn error(&self, msg: &str) {
         eprintln!("Error: {msg}");

--- a/src/utils/ui/backends/plain.rs
+++ b/src/utils/ui/backends/plain.rs
@@ -76,7 +76,7 @@ impl Ui for PlainOutput {
         println!("{msg}");
     }
     fn warn(&self, msg: &str) {
-        println!("Warning: {msg}");
+        eprintln!("Warning: {msg}");
     }
     fn error(&self, msg: &str) {
         eprintln!("Error: {msg}");

--- a/src/utils/ui/backends/terminal.rs
+++ b/src/utils/ui/backends/terminal.rs
@@ -177,7 +177,7 @@ impl Ui for TerminalOutput {
         if !self.is_tty {
             return PlainOutput.warn(msg);
         }
-        println!(
+        eprintln!(
             "{}{}Warning:{} {}",
             SetForegroundColor(Color::Yellow),
             SetAttribute(Attribute::Bold),


### PR DESCRIPTION
## Description

Route terminal and plain warning to stderr.
Write markdown warning message as markdown warning syntax.

## Changes

- route terminal warning message to stderr
- route plain warning message to stderr
- write markdown warning message as markdown warning syntax.

## Testing

cargo test and run CLI with warning message to check routing to stderr.

## Related Issue(s)

#118

## AI Usage

just research.