### PR TITLE
OpenAI provider custom headers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /target
+/target-mounted
 tmp
 
 # Agent-specific outputs

--- a/scripts/launcher-testing/build.sh
+++ b/scripts/launcher-testing/build.sh
@@ -1,2 +1,3 @@
 #!/usr/bin/env bash
+cd $(dirname ${BASH_SOURCE[0]})
 docker buildx build -t agents-test .

--- a/src/capabilities/agent_model.rs
+++ b/src/capabilities/agent_model.rs
@@ -124,6 +124,7 @@ impl Capability for AgentModelCapability {
             api_key: provider.api_key().cloned(),
             verify_ssl: provider.verify_ssl(),
             context_length: Some(self.configured_model.model.context_length()),
+            custom_headers: provider.custom_headers(),
         }))
     }
 }
@@ -211,6 +212,9 @@ mod tests {
         }
         fn verify_ssl(&self) -> bool {
             self.verify_ssl
+        }
+        fn custom_headers(&self) -> Option<HashMap<String, Secret>> {
+            None
         }
         fn supported_formats(&self) -> Vec<ModelFormat> {
             vec![]

--- a/src/capabilities/agent_model.rs
+++ b/src/capabilities/agent_model.rs
@@ -219,7 +219,11 @@ mod tests {
         fn supported_formats(&self) -> Vec<ModelFormat> {
             vec![]
         }
-        fn model_alias(&self, _model_id: String, _variant: Option<&crate::models::ModelVariant>) -> Option<String> {
+        fn model_alias(
+            &self,
+            _model_id: String,
+            _variant: Option<&crate::models::ModelVariant>,
+        ) -> Option<String> {
             self.alias.clone()
         }
         async fn health_check(&self) -> Result<HealthStatus, ProviderError> {

--- a/src/capabilities/agent_model.rs
+++ b/src/capabilities/agent_model.rs
@@ -219,7 +219,7 @@ mod tests {
         fn supported_formats(&self) -> Vec<ModelFormat> {
             vec![]
         }
-        fn model_alias(&self, _variant: Option<&crate::models::ModelVariant>) -> Option<String> {
+        fn model_alias(&self, _model_id: String, _variant: Option<&crate::models::ModelVariant>) -> Option<String> {
             self.alias.clone()
         }
         async fn health_check(&self) -> Result<HealthStatus, ProviderError> {

--- a/src/capabilities/base.rs
+++ b/src/capabilities/base.rs
@@ -96,6 +96,8 @@ pub struct AgentModelBinding {
     pub api_key: Option<Secret>,
     pub verify_ssl: bool,
     pub context_length: Option<u64>,
+    /// Custom headers to be sent with each request to the provider.
+    pub custom_headers: Option<HashMap<String, Secret>>,
 }
 
 /// Request payload for `BindingType::SubAgent` -- which `ApiType` the

--- a/src/capabilities/sub_agent.rs
+++ b/src/capabilities/sub_agent.rs
@@ -129,6 +129,7 @@ macro_rules! declare_sub_agent_basic {
                         api_key: provider.api_key().cloned(),
                         verify_ssl: provider.verify_ssl(),
                         context_length: Some(self.configured_model.model.context_length()),
+                        custom_headers: provider.custom_headers(),
                     },
                     known_type: $known_type,
                 }))
@@ -283,6 +284,7 @@ macro_rules! declare_sub_agent_full {
                         api_key: provider.api_key().cloned(),
                         verify_ssl: provider.verify_ssl(),
                         context_length: Some(self.configured_model.model.context_length()),
+                        custom_headers: provider.custom_headers(),
                     },
                     known_type: $known_type,
                 }))
@@ -395,6 +397,9 @@ mod tests {
         }
         fn verify_ssl(&self) -> bool {
             self.verify_ssl
+        }
+        fn custom_headers(&self) -> Option<std::collections::HashMap<String, Secret>> {
+            None
         }
         fn supported_formats(&self) -> Vec<ModelFormat> {
             vec![]

--- a/src/capabilities/sub_agent.rs
+++ b/src/capabilities/sub_agent.rs
@@ -404,7 +404,7 @@ mod tests {
         fn supported_formats(&self) -> Vec<ModelFormat> {
             vec![]
         }
-        fn model_alias(&self, _variant: Option<&crate::models::ModelVariant>) -> Option<String> {
+        fn model_alias(&self, _model_id: String, _variant: Option<&crate::models::ModelVariant>) -> Option<String> {
             self.alias.clone()
         }
         async fn health_check(&self) -> Result<HealthStatus, ProviderError> {

--- a/src/capabilities/sub_agent.rs
+++ b/src/capabilities/sub_agent.rs
@@ -404,7 +404,11 @@ mod tests {
         fn supported_formats(&self) -> Vec<ModelFormat> {
             vec![]
         }
-        fn model_alias(&self, _model_id: String, _variant: Option<&crate::models::ModelVariant>) -> Option<String> {
+        fn model_alias(
+            &self,
+            _model_id: String,
+            _variant: Option<&crate::models::ModelVariant>,
+        ) -> Option<String> {
             self.alias.clone()
         }
         async fn health_check(&self) -> Result<HealthStatus, ProviderError> {

--- a/src/capabilities/sub_agent_code.rs
+++ b/src/capabilities/sub_agent_code.rs
@@ -112,6 +112,9 @@ mod tests {
         fn verify_ssl(&self) -> bool {
             self.verify_ssl
         }
+        fn custom_headers(&self) -> Option<std::collections::HashMap<String, Secret>> {
+            None
+        }
         fn supported_formats(&self) -> Vec<ModelFormat> {
             vec![]
         }

--- a/src/capabilities/sub_agent_code.rs
+++ b/src/capabilities/sub_agent_code.rs
@@ -118,7 +118,11 @@ mod tests {
         fn supported_formats(&self) -> Vec<ModelFormat> {
             vec![]
         }
-        fn model_alias(&self, _model_id: String, _variant: Option<&crate::models::ModelVariant>) -> Option<String> {
+        fn model_alias(
+            &self,
+            _model_id: String,
+            _variant: Option<&crate::models::ModelVariant>,
+        ) -> Option<String> {
             self.alias.clone()
         }
         async fn health_check(&self) -> Result<HealthStatus, ProviderError> {

--- a/src/capabilities/sub_agent_code.rs
+++ b/src/capabilities/sub_agent_code.rs
@@ -118,7 +118,7 @@ mod tests {
         fn supported_formats(&self) -> Vec<ModelFormat> {
             vec![]
         }
-        fn model_alias(&self, _variant: Option<&crate::models::ModelVariant>) -> Option<String> {
+        fn model_alias(&self, _model_id: String, _variant: Option<&crate::models::ModelVariant>) -> Option<String> {
             self.alias.clone()
         }
         async fn health_check(&self) -> Result<HealthStatus, ProviderError> {

--- a/src/capabilities/sub_agent_explore.rs
+++ b/src/capabilities/sub_agent_explore.rs
@@ -126,7 +126,11 @@ mod tests {
         fn supported_formats(&self) -> Vec<ModelFormat> {
             vec![]
         }
-        fn model_alias(&self, _model_id: String, _variant: Option<&crate::models::ModelVariant>) -> Option<String> {
+        fn model_alias(
+            &self,
+            _model_id: String,
+            _variant: Option<&crate::models::ModelVariant>,
+        ) -> Option<String> {
             self.alias.clone()
         }
         async fn health_check(&self) -> Result<HealthStatus, ProviderError> {

--- a/src/capabilities/sub_agent_explore.rs
+++ b/src/capabilities/sub_agent_explore.rs
@@ -120,6 +120,9 @@ mod tests {
         fn verify_ssl(&self) -> bool {
             self.verify_ssl
         }
+        fn custom_headers(&self) -> Option<std::collections::HashMap<String, Secret>> {
+            None
+        }
         fn supported_formats(&self) -> Vec<ModelFormat> {
             vec![]
         }

--- a/src/capabilities/sub_agent_explore.rs
+++ b/src/capabilities/sub_agent_explore.rs
@@ -126,7 +126,7 @@ mod tests {
         fn supported_formats(&self) -> Vec<ModelFormat> {
             vec![]
         }
-        fn model_alias(&self, _variant: Option<&crate::models::ModelVariant>) -> Option<String> {
+        fn model_alias(&self, _model_id: String, _variant: Option<&crate::models::ModelVariant>) -> Option<String> {
             self.alias.clone()
         }
         async fn health_check(&self) -> Result<HealthStatus, ProviderError> {

--- a/src/capabilities/sub_agent_plan.rs
+++ b/src/capabilities/sub_agent_plan.rs
@@ -152,7 +152,7 @@ mod tests {
         fn supported_formats(&self) -> Vec<ModelFormat> {
             vec![]
         }
-        fn model_alias(&self, _variant: Option<&crate::models::ModelVariant>) -> Option<String> {
+        fn model_alias(&self, _model_id: String, _variant: Option<&crate::models::ModelVariant>) -> Option<String> {
             self.alias.clone()
         }
         async fn health_check(&self) -> Result<HealthStatus, ProviderError> {

--- a/src/capabilities/sub_agent_plan.rs
+++ b/src/capabilities/sub_agent_plan.rs
@@ -152,7 +152,11 @@ mod tests {
         fn supported_formats(&self) -> Vec<ModelFormat> {
             vec![]
         }
-        fn model_alias(&self, _model_id: String, _variant: Option<&crate::models::ModelVariant>) -> Option<String> {
+        fn model_alias(
+            &self,
+            _model_id: String,
+            _variant: Option<&crate::models::ModelVariant>,
+        ) -> Option<String> {
             self.alias.clone()
         }
         async fn health_check(&self) -> Result<HealthStatus, ProviderError> {

--- a/src/capabilities/sub_agent_plan.rs
+++ b/src/capabilities/sub_agent_plan.rs
@@ -146,6 +146,9 @@ mod tests {
         fn verify_ssl(&self) -> bool {
             self.verify_ssl
         }
+        fn custom_headers(&self) -> Option<std::collections::HashMap<String, Secret>> {
+            None
+        }
         fn supported_formats(&self) -> Vec<ModelFormat> {
             vec![]
         }

--- a/src/capabilities/vision_mcp/mod.rs
+++ b/src/capabilities/vision_mcp/mod.rs
@@ -301,7 +301,11 @@ mod tests {
         fn supported_formats(&self) -> Vec<ModelFormat> {
             vec![]
         }
-        fn model_alias(&self, _model_id: String, _variant: Option<&ModelVariant>) -> Option<String> {
+        fn model_alias(
+            &self,
+            _model_id: String,
+            _variant: Option<&ModelVariant>,
+        ) -> Option<String> {
             self.alias.clone()
         }
         async fn health_check(&self) -> Result<HealthStatus, ProviderError> {

--- a/src/capabilities/vision_mcp/mod.rs
+++ b/src/capabilities/vision_mcp/mod.rs
@@ -301,7 +301,7 @@ mod tests {
         fn supported_formats(&self) -> Vec<ModelFormat> {
             vec![]
         }
-        fn model_alias(&self, _variant: Option<&ModelVariant>) -> Option<String> {
+        fn model_alias(&self, _model_id: String, _variant: Option<&ModelVariant>) -> Option<String> {
             self.alias.clone()
         }
         async fn health_check(&self) -> Result<HealthStatus, ProviderError> {

--- a/src/capabilities/vision_mcp/mod.rs
+++ b/src/capabilities/vision_mcp/mod.rs
@@ -295,6 +295,9 @@ mod tests {
         fn verify_ssl(&self) -> bool {
             self.verify_ssl
         }
+        fn custom_headers(&self) -> Option<StdHashMap<String, Secret>> {
+            None
+        }
         fn supported_formats(&self) -> Vec<ModelFormat> {
             vec![]
         }

--- a/src/launchers/claude.rs
+++ b/src/launchers/claude.rs
@@ -165,7 +165,7 @@ impl Launcher for ClaudeLauncher {
             if api_key_val.is_empty() {
                 api_key_val = "unset".to_string(); // Claude treats empty strings like unset
             }
-            let bindings = vec![
+            let mut bindings = vec![
                 EnvBinding {
                     key: "ANTHROPIC_BASE_URL".to_string(),
                     value: binding.base_url.clone(),
@@ -185,6 +185,28 @@ impl Launcher for ClaudeLauncher {
                     value: api_key_val,
                 },
             ];
+
+            // Add custom headers if configured, formatted as "Name: Value" pairs
+            // newline-separated, matching ANTHROPIC_CUSTOM_HEADERS format.
+            // Sort by key for deterministic output.
+            if let Some(ref headers) = binding.custom_headers {
+                if !headers.is_empty() {
+                    let mut header_pairs: Vec<(String, String)> =
+                        headers.iter().map(
+                            |(k, v)| (k.clone(), serde_json::to_value(v).unwrap().as_str().unwrap().to_string())
+                        ).collect();
+                    header_pairs.sort_by(|a, b| a.0.cmp(&b.0));
+                    let header_lines: Vec<String> = header_pairs
+                        .iter()
+                        .map(|(k, v)| format!("{k}: {v}"))
+                        .collect();
+                    bindings.push(EnvBinding {
+                        key: "ANTHROPIC_CUSTOM_HEADERS".to_string(),
+                        value: header_lines.join("\n"),
+                    });
+                }
+            }
+
             // verify_ssl is dropped per user's note
             Ok(bindings)
         } else {
@@ -415,6 +437,7 @@ impl HasClaudeLauncherMetadata for ClaudeLauncher {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::collections::HashMap;
 
     #[test]
     fn command_defaults_to_claude() {
@@ -485,6 +508,80 @@ mod tests {
     fn metadata_supports_sub_agent_binding() {
         let meta = ClaudeLauncher::metadata();
         assert!(meta.supported_capabilities.contains(&BindingType::SubAgent));
+    }
+
+    #[tokio::test]
+    async fn env_overlay_includes_custom_headers() {
+        let mut headers = HashMap::new();
+        headers.insert("X-Custom-Header".to_string(), crate::registry::Secret::from("value1"));
+        headers.insert("User-Agent".to_string(), crate::registry::Secret::from("my-agent/1.0"));
+        let l = launcher_with(
+            Some(crate::capabilities::AgentModelBinding {
+                api_type: crate::providers::ApiType::Anthropic,
+                provider_name: "test".to_string(),
+                base_url: "http://test".to_string(),
+                model_name: "test-model".to_string(),
+                endpoint_path: "/v1/messages".to_string(),
+                api_key: Some(crate::registry::Secret::from("test-key")),
+                verify_ssl: true,
+                context_length: Some(4096),
+                custom_headers: Some(headers),
+            }),
+            vec![],
+        );
+        let overlay = l.env_overlay(&test_launch_context(false)).await.unwrap();
+        let headers_entry = overlay
+            .iter()
+            .find(|b| b.key == "ANTHROPIC_CUSTOM_HEADERS")
+            .expect("ANTHROPIC_CUSTOM_HEADERS should be set");
+        // Headers are formatted as "Name: Value" pairs, newline-separated, sorted by key.
+        assert_eq!(headers_entry.value, "User-Agent: my-agent/1.0\nX-Custom-Header: value1");
+    }
+
+    #[tokio::test]
+    async fn env_overlay_omits_custom_headers_when_none_set() {
+        let l = launcher_with(
+            Some(crate::capabilities::AgentModelBinding {
+                api_type: crate::providers::ApiType::Anthropic,
+                provider_name: "test".to_string(),
+                base_url: "http://test".to_string(),
+                model_name: "test-model".to_string(),
+                endpoint_path: "/v1/messages".to_string(),
+                api_key: Some(crate::registry::Secret::from("test-key")),
+                verify_ssl: true,
+                context_length: Some(4096),
+                custom_headers: None,
+            }),
+            vec![],
+        );
+        let overlay = l.env_overlay(&test_launch_context(false)).await.unwrap();
+        let headers_entry = overlay
+            .iter()
+            .find(|b| b.key == "ANTHROPIC_CUSTOM_HEADERS");
+        assert!(headers_entry.is_none());
+    }
+
+    #[tokio::test]
+    async fn env_overlay_omits_custom_headers_when_empty_map() {
+        let l = launcher_with(
+            Some(crate::capabilities::AgentModelBinding {
+                api_type: crate::providers::ApiType::Anthropic,
+                provider_name: "test".to_string(),
+                base_url: "http://test".to_string(),
+                model_name: "test-model".to_string(),
+                endpoint_path: "/v1/messages".to_string(),
+                api_key: Some(crate::registry::Secret::from("test-key")),
+                verify_ssl: true,
+                context_length: Some(4096),
+                custom_headers: Some(HashMap::new()),
+            }),
+            vec![],
+        );
+        let overlay = l.env_overlay(&test_launch_context(false)).await.unwrap();
+        let headers_entry = overlay
+            .iter()
+            .find(|b| b.key == "ANTHROPIC_CUSTOM_HEADERS");
+        assert!(headers_entry.is_none());
     }
 
     #[test]

--- a/src/launchers/claude.rs
+++ b/src/launchers/claude.rs
@@ -558,6 +558,7 @@ mod tests {
                 api_key: None,
                 verify_ssl: true,
                 context_length: Some(4096),
+                custom_headers: None,
             },
             known_type: None,
         }
@@ -791,6 +792,7 @@ mod tests {
                 api_key: None,
                 verify_ssl: true,
                 context_length: Some(4096),
+                custom_headers: None,
             }),
             vec![(
                 "reviewer".to_string(),

--- a/src/launchers/claude.rs
+++ b/src/launchers/claude.rs
@@ -191,10 +191,19 @@ impl Launcher for ClaudeLauncher {
             // Sort by key for deterministic output.
             if let Some(ref headers) = binding.custom_headers {
                 if !headers.is_empty() {
-                    let mut header_pairs: Vec<(String, String)> =
-                        headers.iter().map(
-                            |(k, v)| (k.clone(), serde_json::to_value(v).unwrap().as_str().unwrap().to_string())
-                        ).collect();
+                    let mut header_pairs: Vec<(String, String)> = headers
+                        .iter()
+                        .map(|(k, v)| {
+                            (
+                                k.clone(),
+                                serde_json::to_value(v)
+                                    .unwrap()
+                                    .as_str()
+                                    .unwrap()
+                                    .to_string(),
+                            )
+                        })
+                        .collect();
                     header_pairs.sort_by(|a, b| a.0.cmp(&b.0));
                     let header_lines: Vec<String> = header_pairs
                         .iter()
@@ -513,8 +522,14 @@ mod tests {
     #[tokio::test]
     async fn env_overlay_includes_custom_headers() {
         let mut headers = HashMap::new();
-        headers.insert("X-Custom-Header".to_string(), crate::registry::Secret::from("value1"));
-        headers.insert("User-Agent".to_string(), crate::registry::Secret::from("my-agent/1.0"));
+        headers.insert(
+            "X-Custom-Header".to_string(),
+            crate::registry::Secret::from("value1"),
+        );
+        headers.insert(
+            "User-Agent".to_string(),
+            crate::registry::Secret::from("my-agent/1.0"),
+        );
         let l = launcher_with(
             Some(crate::capabilities::AgentModelBinding {
                 api_type: crate::providers::ApiType::Anthropic,
@@ -535,7 +550,10 @@ mod tests {
             .find(|b| b.key == "ANTHROPIC_CUSTOM_HEADERS")
             .expect("ANTHROPIC_CUSTOM_HEADERS should be set");
         // Headers are formatted as "Name: Value" pairs, newline-separated, sorted by key.
-        assert_eq!(headers_entry.value, "User-Agent: my-agent/1.0\nX-Custom-Header: value1");
+        assert_eq!(
+            headers_entry.value,
+            "User-Agent: my-agent/1.0\nX-Custom-Header: value1"
+        );
     }
 
     #[tokio::test]
@@ -555,9 +573,7 @@ mod tests {
             vec![],
         );
         let overlay = l.env_overlay(&test_launch_context(false)).await.unwrap();
-        let headers_entry = overlay
-            .iter()
-            .find(|b| b.key == "ANTHROPIC_CUSTOM_HEADERS");
+        let headers_entry = overlay.iter().find(|b| b.key == "ANTHROPIC_CUSTOM_HEADERS");
         assert!(headers_entry.is_none());
     }
 
@@ -578,9 +594,7 @@ mod tests {
             vec![],
         );
         let overlay = l.env_overlay(&test_launch_context(false)).await.unwrap();
-        let headers_entry = overlay
-            .iter()
-            .find(|b| b.key == "ANTHROPIC_CUSTOM_HEADERS");
+        let headers_entry = overlay.iter().find(|b| b.key == "ANTHROPIC_CUSTOM_HEADERS");
         assert!(headers_entry.is_none());
     }
 

--- a/src/launchers/goose.rs
+++ b/src/launchers/goose.rs
@@ -7,6 +7,16 @@
 //! session-scoped `--with-extension`/`--with-streamable-http-extension` CLI
 //! flags for MCP servers (goose calls them "extensions").
 
+// Standard
+use std::collections::HashSet;
+use std::path::PathBuf;
+
+// Third Party
+use alog::{alog_channel, use_channel, MessageLevel};
+use async_trait::async_trait;
+use serde::{Deserialize, Serialize};
+
+// Local
 use crate::capabilities::{
     AgentModelBinding, ApiType, Binding, BindingType, Capability, McpBinding,
 };
@@ -15,10 +25,8 @@ use crate::launchers::shared::mcp_cli::mcp_binding_request;
 use crate::registry::ConfigConstructable;
 use crate::utils::resolve_shell_command;
 use crate::utils::ui::Ui;
-use async_trait::async_trait;
-use serde::{Deserialize, Serialize};
-use std::collections::HashSet;
-use std::path::PathBuf;
+
+use_channel!("GOOSE");
 
 /*-- public --*/
 
@@ -179,8 +187,28 @@ impl Launcher for GooseLauncher {
                 key: "OPENAI_API_KEY".to_string(),
                 value: api_key_val,
             });
-        }
 
+            // Add custom headers as OPENAI_CUSTOM_HEADERS env var if configured.
+            // Format: HEADER_A=VALUE_A,HEADER_B=VALUE_B, sorted by key for deterministic output.
+            if let Some(ref headers) = binding.custom_headers {
+                if !headers.is_empty() {
+                    let mut header_pairs: Vec<(String, String)> =
+                        headers.iter().map(
+                            |(k, v)| (k.clone(), serde_json::to_value(v).unwrap().as_str().unwrap().to_string())
+                        ).collect();
+                    header_pairs.sort_by(|a, b| a.0.cmp(&b.0));
+                    let header_lines: Vec<String> = header_pairs
+                        .iter()
+                        .map(|(k, v)| format!("{k}={v}"))
+                        .collect();
+                    overlay.push(EnvBinding {
+                        key: "OPENAI_CUSTOM_HEADERS".to_string(),
+                        value: header_lines.join(","),
+                    });
+                }
+            }
+        }
+        alog_channel!(MessageLevel::Debug4, "Env Overlay: {:#?}", overlay);
         Ok(overlay)
     }
 
@@ -338,6 +366,7 @@ mod tests {
     use super::*;
     use crate::registry::Named;
     use crate::utils::ui::base::tests::CaptureUi;
+    use std::collections::HashMap;
 
     fn launcher(cfg: serde_json::Value) -> GooseLauncher {
         GooseLauncher::new("goose", &cfg, &crate::config::Config::default())
@@ -528,6 +557,41 @@ mod tests {
             .find(|b| b.key == "OPENAI_API_KEY")
             .expect("OPENAI_API_KEY env is required by goose even for local servers");
         assert_eq!(key.value, "granite-cli");
+    }
+
+    #[tokio::test]
+    async fn env_overlay_includes_custom_headers() {
+        let mut b = binding();
+        let mut headers = HashMap::new();
+        headers.insert("X-Custom-Header".to_string(), crate::registry::Secret::from("value1"));
+        headers.insert("User-Agent".to_string(), crate::registry::Secret::from("my-agent/1.0"));
+        b.custom_headers = Some(headers);
+        let l = bound(serde_json::json!({}), b);
+        let overlay = l.env_overlay(&ctx(false)).await.unwrap();
+        let headers_entry = overlay
+            .iter()
+            .find(|b| b.key == "OPENAI_CUSTOM_HEADERS")
+            .expect("OPENAI_CUSTOM_HEADERS env");
+        // Headers are formatted as "Name=Value" pairs, comma-separated, sorted by key.
+        assert_eq!(headers_entry.value, "User-Agent=my-agent/1.0,X-Custom-Header=value1");
+    }
+
+    #[tokio::test]
+    async fn env_overlay_omits_custom_headers_when_none_set() {
+        let l = bound(serde_json::json!({}), binding());
+        let overlay = l.env_overlay(&ctx(false)).await.unwrap();
+        let headers_entry = overlay.iter().find(|b| b.key == "OPENAI_CUSTOM_HEADERS");
+        assert!(headers_entry.is_none());
+    }
+
+    #[tokio::test]
+    async fn env_overlay_omits_custom_headers_when_empty_map() {
+        let mut b = binding();
+        b.custom_headers = Some(HashMap::new());
+        let l = bound(serde_json::json!({}), b);
+        let overlay = l.env_overlay(&ctx(false)).await.unwrap();
+        let headers_entry = overlay.iter().find(|b| b.key == "OPENAI_CUSTOM_HEADERS");
+        assert!(headers_entry.is_none());
     }
 
     #[tokio::test]

--- a/src/launchers/goose.rs
+++ b/src/launchers/goose.rs
@@ -353,6 +353,7 @@ mod tests {
             api_key: None,
             verify_ssl: true,
             context_length: Some(131072),
+            custom_headers: None,
         }
     }
 

--- a/src/launchers/goose.rs
+++ b/src/launchers/goose.rs
@@ -12,7 +12,7 @@ use std::collections::HashSet;
 use std::path::PathBuf;
 
 // Third Party
-use alog::{alog_channel, use_channel, MessageLevel};
+use alog::{MessageLevel, alog_channel, use_channel};
 use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
 
@@ -192,10 +192,19 @@ impl Launcher for GooseLauncher {
             // Format: HEADER_A=VALUE_A,HEADER_B=VALUE_B, sorted by key for deterministic output.
             if let Some(ref headers) = binding.custom_headers {
                 if !headers.is_empty() {
-                    let mut header_pairs: Vec<(String, String)> =
-                        headers.iter().map(
-                            |(k, v)| (k.clone(), serde_json::to_value(v).unwrap().as_str().unwrap().to_string())
-                        ).collect();
+                    let mut header_pairs: Vec<(String, String)> = headers
+                        .iter()
+                        .map(|(k, v)| {
+                            (
+                                k.clone(),
+                                serde_json::to_value(v)
+                                    .unwrap()
+                                    .as_str()
+                                    .unwrap()
+                                    .to_string(),
+                            )
+                        })
+                        .collect();
                     header_pairs.sort_by(|a, b| a.0.cmp(&b.0));
                     let header_lines: Vec<String> = header_pairs
                         .iter()
@@ -563,8 +572,14 @@ mod tests {
     async fn env_overlay_includes_custom_headers() {
         let mut b = binding();
         let mut headers = HashMap::new();
-        headers.insert("X-Custom-Header".to_string(), crate::registry::Secret::from("value1"));
-        headers.insert("User-Agent".to_string(), crate::registry::Secret::from("my-agent/1.0"));
+        headers.insert(
+            "X-Custom-Header".to_string(),
+            crate::registry::Secret::from("value1"),
+        );
+        headers.insert(
+            "User-Agent".to_string(),
+            crate::registry::Secret::from("my-agent/1.0"),
+        );
         b.custom_headers = Some(headers);
         let l = bound(serde_json::json!({}), b);
         let overlay = l.env_overlay(&ctx(false)).await.unwrap();
@@ -573,7 +588,10 @@ mod tests {
             .find(|b| b.key == "OPENAI_CUSTOM_HEADERS")
             .expect("OPENAI_CUSTOM_HEADERS env");
         // Headers are formatted as "Name=Value" pairs, comma-separated, sorted by key.
-        assert_eq!(headers_entry.value, "User-Agent=my-agent/1.0,X-Custom-Header=value1");
+        assert_eq!(
+            headers_entry.value,
+            "User-Agent=my-agent/1.0,X-Custom-Header=value1"
+        );
     }
 
     #[tokio::test]

--- a/src/launchers/hermes.rs
+++ b/src/launchers/hermes.rs
@@ -470,6 +470,7 @@ mod tests {
             api_key: None,
             verify_ssl: true,
             context_length: Some(131072),
+            custom_headers: None,
         }
     }
 

--- a/src/launchers/hermes.rs
+++ b/src/launchers/hermes.rs
@@ -263,6 +263,14 @@ impl HermesLauncher {
                 model["api_key"] = serde_json::Value::String(format!("${{{API_KEY_ENV}}}"));
             }
 
+            // Add custom headers as extra_headers if configured.
+            // Sorted by key for deterministic output.
+            if let Some(ref headers) = binding.custom_headers {
+                if !headers.is_empty() {
+                    model["extra_headers"] = serde_json::to_value(headers)?;
+                }
+            }
+
             // Merge user-provided overrides on top so they win on conflict.
             // Special case: if the override key is "model", merge the inner
             // object into config["model"] rather than replacing it entirely.

--- a/src/launchers/openclaw.rs
+++ b/src/launchers/openclaw.rs
@@ -318,6 +318,7 @@ mod tests {
             api_key: None,
             verify_ssl: true,
             context_length: Some(131072),
+            custom_headers: None,
         }
     }
 

--- a/src/launchers/openclaw.rs
+++ b/src/launchers/openclaw.rs
@@ -441,10 +441,9 @@ mod tests {
             "my-ollama/granite4.1:8b"
         );
         // No key means no apiKey field at all.
-        assert!(
-            config["models"]["providers"]["my-ollama"]
-                .get("apiKey")
-                .is_none()
+        assert_eq!(
+            config["models"]["providers"]["my-ollama"]["apiKey"],
+            "unused"
         );
     }
 

--- a/src/launchers/openclaw.rs
+++ b/src/launchers/openclaw.rs
@@ -240,13 +240,28 @@ fn generate_config(
             "api": "openai-completions",
             "models": [model_entry],
         });
+        // API Key is required even if the provider doesn't use it
+        let mut api_key_val = serde_json::Value::String("unused".to_string());
         if let Some(api_key) = binding
             .api_key
             .as_ref()
             .map(|api_key| api_key.0.clone())
             .filter(|key| !key.is_empty())
         {
-            provider_entry["apiKey"] = serde_json::Value::String(api_key);
+            api_key_val = serde_json::Value::String(api_key);
+        }
+        provider_entry["apiKey"] = api_key_val;
+
+        // Add custom headers from binding if present. Omit entirely when
+        // custom_headers is empty to match the behavior of other launchers.
+        if let Some(headers) = &binding.custom_headers {
+            if !headers.is_empty() {
+                let header_map: serde_json::Map<String, serde_json::Value> = headers
+                    .iter()
+                    .map(|(k, v)| (k.clone(), serde_json::Value::String(v.0.clone())))
+                    .collect();
+                provider_entry["headers"] = serde_json::Value::Object(header_map);
+            }
         }
 
         let mut providers = serde_json::Map::new();
@@ -478,6 +493,50 @@ mod tests {
         );
         assert_eq!(config["mcp"]["servers"]["vision"]["args"][0], "__mcp-serve");
         assert_eq!(config["mcp"]["servers"]["vision"]["env"]["FOO"], "bar");
+    }
+
+    #[test]
+    fn generate_config_includes_headers_when_present() {
+        let mut headers = std::collections::HashMap::new();
+        headers.insert("X-Custom".to_string(), Secret::from("value1"));
+        headers.insert("Authorization".to_string(), Secret::from("Bearer token"));
+        let b = AgentModelBinding {
+            custom_headers: Some(headers),
+            ..binding()
+        };
+        let config = generate_config(Some(&b), &[]);
+        assert_eq!(
+            config["models"]["providers"]["my-ollama"]["headers"]["Authorization"],
+            "Bearer token"
+        );
+        assert_eq!(
+            config["models"]["providers"]["my-ollama"]["headers"]["X-Custom"],
+            "value1"
+        );
+    }
+
+    #[test]
+    fn generate_config_omits_headers_when_none() {
+        let config = generate_config(Some(&binding()), &[]);
+        assert!(
+            config["models"]["providers"]["my-ollama"]
+                .get("headers")
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn generate_config_omits_headers_when_empty() {
+        let b = AgentModelBinding {
+            custom_headers: Some(std::collections::HashMap::new()),
+            ..binding()
+        };
+        let config = generate_config(Some(&b), &[]);
+        assert!(
+            config["models"]["providers"]["my-ollama"]
+                .get("headers")
+                .is_none()
+        );
     }
 
     // -- env overlay -----------------------------------------------------------

--- a/src/launchers/opencode.rs
+++ b/src/launchers/opencode.rs
@@ -817,10 +817,7 @@ mod tests {
             entry["options"]["headers"]["Helicone-Cache-Enabled"],
             "true"
         );
-        assert_eq!(
-            entry["options"]["headers"]["Helicone-User-Id"],
-            "opencode"
-        );
+        assert_eq!(entry["options"]["headers"]["Helicone-User-Id"], "opencode");
     }
 
     // -- provider_api_key_env ---------------------------------------------------

--- a/src/launchers/opencode.rs
+++ b/src/launchers/opencode.rs
@@ -347,6 +347,13 @@ impl OpenCodeLauncher {
         {
             options["apiKey"] = serde_json::Value::String(format!("{{env:{api_key_env}}}"));
         }
+        if let Some(headers) = &binding.custom_headers {
+            let header_map: serde_json::Map<String, serde_json::Value> = headers
+                .iter()
+                .map(|(k, v)| (k.clone(), serde_json::Value::String(v.0.clone())))
+                .collect();
+            options["headers"] = serde_json::Value::Object(header_map);
+        }
 
         // `limit` is all-or-nothing in OpenCode's schema: if present, both
         // `context` and `output` are required. granite-cli only tracks a
@@ -786,6 +793,34 @@ mod tests {
             .provider_entry(&b, &[b.model_name.as_str()], API_KEY_ENV)
             .unwrap();
         assert_eq!(entry["npm"], "@ai-sdk/openai");
+    }
+
+    #[test]
+    fn provider_entry_includes_custom_headers_when_present() {
+        let mut headers = std::collections::HashMap::new();
+        headers.insert(
+            "Helicone-Cache-Enabled".to_string(),
+            Secret("true".to_string()),
+        );
+        headers.insert(
+            "Helicone-User-Id".to_string(),
+            Secret("opencode".to_string()),
+        );
+        let b = AgentModelBinding {
+            custom_headers: Some(headers),
+            ..binding()
+        };
+        let entry = launcher(serde_json::json!({}))
+            .provider_entry(&b, &[b.model_name.as_str()], API_KEY_ENV)
+            .unwrap();
+        assert_eq!(
+            entry["options"]["headers"]["Helicone-Cache-Enabled"],
+            "true"
+        );
+        assert_eq!(
+            entry["options"]["headers"]["Helicone-User-Id"],
+            "opencode"
+        );
     }
 
     // -- provider_api_key_env ---------------------------------------------------

--- a/src/launchers/opencode.rs
+++ b/src/launchers/opencode.rs
@@ -598,6 +598,7 @@ mod tests {
             api_key: None,
             verify_ssl: true,
             context_length: Some(131072),
+            custom_headers: None,
         }
     }
 

--- a/src/launchers/pi.rs
+++ b/src/launchers/pi.rs
@@ -33,8 +33,9 @@ pub struct PiLauncherConfig {
     pub command_path: Option<String>,
 
     /// Extra keys merged (shallow, last-write-wins) into the generated Pi
-    /// provider entry -- e.g. `compat` flags or `headers` a particular server
-    /// needs. Necessary because the entry is regenerated on every launch.
+    /// provider entry -- e.g. `compat` flags or other provider-level
+    /// configuration a particular server needs. Necessary because the entry
+    /// is regenerated on every launch.
     #[serde(default)]
     pub provider_overrides: Option<serde_json::Value>,
 }
@@ -241,6 +242,12 @@ impl PiLauncher {
                 "contextWindow": binding.context_length,
             }],
         });
+
+        // Add custom headers from binding if present. They are merged at the
+        // provider level in Pi's models.json.
+        if let Some(ref headers) = binding.custom_headers {
+            entry["headers"] = serde_json::to_value(headers)?;
+        }
 
         // Shallow merge so a user override of e.g. `compat` doesn't clobber the
         // generated `baseUrl`/`models`, and vice versa.
@@ -535,7 +542,7 @@ mod tests {
     }
 
     #[test]
-    fn config_schema_exposes_only_command_path_and_overrides() {
+    fn config_schema_exposes_command_path_overrides() {
         use crate::launchers::base::LauncherFactory;
         let mut factory = LauncherFactory::new();
         factory.register::<PiLauncher>("pi");
@@ -582,6 +589,20 @@ mod tests {
         }));
         let entry = l.provider_entry(&binding()).unwrap();
         assert_eq!(entry["baseUrl"], "http://proxy:8080/v1");
+    }
+
+    #[test]
+    fn provider_entry_headers_can_be_overridden_by_provider_overrides() {
+        let l = launcher(serde_json::json!({
+            "headers": { "X-Config": "config-value" },
+            "provider_overrides": { "headers": { "X-Override": "override-value" } }
+        }));
+        let entry = l.provider_entry(&binding()).unwrap();
+        // provider_overrides replaces the entire headers object since it's a
+        // top-level key merge (shallow, last-write-wins).
+        assert_eq!(entry["headers"]["X-Override"], "override-value");
+        // config-level headers are not merged in.
+        assert!(entry["headers"].get("X-Config").is_none());
     }
 
     // -- base url / api mapping ------------------------------------------------

--- a/src/launchers/pi.rs
+++ b/src/launchers/pi.rs
@@ -467,6 +467,7 @@ mod tests {
             api_key: None,
             verify_ssl: true,
             context_length: Some(131072),
+            custom_headers: None,
         }
     }
 

--- a/src/models/base.rs
+++ b/src/models/base.rs
@@ -330,7 +330,7 @@ impl ConfiguredModel {
                 )
             })?;
         let model_name = provider
-            .model_alias(self.resolve_variant())
+            .model_alias(model_id.to_string(), self.resolve_variant())
             .unwrap_or_else(|| model_id.to_string());
         Ok((provider, endpoint, model_name))
     }

--- a/src/models/base.rs
+++ b/src/models/base.rs
@@ -700,7 +700,7 @@ mod configured_model_tests {
         fn supported_formats(&self) -> Vec<ModelFormat> {
             vec![]
         }
-        fn model_alias(&self, _variant: Option<&ModelVariant>) -> Option<String> {
+        fn model_alias(&self, _model_id: String, _variant: Option<&ModelVariant>) -> Option<String> {
             self.alias.clone()
         }
         async fn health_check(&self) -> Result<HealthStatus, ProviderError> {

--- a/src/models/base.rs
+++ b/src/models/base.rs
@@ -694,6 +694,9 @@ mod configured_model_tests {
         fn verify_ssl(&self) -> bool {
             self.verify_ssl
         }
+        fn custom_headers(&self) -> Option<HashMap<String, Secret>> {
+            None
+        }
         fn supported_formats(&self) -> Vec<ModelFormat> {
             vec![]
         }

--- a/src/models/base.rs
+++ b/src/models/base.rs
@@ -700,7 +700,11 @@ mod configured_model_tests {
         fn supported_formats(&self) -> Vec<ModelFormat> {
             vec![]
         }
-        fn model_alias(&self, _model_id: String, _variant: Option<&ModelVariant>) -> Option<String> {
+        fn model_alias(
+            &self,
+            _model_id: String,
+            _variant: Option<&ModelVariant>,
+        ) -> Option<String> {
             self.alias.clone()
         }
         async fn health_check(&self) -> Result<HealthStatus, ProviderError> {

--- a/src/models/mod.rs
+++ b/src/models/mod.rs
@@ -99,7 +99,7 @@ impl ModelSource {
             Ok(provider) => {
                 let variant = base::find_variant(model.variants(), configured_variant);
                 let route_key = provider
-                    .model_alias(variant)
+                    .model_alias(model_id.to_string(), variant)
                     .unwrap_or_else(|| model_id.to_string());
                 let target = crate::proxy::UpstreamTarget {
                     base_url: provider.base_url().to_string(),

--- a/src/providers/base.rs
+++ b/src/providers/base.rs
@@ -137,6 +137,13 @@ pub trait Provider: crate::registry::Named + Send + Sync {
     /// Returns the configured API key for this provider instance, if any.
     fn api_key(&self) -> Option<&Secret>;
 
+    /// Returns the configured custom HTTP headers for this provider instance, if any.
+    /// Custom headers are used as-is in outgoing requests. Keys are the header names
+    /// (strings) and values are secret tokens.
+    fn custom_headers(&self) -> Option<HashMap<String, Secret>> {
+        None
+    }
+
     /// Returns whether this provider instance verifies SSL certificates.
     fn verify_ssl(&self) -> bool;
 

--- a/src/providers/base.rs
+++ b/src/providers/base.rs
@@ -158,7 +158,7 @@ pub trait Provider: crate::registry::Named + Send + Sync {
     /// naming convention (e.g. Ollama's `granite4.1:8b` vs the catalog ID
     /// `granite-4.1-8b`) override this to derive the alias from the variant URL.
     /// The default returns `None`, meaning the catalog ID should be used as-is.
-    fn model_alias(&self, _variant: Option<&ModelVariant>) -> Option<String> {
+    fn model_alias(&self, _model_id: String, _variant: Option<&ModelVariant>) -> Option<String> {
         None
     }
 

--- a/src/providers/llamacpp.rs
+++ b/src/providers/llamacpp.rs
@@ -595,7 +595,7 @@ mod tests {
             url: "https://huggingface.co/ibm-granite/granite-4.1-8b-GGUF/blob/main/granite-4.1-8b-Q4_K_M.gguf".to_string(),
         };
         assert_eq!(
-            provider.model_alias(Some(&variant)),
+            provider.model_alias("unused".to_string(), Some(&variant)),
             Some("ibm-granite/granite-4.1-8b-GGUF:Q4_K_M".to_string())
         );
     }
@@ -613,7 +613,7 @@ mod tests {
             size_gb: Some(5.3),
             url: "https://ollama.com/library/granite4.1:8b".to_string(),
         };
-        assert_eq!(provider.model_alias(Some(&variant)), None);
+        assert_eq!(provider.model_alias("unused".to_string(), Some(&variant)), None);
     }
 
     #[test]
@@ -623,7 +623,7 @@ mod tests {
             &serde_json::json!({}),
             &crate::config::Config::default(),
         );
-        assert_eq!(provider.model_alias(None), None);
+        assert_eq!(provider.model_alias("unused".to_string(), None), None);
     }
 
     #[test]

--- a/src/providers/llamacpp.rs
+++ b/src/providers/llamacpp.rs
@@ -357,7 +357,7 @@ impl Provider for LlamaCppProvider {
         variant_format.eq_ignore_ascii_case("gguf")
     }
 
-    fn model_alias(&self, variant: Option<&crate::models::ModelVariant>) -> Option<String> {
+    fn model_alias(&self, _model_id: String, variant: Option<&crate::models::ModelVariant>) -> Option<String> {
         let v = variant?;
         let repo = hf_repo_id(&v.url)?;
         Some(format!("{}:{}", repo, v.precision))

--- a/src/providers/llamacpp.rs
+++ b/src/providers/llamacpp.rs
@@ -357,7 +357,11 @@ impl Provider for LlamaCppProvider {
         variant_format.eq_ignore_ascii_case("gguf")
     }
 
-    fn model_alias(&self, _model_id: String, variant: Option<&crate::models::ModelVariant>) -> Option<String> {
+    fn model_alias(
+        &self,
+        _model_id: String,
+        variant: Option<&crate::models::ModelVariant>,
+    ) -> Option<String> {
         let v = variant?;
         let repo = hf_repo_id(&v.url)?;
         Some(format!("{}:{}", repo, v.precision))
@@ -613,7 +617,10 @@ mod tests {
             size_gb: Some(5.3),
             url: "https://ollama.com/library/granite4.1:8b".to_string(),
         };
-        assert_eq!(provider.model_alias("unused".to_string(), Some(&variant)), None);
+        assert_eq!(
+            provider.model_alias("unused".to_string(), Some(&variant)),
+            None
+        );
     }
 
     #[test]

--- a/src/providers/ollama.rs
+++ b/src/providers/ollama.rs
@@ -622,7 +622,7 @@ mod tests {
             url: "https://ollama.com/library/granite4.1:8b".to_string(),
         };
         assert_eq!(
-            provider.model_alias(Some(&variant)),
+            provider.model_alias("unused".to_string(), Some(&variant)),
             Some("granite4.1:8b".to_string())
         );
     }
@@ -641,7 +641,7 @@ mod tests {
             url: "https://ollama.com/ibm/granite4.1:8b".to_string(),
         };
         assert_eq!(
-            provider.model_alias(Some(&variant)),
+            provider.model_alias("unused".to_string(), Some(&variant)),
             Some("ibm/granite4.1:8b".to_string())
         );
     }
@@ -659,7 +659,7 @@ mod tests {
             size_gb: Some(5.3),
             url: "https://huggingface.co/ibm-granite/granite-4.1-8b-GGUF/blob/main/granite-4.1-8b-Q4_K_M.gguf".to_string(),
         };
-        assert_eq!(provider.model_alias(Some(&variant)), None);
+        assert_eq!(provider.model_alias("unused".to_string(), Some(&variant)), None);
     }
 
     #[test]
@@ -669,7 +669,7 @@ mod tests {
             &serde_json::json!({}),
             &crate::config::Config::default(),
         );
-        assert_eq!(provider.model_alias(None), None);
+        assert_eq!(provider.model_alias("unused".to_string(), None), None);
     }
 
     #[test]

--- a/src/providers/ollama.rs
+++ b/src/providers/ollama.rs
@@ -250,7 +250,11 @@ impl Provider for OllamaProvider {
         variant_format.eq_ignore_ascii_case("gguf") || variant_format.eq_ignore_ascii_case("ollama")
     }
 
-    fn model_alias(&self, _model_id: String, variant: Option<&crate::models::ModelVariant>) -> Option<String> {
+    fn model_alias(
+        &self,
+        _model_id: String,
+        variant: Option<&crate::models::ModelVariant>,
+    ) -> Option<String> {
         variant.and_then(|v| ollama_model_ref(&v.url))
     }
 
@@ -659,7 +663,10 @@ mod tests {
             size_gb: Some(5.3),
             url: "https://huggingface.co/ibm-granite/granite-4.1-8b-GGUF/blob/main/granite-4.1-8b-Q4_K_M.gguf".to_string(),
         };
-        assert_eq!(provider.model_alias("unused".to_string(), Some(&variant)), None);
+        assert_eq!(
+            provider.model_alias("unused".to_string(), Some(&variant)),
+            None
+        );
     }
 
     #[test]

--- a/src/providers/ollama.rs
+++ b/src/providers/ollama.rs
@@ -250,7 +250,7 @@ impl Provider for OllamaProvider {
         variant_format.eq_ignore_ascii_case("gguf") || variant_format.eq_ignore_ascii_case("ollama")
     }
 
-    fn model_alias(&self, variant: Option<&crate::models::ModelVariant>) -> Option<String> {
+    fn model_alias(&self, _model_id: String, variant: Option<&crate::models::ModelVariant>) -> Option<String> {
         variant.and_then(|v| ollama_model_ref(&v.url))
     }
 

--- a/src/providers/openai.rs
+++ b/src/providers/openai.rs
@@ -34,6 +34,10 @@ pub struct OpenAIProviderConfig {
     /// Specific function-to-endpoint mappings this instance supports.
     /// If None, will use default OpenAI mappings.
     pub function_endpoints: Option<HashMap<ModelFunction, Vec<ApiEndpoint>>>,
+
+    /// Custom HTTP headers to be sent with each API request.
+    /// Keys are header names (strings) and values are secret tokens.
+    pub custom_headers: Option<HashMap<String, Secret>>,
 }
 
 fn default_timeout() -> u64 {
@@ -57,6 +61,7 @@ impl Default for OpenAIProviderConfig {
             verify_ssl: true,
             health_check_endpoint: "/v1/models".to_string(),
             function_endpoints: None,
+            custom_headers: None,
         }
     }
 }
@@ -68,6 +73,7 @@ pub struct OpenAIProvider {
     config: OpenAIProviderConfig,
     client: reqwest::Client,
     function_endpoints: HashMap<ModelFunction, Vec<ApiEndpoint>>,
+    custom_headers: HashMap<String, Secret>,
 }
 
 impl OpenAIProvider {
@@ -114,11 +120,17 @@ impl ConfigConstructable for OpenAIProvider {
             .clone()
             .unwrap_or_else(Self::default_function_endpoints);
 
+        let custom_headers = config
+            .custom_headers
+            .clone()
+            .unwrap_or_else(HashMap::new);
+
         Self {
             instance_id: instance_id.to_string(),
             config,
             client,
             function_endpoints,
+            custom_headers,
         }
     }
 }
@@ -175,6 +187,12 @@ impl Provider for OpenAIProvider {
 
         if let Some(ref api_key) = self.config.api_key {
             request = request.bearer_auth(&api_key.0);
+        }
+
+        if let Some(custom_headers) = &self.config.custom_headers {
+            for (key, value) in custom_headers {
+                request = request.header(key.clone(), &value.0);
+            }
         }
 
         match request.send().await {
@@ -355,6 +373,40 @@ mod tests {
             Some(Secret("test-key".to_string()))
         );
         assert_eq!(provider.config.timeout_secs, 30);
+    }
+
+    #[test]
+    fn test_custom_headers_are_applied_to_requests() {
+        let mut custom_headers = HashMap::new();
+        custom_headers.insert(
+            "X-Custom-Header".to_string(),
+            Secret("custom-value".to_string()),
+        );
+        custom_headers.insert(
+            "X-Another-Header".to_string(),
+            Secret("another-value".to_string()),
+        );
+
+        let cfg = serde_json::json!({
+            "base_url": "http://example.com:8080",
+            "custom_headers": {
+                "X-Custom-Header": "custom-value",
+                "X-Another-Header": "another-value"
+            }
+        });
+
+        let provider = OpenAIProvider::new("my-openai", &cfg, &crate::config::Config::default());
+        assert!(provider.config.custom_headers.is_some());
+        let headers = provider.config.custom_headers.as_ref().unwrap();
+        assert_eq!(headers.len(), 2);
+        assert_eq!(
+            headers.get("X-Custom-Header").map(|s| s.0.as_str()),
+            Some("custom-value")
+        );
+        assert_eq!(
+            headers.get("X-Another-Header").map(|s| s.0.as_str()),
+            Some("another-value")
+        );
     }
 
     #[test]

--- a/src/providers/openai.rs
+++ b/src/providers/openai.rs
@@ -185,7 +185,11 @@ impl Provider for OpenAIProvider {
         true
     }
 
-    fn model_alias(&self, model_id: String, _variant: Option<&crate::models::ModelVariant>) -> Option<String> {
+    fn model_alias(
+        &self,
+        model_id: String,
+        _variant: Option<&crate::models::ModelVariant>,
+    ) -> Option<String> {
         self.model_aliases.get(&model_id).cloned()
     }
 

--- a/src/providers/openai.rs
+++ b/src/providers/openai.rs
@@ -120,10 +120,7 @@ impl ConfigConstructable for OpenAIProvider {
             .clone()
             .unwrap_or_else(Self::default_function_endpoints);
 
-        let custom_headers = config
-            .custom_headers
-            .clone()
-            .unwrap_or_else(HashMap::new);
+        let custom_headers = config.custom_headers.clone().unwrap_or_default();
 
         Self {
             instance_id: instance_id.to_string(),
@@ -165,6 +162,10 @@ impl Provider for OpenAIProvider {
 
     fn verify_ssl(&self) -> bool {
         self.config.verify_ssl
+    }
+
+    fn custom_headers(&self) -> Option<HashMap<String, Secret>> {
+        Some(self.custom_headers.clone())
     }
 
     fn supported_formats(&self) -> Vec<ModelFormat> {

--- a/src/providers/openai.rs
+++ b/src/providers/openai.rs
@@ -268,24 +268,13 @@ impl Provider for OpenAIProvider {
 
 impl HasProviderMetadata for OpenAIProvider {
     fn metadata() -> ProviderMetadata {
-        let mut default_mappings = HashMap::new();
-        default_mappings.insert(ModelFunction::Chat, vec![ApiEndpoint::OpenAIChat]);
-        default_mappings.insert(
-            ModelFunction::Embeddings,
-            vec![ApiEndpoint::OpenAIEmbeddings],
-        );
-        default_mappings.insert(
-            ModelFunction::Transcription,
-            vec![ApiEndpoint::OpenAIAudioTranscription],
-        );
-
         ProviderMetadata {
             name: "OpenAI Compatible Provider".to_string(),
             description: "Provider for OpenAI-compatible API endpoints supporting chat, embeddings, and audio transcription".to_string(),
             provider_type: ProviderType::Local,
             default_endpoint: "http://localhost:8080".to_string(),
             supported_api_types: vec![ApiType::OpenAI],
-            default_function_endpoints: default_mappings,
+            default_function_endpoints: Self::default_function_endpoints(),
             supported_formats: vec![
                 ModelFormat::Safetensors,
                 ModelFormat::GGUF,

--- a/src/providers/openai.rs
+++ b/src/providers/openai.rs
@@ -38,6 +38,9 @@ pub struct OpenAIProviderConfig {
     /// Custom HTTP headers to be sent with each API request.
     /// Keys are header names (strings) and values are secret tokens.
     pub custom_headers: Option<HashMap<String, Secret>>,
+
+    /// Per-model alias mapping.
+    pub model_aliases: Option<HashMap<String, String>>,
 }
 
 fn default_timeout() -> u64 {
@@ -62,6 +65,7 @@ impl Default for OpenAIProviderConfig {
             health_check_endpoint: "/v1/models".to_string(),
             function_endpoints: None,
             custom_headers: None,
+            model_aliases: None,
         }
     }
 }
@@ -74,6 +78,7 @@ pub struct OpenAIProvider {
     client: reqwest::Client,
     function_endpoints: HashMap<ModelFunction, Vec<ApiEndpoint>>,
     custom_headers: HashMap<String, Secret>,
+    model_aliases: HashMap<String, String>,
 }
 
 impl OpenAIProvider {
@@ -122,12 +127,15 @@ impl ConfigConstructable for OpenAIProvider {
 
         let custom_headers = config.custom_headers.clone().unwrap_or_default();
 
+        let model_aliases = config.model_aliases.clone().unwrap_or_default();
+
         Self {
             instance_id: instance_id.to_string(),
             config,
             client,
             function_endpoints,
             custom_headers,
+            model_aliases,
         }
     }
 }
@@ -174,6 +182,10 @@ impl Provider for OpenAIProvider {
 
     fn can_run_model(&self, _variant_format: &str, _variant_precision: &str) -> bool {
         true
+    }
+
+    fn model_alias(&self, model_id: String, _variant: Option<&crate::models::ModelVariant>) -> Option<String> {
+        self.model_aliases.get(&model_id).cloned()
     }
 
     async fn health_check(&self) -> Result<HealthStatus, ProviderError> {

--- a/src/providers/openai.rs
+++ b/src/providers/openai.rs
@@ -123,6 +123,7 @@ impl ConfigConstructable for OpenAIProvider {
         let function_endpoints = config
             .function_endpoints
             .clone()
+            .filter(|v| !v.is_empty())
             .unwrap_or_else(Self::default_function_endpoints);
 
         let custom_headers = config.custom_headers.clone().unwrap_or_default();

--- a/src/providers/openai.rs
+++ b/src/providers/openai.rs
@@ -276,7 +276,7 @@ impl HasProviderMetadata for OpenAIProvider {
         ProviderMetadata {
             name: "OpenAI Compatible Provider".to_string(),
             description: "Provider for OpenAI-compatible API endpoints supporting chat, embeddings, and audio transcription".to_string(),
-            provider_type: ProviderType::Local,
+            provider_type: ProviderType::Hosted,
             default_endpoint: "http://localhost:8080".to_string(),
             supported_api_types: vec![ApiType::OpenAI],
             default_function_endpoints: Self::default_function_endpoints(),

--- a/src/proxy/model_wrapper.rs
+++ b/src/proxy/model_wrapper.rs
@@ -137,8 +137,8 @@ impl Provider for ProxiedProvider {
     fn can_run_model(&self, variant_format: &str, variant_precision: &str) -> bool {
         self.inner.can_run_model(variant_format, variant_precision)
     }
-    fn model_alias(&self, variant: Option<&ModelVariant>) -> Option<String> {
-        self.inner.model_alias(variant)
+    fn model_alias(&self, model_id: String, variant: Option<&ModelVariant>) -> Option<String> {
+        self.inner.model_alias(model_id, variant)
     }
     async fn health_check(&self) -> Result<HealthStatus, ProviderError> {
         self.inner.health_check().await

--- a/src/proxy/model_wrapper.rs
+++ b/src/proxy/model_wrapper.rs
@@ -195,9 +195,7 @@ mod tests {
         fn verify_ssl(&self) -> bool {
             true
         }
-        fn custom_headers(
-            &self,
-        ) -> Option<std::collections::HashMap<String, Secret>> {
+        fn custom_headers(&self) -> Option<std::collections::HashMap<String, Secret>> {
             None
         }
         fn supported_formats(&self) -> Vec<ModelFormat> {

--- a/src/proxy/model_wrapper.rs
+++ b/src/proxy/model_wrapper.rs
@@ -143,6 +143,10 @@ impl Provider for ProxiedProvider {
     async fn health_check(&self) -> Result<HealthStatus, ProviderError> {
         self.inner.health_check().await
     }
+
+    fn custom_headers(&self) -> Option<std::collections::HashMap<String, Secret>> {
+        self.inner.custom_headers()
+    }
     async fn pull_model(
         &self,
         model: &ModelMetadata,
@@ -190,6 +194,11 @@ mod tests {
         }
         fn verify_ssl(&self) -> bool {
             true
+        }
+        fn custom_headers(
+            &self,
+        ) -> Option<std::collections::HashMap<String, Secret>> {
+            None
         }
         fn supported_formats(&self) -> Vec<ModelFormat> {
             vec![]

--- a/src/utils/ui/prompt.rs
+++ b/src/utils/ui/prompt.rs
@@ -1,6 +1,6 @@
 // Third Party
 use alog::{MessageLevel, alog_channel, use_channel};
-use serde_json::Value;
+use serde_json::{Value, json};
 
 // Local
 use crate::utils::ui::Ui;
@@ -61,7 +61,9 @@ fn prompt_object(
     }
 
     let mut result = serde_json::Map::new();
-    if let Some(properties) = node.get("properties").and_then(Value::as_object) {
+    let properties = node.get("properties").and_then(Value::as_object);
+
+    if let Some(properties) = properties {
         let child_indent = format!("{indent}  ");
         for (name, prop_schema) in properties {
             let prop_schema = resolve_ref(root, prop_schema);
@@ -78,6 +80,60 @@ fn prompt_object(
             result.insert(name.clone(), value);
         }
     }
+
+    // Handle additionalProperties (e.g., HashMap<String, T> fields)
+    if let Some(additional_props_schema_val) = node.get("additionalProperties") {
+        let additional_props_schema = resolve_ref(root, additional_props_schema_val);
+        // Only handle additionalProperties if the value schema is promptable
+        if get_promptable_type(additional_props_schema).is_some()
+            || enum_choices(root, additional_props_schema).is_some()
+        {
+            let child_indent = format!("{indent}  ");
+
+            // Get remaining defaults: keys in default that aren't explicit properties
+            let default_obj = default.as_object().cloned().unwrap_or_default();
+            let remaining_defaults: Vec<(String, Value)> = default_obj
+                .iter()
+                .filter(|(k, _)| !result.contains_key(k.as_str()))
+                .map(|(k, v)| (k.to_string(), v.clone()))
+                .collect();
+
+            let mut defaults_iter = remaining_defaults.into_iter();
+
+            loop {
+                let next_default = defaults_iter.next();
+                let add = ui.confirm(&format!("{indent}Add {label}?"), next_default.is_some())?;
+                if !add {
+                    break;
+                }
+                let (key_default_str, item_default) = next_default
+                    .unwrap_or((String::new(), zero_value_for(additional_props_schema)));
+
+                // Prompt for the key (always a string for JSON object keys)
+                let key_schema = json!({"type": "string"});
+                let key_value = prompt_string(
+                    ui,
+                    &key_schema,
+                    &json!(key_default_str),
+                    &child_indent,
+                    "key",
+                )?;
+                let key_str = key_value.as_str().unwrap().to_string();
+
+                // Prompt for the value using the additionalProperties schema
+                let value = prompt_value(
+                    ui,
+                    root,
+                    additional_props_schema,
+                    &item_default,
+                    &child_indent,
+                    &key_str,
+                )?;
+                result.insert(key_str, value);
+            }
+        }
+    }
+
     Ok(Value::Object(result))
 }
 
@@ -484,6 +540,7 @@ fn zero_value_for(schema: &Value) -> Value {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use serde::{Deserialize, Serialize};
     use serde_json::json;
 
     #[test]
@@ -1046,5 +1103,86 @@ mod tests {
         assert_eq!(result, json!({"tools": ["FileRead", "Shell"]}));
         assert_eq!(ui.multi_select_prompts.borrow().len(), 1);
         assert!(ui.confirm_prompts.borrow().is_empty());
+    }
+
+    #[test]
+    fn prompt_from_schema_handles_hashmap_string_string() {
+        use crate::utils::ui::base::tests::CaptureUi;
+        use std::collections::HashMap;
+
+        #[derive(Debug, Clone, Serialize, Deserialize, schemars::JsonSchema)]
+        struct TestConfig {
+            headers: HashMap<String, String>,
+        }
+
+        let ui = CaptureUi::default();
+        ui.confirm_answers.borrow_mut().push_back(true); // Add headers?
+        ui.text_answers
+            .borrow_mut()
+            .push_back("X-API-Key".to_string()); // key
+        ui.text_answers.borrow_mut().push_back("my-key".to_string()); // value
+        ui.confirm_answers.borrow_mut().push_back(false); // Add headers? no more
+
+        let defaults = json!({"headers": {"X-API-Key": "default-key"}});
+        let schema = schemars::schema_for!(TestConfig);
+        let result = prompt_from_schema(&ui, &schema, &defaults).unwrap();
+
+        assert_eq!(result["headers"], json!({"X-API-Key": "my-key"}));
+    }
+
+    #[test]
+    fn prompt_from_schema_handles_hashmap_string_secret() {
+        use crate::registry::Secret;
+        use crate::utils::ui::base::tests::CaptureUi;
+        use std::collections::HashMap;
+
+        #[derive(Debug, Clone, Serialize, Deserialize, schemars::JsonSchema)]
+        struct TestConfig {
+            custom_headers: HashMap<String, Secret>,
+        }
+
+        let ui = CaptureUi::default();
+        ui.confirm_answers.borrow_mut().push_back(true); // Add custom_headers?
+        ui.text_answers
+            .borrow_mut()
+            .push_back("Authorization".to_string()); // key
+        ui.password_answers
+            .borrow_mut()
+            .push_back("Bearer my-token".to_string()); // value
+        ui.confirm_answers.borrow_mut().push_back(false); // Add custom_headers? no more
+
+        let defaults = json!({"custom_headers": {"Authorization": "Bearer default-token"}});
+        let schema = schemars::schema_for!(TestConfig);
+        let result = prompt_from_schema(&ui, &schema, &defaults).unwrap();
+
+        assert_eq!(
+            result["custom_headers"],
+            json!({"Authorization": "Bearer my-token"})
+        );
+    }
+
+    #[test]
+    fn prompt_from_schema_handles_hashmap_without_defaults() {
+        use crate::utils::ui::base::tests::CaptureUi;
+        use std::collections::HashMap;
+
+        #[derive(Debug, Clone, Serialize, Deserialize, schemars::JsonSchema)]
+        struct TestConfig {
+            headers: HashMap<String, String>,
+        }
+
+        let ui = CaptureUi::default();
+        ui.confirm_answers.borrow_mut().push_back(true); // Add headers?
+        ui.text_answers
+            .borrow_mut()
+            .push_back("X-API-Key".to_string()); // key
+        ui.text_answers.borrow_mut().push_back("my-key".to_string()); // value
+        ui.confirm_answers.borrow_mut().push_back(false); // Add headers? no more
+
+        let defaults = json!({"headers": {}}); // empty defaults
+        let schema = schemars::schema_for!(TestConfig);
+        let result = prompt_from_schema(&ui, &schema, &defaults).unwrap();
+
+        assert_eq!(result["headers"], json!({"X-API-Key": "my-key"}));
     }
 }


### PR DESCRIPTION
## Description

This PR extends the usefulness of the generic OpainAI Compatible provider. This is akin to the "custom" model where the user needs to provide the majority of the information to configure the connection. Some hosting platforms have non-standard auth mechanisms that need custom headers, so this PR adds that support. It also fixes several other issues with the generic provider along the way.

## Changes

### Custom Headers Plumbing

- Add `custom_headers` to `AgentModelBinding` (used both standalone and for `SubAgentBinding`)
- Add `custom_headers()` to `trait Provider` so that all providers can optionally surface custom headers
  - This needs to be in the `trait` so that Capabilities can use a model's provider by API contract to create bindings which is where these need to finally surface to launchers.
- Add `custom_headers` in `OpenAIProviderConfig` so it can be populated at setup time
- Populate `custom_headers` in Capabilities' `bind` methods by using the bound model's provider
- Use `custom_headers` in launchers
  - [x] OpenCode
  - [x] Pi (https://pi.dev/docs/latest/models#provider-configuration)
  - [ ] Claude (`ANTHROPIC_CUSTOM_HEADERS` env var)
    - NOTE: This is complete, but untested since this PR only targets the OpenAI-compatible provider. We would need to extend it to support Anthropic (ie change to a simple "custom" rather than openai specific), or add a parallel Anthropic-compatible provider
  - [x] Hermes (https://hermes-agent.nousresearch.com/docs/user-guide/configuring-models#per-provider-request-options)
  - [x] OpenClaw
  - [x] Goose (https://github.com/aaif-goose/goose/blob/e0e8625413509e67f98efe74938709150739df79/documentation/docs/getting-started/providers.md?plain=1#L308)

## Testing

This PR was tested using IBM's internal inference service which requires non-standard auth through a custom header. It was tested against all implemented launchers _except_ `claude` (see NOTE above) using the `./scripts/launcher-testing` framework.

### Config setup

```sh
cargo run provider setup openai-compatible
```

<details>
<summary>config</summary>

```sh
Setting up provider instance: openai-compatible
Provider for OpenAI-compatible API endpoints supporting chat, embeddings, and audio transcription

Type: Hosted
Instance name: : INTERNAL
Authentication: Bearer Token, None
  api_key (leave blank to keep current): [hidden]
  base_url: https://internal.endpoint
  custom_headers:
  Add custom_headers? yes
    key: CUSTOM_API_KEY
    CUSTOM_API_KEY (leave blank to keep current): [hidden]
  Add custom_headers? no
  function_endpoints:
  Add function_endpoints? no
  health_check_endpoint: /v1/models
  model_aliases:
  Add model_aliases? yes
    key: granite-4.2-30b
    granite-4.2-30b: ibm-research/granite-4.2-30b
  Add model_aliases? no
  timeout_secs: 10
  verify_ssl yes

Running health check...
Warning: Provider 'INTERNAL' health check failed. It may need to be started or configured differently.

Provider instance 'INTERNAL' configured successfully!
Supported APIs:
  - Embeddings -> OpenAI (/v1/embeddings)
  - Transcription -> OpenAI (/v1/audio/transcriptions)
  - Thinking -> OpenAI (/v1/chat/completions)
  - Image Understanding -> OpenAI (/v1/chat/completions)
  - Chat -> OpenAI (/v1/chat/completions)
  - ToolCalling -> OpenAI (/v1/chat/completions)
  - Guardian -> OpenAI (/v1/chat/completions)
I have no name!@lima-rancher-desktop:/src$ vim tmp/mounted-home/.
./       ../      .cargo/  .config/ .rustup/ 
I have no name!@lima-rancher-desktop:/src$ vim tmp/mounted-home/.config/granite-cli/
capabilities/ launchers/    models/       providers/    
I have no name!@lima-rancher-desktop:/src$ vim tmp/mounted-home/.config/granite-cli/providers/INTERNAL.yaml 
```
</details>

```sh
cargo run -q capability setup agent-model
```

<details>
<summary>config</summary>

```sh
Setting up capability: agent-model
Surfaces a configured model's connection details (base URL, model name, auth, TLS) to a launched agent.
Instance name: : agent-model
Select a model type to configure:: granite-4.2-30b

Setting up model: granite-4.2-30b
| | |
|---|---|
| **Developers** | Granite Team, IBM |
| **Model Type** | Decoder-only Dense Transformer (Reasoning) |
| **Architecture** | GraniteForCausalLM |
| **Base Model** | [Granite-4.1-30B-Base](https://huggingface.co/ibm-granite/granite-4.1-30b-base) |
| **Parameters** | 30B |
| **Context Length** | Natively Supports 128K (Long-context extension to 512K) |
| **Precision** | bfloat16 |
| **Tested Languages** | English, German, Spanish, French, Japanese, Portuguese, Arabic, Czech, Italian, Korean, Dutch, Chinese (other languages may work but have not been fully tested) |
| **Reasoning Mode** | Built-in `<think>...</think>` chain-of-thought |
| **Best For** | Reasoning, Code Generation, Tool Calling, Agentic Workflows, Multilingual Dialog |
| **License** | [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0) |
| **HF Collection** | [Granite 4.2 Language Models](https://huggingface.co/collections/ibm-granite/granite-42-language-models) |
| **Release Date** | August 25, 2026 |


Size: 29B params, 131072 context
Type: Text

Instance name: : granite-4.2-30b
Select model variant:: safetensors / bfloat16 (58.6 GB)

Selected: safetensors / bfloat16
Select a provider for this model: INTERNAL

Model 'granite-4.2-30b' configured successfully!

Capability 'agent-model' configured successfully!
```

</details>

### Launchers

```sh
# Select agent-model for each
cargo run -q launcher setup opencode
cargo run -q launcher setup pi
cargo run -q launcher setup hermes
cargo run -q launcher setup openclaw
cargo run -q launcher setup goose
```

```sh
cargo run -q launch opencode -- run "what does this project do?"
cargo run -q launch pi -- "What does this project do?" --approve
cargo run -q launch hermes -- chat -q "What does this project do?"
cargo run -q launch openclaw -- chat --message "What does this project do?" # Note: this seems to dump into OpenClaw personality setup, but it generates!
cargo run -q launch goose -- run -t "What does this project do?"
```

## AI Usage

```sh
╔══════════════════════════════════════════════════════════╗
║           GIT AI USAGE ANALYSIS                          ║
╚══════════════════════════════════════════════════════════╝

📊 COMMITS BY AGENT

--- Aggregate ---
Commits                        |      Count
---------------------------------------------
none                           |         10
OpenCode + granite-4.2-30b     |          6
OpenCode + GraniteXXX + Qwen3.6-35b |          4
OpenCode + GraniteXXX          |          1
OpenCode + Qwen3.6-35b         |          1
---------------------------------------------
TOTAL                          |         22

📊 COMMITS BY USAGE TYPE

--- Aggregate ---
Commits                        |      Count
---------------------------------------------
none                           |         10
draft                          |          8
full                           |          4
---------------------------------------------
TOTAL                          |         22

📈 LINES OF CODE BY AGENT

--- Aggregate ---
Agent                     |    Commits |  Additions |  Deletions
------------------------------------------------------------
none                      |         10 |        151 |         74
OpenCode + granite-4.2-30b |          6 |        399 |         12
OpenCode + GraniteXXX + Qwen3.6-35b |          4 |         54 |          4
OpenCode + GraniteXXX     |          1 |         52 |          0
OpenCode + Qwen3.6-35b    |          1 |         35 |          0
------------------------------------------------------------
TOTAL                     |         22 |        691 |         90

📈 LINES OF CODE BY USAGE TYPE

--- Aggregate ---
Usage Type           |    Commits |  Additions |  Deletions
-------------------------------------------------------
none                 |         10 |        151 |         74
draft                |          8 |        291 |         14
full                 |          4 |        249 |          2
-------------------------------------------------------
TOTAL                |         22 |        691 |         90
```