### PR TITLE
feat: config integrity validation (part 2)

### DIFF
--- a/docs/specs/0024-config-integrity-validation.md
+++ b/docs/specs/0024-config-integrity-validation.md
@@ -241,6 +241,22 @@ it (Sub-Task 5).
   is two confirmations for one decision, and accepting the default leaves the
   reference broken. Fixing it means changing how the four setup commands
   treat an explicit instance id, which affects every caller of them.
+- A flag for non-interactive removal (issue to file). A session with nobody
+  to ask always removes only what was asked and warns about what that broke.
+  A script has no way to say that it wants the dependents removed too, or
+  that it wants the removal refused when anything depends on the target. A
+  flag on the four removal commands would give it both, and would give the
+  refusal a non-zero exit to act on.
+- Removing a capability without breaking or deleting its launcher (issue to
+  file). A launcher depends on a capability by listing it in
+  `enabled_capabilities`, so the removal prompt's three answers are: delete
+  the launcher too, do nothing, or leave the launcher pointing at something
+  that is gone. None of them deletes exactly what was asked and leaves the
+  launcher working. A fourth choice would drop the id from that list as part
+  of the removal. Reaching that end state today takes two commands: remove
+  only the capability, then accept the disable the next `launch` offers.
+  The behaviour exists in `remediation::disable` and needs extracting to
+  take an explicit launcher and capability id.
 - Sibling problems a declined prompt hides (issue to file). Remediation
   reports one problem at a time and stops when the user declines, so a
   launcher with two broken capabilities only ever names the first. Reporting
@@ -537,31 +553,49 @@ Stop `Remove` from stranding whatever pointed at what it just deleted.
 
 **Expected Outcomes**
 
-Before any of the four removal methods on `Config` deletes an entry, we scan
-the other configuration maps for anything that depends on the id being
-removed. If something does, the command layer, not `Config` itself per Spec
-0001, offers a choice: remove both together, cancel, or remove only what was
-asked for. Non-interactive backends default to removing only what was asked,
-with a warning.
+Before any of the four removal commands deletes an entry, we scan the other
+configuration maps for anything that depends on the id being removed. If
+something does, the command layer, not `Config` itself per Spec 0001, offers
+a choice: remove both together, cancel, or remove only what was asked for.
+Non-interactive backends default to removing only what was asked, with a
+warning.
+
+Finding the dependents is `Validatable::refs` read backwards: an instance
+depends on the target when the target appears among the references it
+declares. It lives beside the walk in the validation module and needs no
+knowledge of its own about which field holds what.
+
+Cancelling is the default answer, since this is the destructive prompt and
+the other two both delete something. It reports what was kept and succeeds
+rather than failing: the user made a deliberate choice, and a script never
+reaches it, since a session with nobody to ask does not prompt.
 
 ```
-⚠ Removing 'granite-3.1-8b-instruct' will break:
+⚠ Removing model 'granite-3.1-8b-instruct' will break:
   - capability 'chat' (agent-model)
 
-  [1] Remove 'granite-3.1-8b-instruct' and 'chat' together
-  [2] Cancel — keep 'granite-3.1-8b-instruct'
-  [3] Remove only 'granite-3.1-8b-instruct' — fix 'chat' later
->
+? What would you like to do?
+  [1] Remove model 'granite-3.1-8b-instruct' and capability 'chat' together
+> [2] Cancel, keep model 'granite-3.1-8b-instruct'
+  [3] Remove only model 'granite-3.1-8b-instruct', fix the rest later
 ```
+
+Removing the dependents goes through their own removal commands, so anything
+depending on *them* gets the same question in turn. Removing a model the user
+agrees to take a capability with will ask again about the launcher enabling
+that capability. The reference graph runs launcher to capability to model to
+provider, so the questions are bounded by its depth.
 
 Tests cover: a model with one dependent capability producing the right final
 configuration for each of the three outcomes, including the non-interactive
-default.
+default; a removal with no dependents, confirming it does not prompt; and the
+dependents scan itself, in each direction and for a target nothing points
+at.
 
 **Relevant Context**
 - `src/config/mod.rs:318-418` (`remove_model`/`remove_provider`/`remove_capability`/`remove_launcher`, all currently unconditional)
 
-**Status** — `[ ]` not started
+**Status** — `[x] done`
 
 ---
 

--- a/docs/specs/0024-config-integrity-validation.md
+++ b/docs/specs/0024-config-integrity-validation.md
@@ -658,3 +658,68 @@ resolves is named without it.
 - `src/commands/model.rs:722-770` (`select_provider`)
 
 **Status** — `[x] done`
+
+---
+
+## Implementation Summary
+
+Measured against `main` at bf117bb, the commit merged into the branch carrying
+Sub-Tasks 1 to 3. Every production figure excludes the file's own `#[cfg(test)]`
+items. The figures cover everything the two branches carry, which includes
+making `ModelConfig.provider_id` required, a change that came out of the review
+of Sub-Tasks 1 to 3.
+
+### New modules
+
+| Module | Production | Tests | Line coverage |
+|---|---:|---:|---:|
+| `src/config/validation.rs` | 436 | 412 | 98.64% |
+| `src/commands/shared/remediation.rs` | 430 | 552 | 97.92% |
+
+The validator answers three questions, `validate_ref`, `find_dangling` and
+`dependents`, over one `Validatable` implementation per config type.
+Remediation drives the prompts: `remediate`, `confirm_removal`,
+`dangling_notes` and `prompt_with_current`. A third new file,
+`src/commands/shared/mod.rs`, declares the remediation module in four lines.
+
+### Existing code
+
+| | Added | Removed |
+|---|---:|---:|
+| Production | 382 | 110 |
+| Tests | 376 | 145 |
+
+Twenty-four files: the five command modules and the `mod.rs` that declares
+them, the capability registrations, the `Ui` trait with its JSON and Markdown
+backends and the TUI app, `Config`, the model source, the registry macro,
+`main`, and the two launchers whose test doubles implemented the removed
+`dependencies` method.
+
+### Tests
+
+55 new, 27 updated, 8 removed or renamed away. The suite goes from 692 test
+functions to 739, and from 720 passing tests to 767. The gap between the two
+counts is the macro-generated output-contract tests each `Ui` backend gets.
+
+### Coverage
+
+| | Before | After |
+|---|---:|---:|
+| Lines | 78.79% | 80.38% |
+| Regions | 78.45% | 79.91% |
+| Functions | 77.14% | 78.75% |
+
+Measured with `cargo llvm-cov`. Per-file coverage counts a file's own
+`#[cfg(test)]` module, which runs in full, so a file that is half tests reads
+higher than its production half alone. Where the misses sit is exact, since
+test code always executes: `validation.rs` leaves 7 of 516 instrumented lines
+uncovered and `remediation.rs` 14 of 672, and all of those are production
+lines.
+
+### Other
+
+27 Rust files changed, plus this document, and no new dependencies. The
+declaration sites for a capability's `model_id` config key drop from eight to
+four, one per capability type, which is what removing
+`Capability::dependencies(&self)` was for. Neither new module carries
+`#![allow(dead_code)]`: every item has a production caller.

--- a/docs/specs/0024-config-integrity-validation.md
+++ b/docs/specs/0024-config-integrity-validation.md
@@ -620,7 +620,11 @@ Separately, the provider-selection helper does not re-validate the id it
 returns at all. If a user picks "configure a new provider," types a name that
 collides with an existing provider, and declines to overwrite it, the helper
 still returns that existing provider's id, even if it does not satisfy what
-the model needs. It should get the same re-validation.
+the model needs. It gets the same re-validation, by reading what is
+configured under that id after setup returns and comparing its type against
+the one being configured. A mismatch is rejected with an error naming the
+collision, rather than re-prompted: the wizard has no loop to return to, and
+the message says what to do differently.
 
 The overwrite wizard is the third case. When `setup` presents an existing
 instance's current values as defaults, a default that is itself a dangling
@@ -628,21 +632,29 @@ reference is flagged inline, so pressing Enter through the wizard cannot
 silently re-save it:
 
 ```
-Model for 'chat' [current: granite-4.2-8b — ⚠ no longer configured]:
+Select a model for this capability [current: 'granite-4.2-8b', ⚠ no longer resolves]
   > granite-vision
     granite-3.1-8b
+    Configure a new model...
 ```
+
+The flag says the reference no longer resolves rather than naming which of
+the four problems it is, since the prompt is asking for a replacement either
+way. A current value that still resolves is named without a flag, so the
+wizard always says what pressing Enter would be replacing. The same applies
+to a model's provider, whose current value comes from the instance being
+overwritten.
 
 Tests cover: inserting a provider into an unwritable configuration directory
 returns an error while the entry still appears in memory, which is the root
 cause this sub-task addresses; declining an overwrite onto a mismatched
-existing provider is rejected or re-prompted rather than silently reused; and
-an overwrite wizard whose current value is dangling renders the flag rather
-than offering it as a clean default.
+existing provider is rejected rather than silently reused; and an overwrite
+wizard whose current value is dangling renders the flag, while one that still
+resolves is named without it.
 
 **Relevant Context**
 - `src/config/mod.rs:313-413` (`insert_model`/`insert_provider`/`insert_capability`/`insert_launcher`, `save()`)
 - `src/commands/capability.rs:334-352` (`resolve_model_dependency`)
 - `src/commands/model.rs:722-770` (`select_provider`)
 
-**Status** — `[ ]` not started
+**Status** — `[x] done`

--- a/src/commands/capability.rs
+++ b/src/commands/capability.rs
@@ -232,8 +232,9 @@ impl CapabilityCommands {
                     required,
                     ..
                 } => {
+                    let current = defaults.get(config_key).and_then(|v| v.as_str());
                     if let Some(id) =
-                        Self::resolve_model_dependency(ctx, requirement, *required).await?
+                        Self::resolve_model_dependency(ctx, requirement, *required, current).await?
                     {
                         config
                             // NOTE: Safe since config MUST be an object when registered
@@ -248,8 +249,10 @@ impl CapabilityCommands {
                     required,
                     ..
                 } => {
+                    let current = defaults.get(config_key).and_then(|v| v.as_str());
                     if let Some(id) =
-                        Self::resolve_provider_dependency(ctx, requirement, *required).await?
+                        Self::resolve_provider_dependency(ctx, requirement, *required, current)
+                            .await?
                     {
                         config
                             // NOTE: Safe since config MUST be an object when registered
@@ -306,6 +309,7 @@ impl CapabilityCommands {
         ctx: &mut crate::AppContext,
         requirement: &ModelRequirement,
         required: bool,
+        current: Option<&str>,
     ) -> Result<Option<String>> {
         alog_channel!(
             MessageLevel::Debug2,
@@ -339,8 +343,13 @@ impl CapabilityCommands {
         let choice_idx = if options.len() == 1 {
             0
         } else {
-            ctx.ui
-                .select("Select a model for this capability:", &options, 0)?
+            let prompt = crate::commands::shared::remediation::prompt_with_current(
+                ctx,
+                "Select a model for this capability",
+                RefKind::Model,
+                current,
+            );
+            ctx.ui.select(&prompt, &options, 0)?
         };
         let choice = options[choice_idx].clone();
         if configure_new_idx.is_none_or(|v| v != choice_idx) {
@@ -358,7 +367,33 @@ impl CapabilityCommands {
             configurable_types[index]
         };
 
+        let before: std::collections::HashSet<String> = ctx.config.models.keys().cloned().collect();
         ModelCommands::setup(ctx, model_type, None).await?;
+
+        // Setup reports success even when it configured nothing, so take the
+        // ids it actually left behind rather than its return value. A new
+        // model that does not itself resolve is no use as a dependency.
+        let added: Vec<String> = ctx
+            .config
+            .models
+            .keys()
+            .filter(|id| !before.contains(*id))
+            .filter(|id| {
+                crate::config::validation::validate_ref(RefKind::Model, id, &ctx.config).is_ok()
+            })
+            .cloned()
+            .collect();
+        if added.is_empty() {
+            if required {
+                anyhow::bail!(
+                    "Model setup did not leave a usable model configured, so this capability has nothing to bind to. Configure a model and try again."
+                );
+            }
+            ctx.ui.warn(
+                "Model setup did not leave a usable model configured; skipping this dependency.",
+            );
+            return Ok(None);
+        }
 
         alog_channel!(
             MessageLevel::Debug3,
@@ -445,6 +480,7 @@ impl CapabilityCommands {
         ctx: &mut crate::AppContext,
         requirement: &ProviderRequirement,
         required: bool,
+        current: Option<&str>,
     ) -> Result<Option<String>> {
         let (existing, configurable_types) = Self::provider_candidates(ctx, requirement);
         if existing.is_empty() && configurable_types.is_empty() {
@@ -467,8 +503,13 @@ impl CapabilityCommands {
         let choice_idx = if options.len() == 1 {
             0
         } else {
-            ctx.ui
-                .select("Select a provider for this capability:", &options, 0)?
+            let prompt = crate::commands::shared::remediation::prompt_with_current(
+                ctx,
+                "Select a provider for this capability",
+                RefKind::Provider,
+                current,
+            );
+            ctx.ui.select(&prompt, &options, 0)?
         };
         let choice = options[choice_idx].clone();
         if configure_new_idx.is_none_or(|v| v != choice_idx) {
@@ -764,6 +805,53 @@ mod tests {
         assert!(capture(&ctx).warns.borrow().is_empty());
     }
 
+    #[tokio::test]
+    async fn a_dangling_current_value_is_flagged_in_the_selection_prompt() {
+        let mut ctx = ctx_with_chat_capable_model();
+        capture(&ctx).select_answers.borrow_mut().push_back(0);
+
+        let picked = CapabilityCommands::resolve_model_dependency(
+            &mut ctx,
+            &ModelRequirement::default(),
+            true,
+            Some("granite-4.2-8b"),
+        )
+        .await
+        .unwrap();
+
+        // The current value is not among the options, since it resolves to
+        // nothing, so the prompt is the only place that can say what
+        // pressing Enter would be replacing.
+        let prompts = capture(&ctx).select_prompts.borrow();
+        let (prompt, _, _) = &prompts[0];
+        assert!(prompt.contains("current: 'granite-4.2-8b'"), "{prompt}");
+        assert!(prompt.contains("no longer resolves"), "{prompt}");
+        assert_eq!(picked.as_deref(), Some("granite-3.1-8b-instruct"));
+    }
+
+    #[tokio::test]
+    async fn a_current_value_that_still_resolves_is_named_without_a_flag() {
+        let mut ctx = ctx_with_chat_capable_model();
+        capture(&ctx).select_answers.borrow_mut().push_back(0);
+
+        CapabilityCommands::resolve_model_dependency(
+            &mut ctx,
+            &ModelRequirement::default(),
+            true,
+            Some("granite-3.1-8b-instruct"),
+        )
+        .await
+        .unwrap();
+
+        let prompts = capture(&ctx).select_prompts.borrow();
+        let (prompt, _, _) = &prompts[0];
+        assert!(
+            prompt.contains("current: 'granite-3.1-8b-instruct'"),
+            "{prompt}"
+        );
+        assert!(!prompt.contains("no longer resolves"), "{prompt}");
+    }
+
     // -- setup ------------------------------------------------------------------
 
     #[tokio::test]
@@ -848,7 +936,7 @@ mod tests {
             ..Default::default()
         };
         let result =
-            CapabilityCommands::resolve_model_dependency(&mut ctx, &requirement, true).await;
+            CapabilityCommands::resolve_model_dependency(&mut ctx, &requirement, true, None).await;
         assert!(result.is_err());
         assert!(
             result
@@ -865,9 +953,10 @@ mod tests {
             family: Some("NoSuchFamilyXYZ".to_string()),
             ..Default::default()
         };
-        let result = CapabilityCommands::resolve_model_dependency(&mut ctx, &requirement, false)
-            .await
-            .unwrap();
+        let result =
+            CapabilityCommands::resolve_model_dependency(&mut ctx, &requirement, false, None)
+                .await
+                .unwrap();
         assert!(result.is_none());
     }
 
@@ -896,7 +985,8 @@ mod tests {
             ..Default::default()
         };
         let result =
-            CapabilityCommands::resolve_provider_dependency(&mut ctx, &requirement, true).await;
+            CapabilityCommands::resolve_provider_dependency(&mut ctx, &requirement, true, None)
+                .await;
         assert!(result.is_err());
         assert!(
             result
@@ -917,9 +1007,10 @@ mod tests {
             functions: vec![ModelFunction::KeywordBiasing],
             ..Default::default()
         };
-        let result = CapabilityCommands::resolve_provider_dependency(&mut ctx, &requirement, false)
-            .await
-            .unwrap();
+        let result =
+            CapabilityCommands::resolve_provider_dependency(&mut ctx, &requirement, false, None)
+                .await
+                .unwrap();
         assert!(result.is_none());
     }
 

--- a/src/commands/capability.rs
+++ b/src/commands/capability.rs
@@ -530,6 +530,22 @@ impl CapabilityCommands {
             anyhow::bail!("No capability configured with id '{capability_id}'. Nothing to remove.");
         }
 
+        // Anything pointing at it would be stranded by this removal.
+        match crate::commands::shared::remediation::confirm_removal(
+            ctx,
+            RefKind::Capability,
+            capability_id,
+        )? {
+            crate::commands::shared::remediation::Removal::Cancel => {
+                ctx.ui
+                    .info(&format!("Keeping capability '{capability_id}'."));
+                return Ok(());
+            }
+            crate::commands::shared::remediation::Removal::Proceed { with } => {
+                crate::commands::shared::remediation::remove_all(ctx, &with)?;
+            }
+        }
+
         if let Err(e) = ctx.config.remove_capability(capability_id) {
             ctx.ui
                 .warn(&format!("failed to persist capability removal: {e}"));

--- a/src/commands/launcher.rs
+++ b/src/commands/launcher.rs
@@ -276,6 +276,21 @@ impl LauncherCommands {
             anyhow::bail!("No launcher configured with id '{launcher_id}'. Nothing to remove.");
         }
 
+        // Anything pointing at it would be stranded by this removal.
+        match crate::commands::shared::remediation::confirm_removal(
+            ctx,
+            RefKind::Launcher,
+            launcher_id,
+        )? {
+            crate::commands::shared::remediation::Removal::Cancel => {
+                ctx.ui.info(&format!("Keeping launcher '{launcher_id}'."));
+                return Ok(());
+            }
+            crate::commands::shared::remediation::Removal::Proceed { with } => {
+                crate::commands::shared::remediation::remove_all(ctx, &with)?;
+            }
+        }
+
         if let Err(e) = ctx.config.remove_launcher(launcher_id) {
             ctx.ui
                 .warn(&format!("failed to persist launcher removal: {e}"));

--- a/src/commands/model.rs
+++ b/src/commands/model.rs
@@ -693,16 +693,17 @@ impl ModelCommands {
         };
 
         let provider_source = ProviderSource::from_config(&ctx.config);
+        let current_provider = existing_config.as_ref().map(|c| c.provider_id.clone());
         let provider_id = if let Some(variant) = &selected_variant {
             let requirement = VariantRequirement {
                 format: variant.format.clone(),
                 precision: variant.precision.clone(),
             };
             let resolution = dependency::resolve(&requirement, &provider_source);
-            Self::select_provider(ctx, &resolution).await?
+            Self::select_provider(ctx, &resolution, current_provider.as_deref()).await?
         } else {
             let resolution = dependency::resolve(&AnyProviderRequirement, &provider_source);
-            Self::select_provider(ctx, &resolution).await?
+            Self::select_provider(ctx, &resolution, current_provider.as_deref()).await?
         };
 
         let model_config = crate::config::ModelConfig {
@@ -882,6 +883,7 @@ impl ModelCommands {
     async fn select_provider(
         ctx: &mut crate::AppContext,
         resolution: &dependency::Resolution,
+        current: Option<&str>,
     ) -> Result<String> {
         if resolution.is_unsatisfiable() {
             anyhow::bail!(
@@ -898,8 +900,13 @@ impl ModelCommands {
         let choice = if options.len() == 1 {
             0
         } else {
-            ctx.ui
-                .select("Select a provider for this model", &options, 0)?
+            let prompt = crate::commands::shared::remediation::prompt_with_current(
+                ctx,
+                "Select a provider for this model",
+                RefKind::Provider,
+                current,
+            );
+            ctx.ui.select(&prompt, &options, 0)?
         };
 
         if options[choice] != CONFIGURE_NEW {
@@ -924,7 +931,22 @@ impl ModelCommands {
 
         ProviderCommands::setup(ctx, provider_type, Some(&nickname)).await?;
 
-        Ok(nickname)
+        // Setup reports success even when it configured nothing: a name that
+        // collides with an existing provider, and an overwrite the user then
+        // declines, both land here. Check what is configured under that id
+        // rather than trusting the id we asked for.
+        match ctx.config.get_provider(&nickname) {
+            Some(provider) if provider.provider_type == provider_type => Ok(nickname),
+            Some(provider) => anyhow::bail!(
+                "Provider '{nickname}' is already configured as '{}', which is not what \
+                 this model needs. Re-run setup and give the new provider a different name.",
+                provider.provider_type
+            ),
+            None => anyhow::bail!(
+                "Provider '{nickname}' was not configured, so this model would have \
+                 nothing to run on. Re-run setup once the provider is in place."
+            ),
+        }
     }
 }
 
@@ -1854,6 +1876,43 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn select_provider_rejects_a_name_colliding_with_a_provider_it_did_not_overwrite() {
+        let _home = crate::config::TestConfigHome::new();
+        let mut ctx = empty_ctx();
+        ctx.config.providers.insert(
+            "shared".to_string(),
+            crate::config::ProviderConfig {
+                provider_id: "shared".to_string(),
+                provider_type: "openai-compatible".to_string(),
+                config: serde_json::json!({}),
+            },
+        );
+        // Configuring a new one is the only choice, and the name typed for it
+        // collides. The overwrite confirmation inside provider setup defaults
+        // to no, so nothing is written.
+        let ui = (&*ctx.ui as &dyn std::any::Any)
+            .downcast_ref::<CaptureUi>()
+            .unwrap();
+        ui.text_answers.borrow_mut().push_back("shared".to_string());
+
+        let resolution = dependency::Resolution {
+            existing_instances: vec![],
+            configurable_types: vec!["ollama"],
+        };
+        let err = ModelCommands::select_provider(&mut ctx, &resolution, None)
+            .await
+            .unwrap_err();
+
+        // Silently handing back the provider that was already there would
+        // attach this model to something that cannot run it.
+        assert!(err.to_string().contains("already configured as"), "{err}");
+        assert_eq!(
+            ctx.config.get_provider("shared").unwrap().provider_type,
+            "openai-compatible"
+        );
+    }
+
+    #[tokio::test]
     async fn select_provider_bails_when_no_provider_type_can_ever_satisfy_the_requirement() {
         let mut ctx = empty_ctx();
         let resolution = dependency::Resolution {
@@ -1861,7 +1920,7 @@ mod tests {
             configurable_types: vec![],
         };
 
-        let err = ModelCommands::select_provider(&mut ctx, &resolution)
+        let err = ModelCommands::select_provider(&mut ctx, &resolution, None)
             .await
             .unwrap_err();
         assert!(

--- a/src/commands/model.rs
+++ b/src/commands/model.rs
@@ -856,6 +856,18 @@ impl ModelCommands {
             anyhow::bail!("No model configured with id '{model_id}'. Nothing to remove.");
         }
 
+        // Anything pointing at it would be stranded by this removal.
+        match crate::commands::shared::remediation::confirm_removal(ctx, RefKind::Model, model_id)?
+        {
+            crate::commands::shared::remediation::Removal::Cancel => {
+                ctx.ui.info(&format!("Keeping model '{model_id}'."));
+                return Ok(());
+            }
+            crate::commands::shared::remediation::Removal::Proceed { with } => {
+                crate::commands::shared::remediation::remove_all(ctx, &with)?;
+            }
+        }
+
         if let Err(e) = ctx.config.remove_model(model_id) {
             ctx.ui
                 .warn(&format!("failed to persist model removal: {e}"));

--- a/src/commands/provider.rs
+++ b/src/commands/provider.rs
@@ -274,6 +274,21 @@ impl ProviderCommands {
             anyhow::bail!("No provider configured with id '{provider_id}'. Nothing to remove.");
         }
 
+        // Anything pointing at it would be stranded by this removal.
+        match crate::commands::shared::remediation::confirm_removal(
+            ctx,
+            RefKind::Provider,
+            provider_id,
+        )? {
+            crate::commands::shared::remediation::Removal::Cancel => {
+                ctx.ui.info(&format!("Keeping provider '{provider_id}'."));
+                return Ok(());
+            }
+            crate::commands::shared::remediation::Removal::Proceed { with } => {
+                crate::commands::shared::remediation::remove_all(ctx, &with)?;
+            }
+        }
+
         if let Err(e) = ctx.config.remove_provider(provider_id) {
             ctx.ui
                 .warn(&format!("failed to persist provider removal: {e}"));

--- a/src/commands/shared/remediation.rs
+++ b/src/commands/shared/remediation.rs
@@ -63,6 +63,31 @@ pub(crate) fn dangling_notes(ctx: &crate::AppContext, kind: RefKind) -> HashMap<
         .collect()
 }
 
+/// A selection prompt that names the instance currently configured, and says
+/// so when it no longer resolves.
+///
+/// A setup run over an existing instance offers its current values as
+/// defaults. Without this, pressing Enter through the wizard re-saves a
+/// dangling reference with nothing on screen to say it was one.
+pub(crate) fn prompt_with_current(
+    ctx: &crate::AppContext,
+    prompt: &str,
+    kind: RefKind,
+    current: Option<&str>,
+) -> String {
+    let Some(current) = current.filter(|id| !id.is_empty()) else {
+        return prompt.to_string();
+    };
+
+    match validate_ref(kind, current, &ctx.config) {
+        Ok(()) => format!("{prompt} [current: '{current}']"),
+        Err(_) => format!(
+            "{prompt} [current: '{current}', {} no longer resolves]",
+            ctx.ui.warn_mark("⚠")
+        ),
+    }
+}
+
 /// What a removal should do about the instances pointing at what is being
 /// removed.
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/src/commands/shared/remediation.rs
+++ b/src/commands/shared/remediation.rs
@@ -1,10 +1,15 @@
-//! Offers to fix a broken configuration reference, one problem at a time,
-//! until what the caller named validates or the user stops accepting fixes.
+//! The prompts that ask what to do about a broken configuration reference,
+//! and the code that applies the answer.
 //!
-//! The fixes are the commands the user would otherwise run by hand:
-//! reconfigure drives the same setup, pre-selected on the instance holding
-//! the broken reference, and remove drives the same removal. Nothing here
-//! edits the configuration itself.
+//! [`remediate`] offers a fix for one broken reference at a time, until what
+//! the caller named validates or the user stops accepting fixes.
+//! [`confirm_removal`] runs before a removal and reports what points at the
+//! instance about to be deleted, so the user can take those with it, cancel,
+//! or leave them.
+//!
+//! Reconfigure and remove run the instance's own setup and removal commands,
+//! the ones a user would run by hand. Un-enabling is the one repair applied
+//! here, dropping an id from a launcher's `enabled_capabilities`.
 //!
 use std::collections::HashMap;
 
@@ -13,7 +18,7 @@ use anyhow::Result;
 use crate::commands::{CapabilityCommands, LauncherCommands, ModelCommands, ProviderCommands};
 use crate::config::Config;
 use crate::config::validation::{
-    Problem, RefKind, ValidationError, find_dangling, type_name, validate_ref,
+    Problem, RefKind, ValidationError, dependents, find_dangling, type_name, validate_ref,
 };
 
 /*-- public --------------------------------------------------------------------*/
@@ -56,6 +61,78 @@ pub(crate) fn dangling_notes(ctx: &crate::AppContext, kind: RefKind) -> HashMap<
             )
         })
         .collect()
+}
+
+/// What a removal should do about the instances pointing at what is being
+/// removed.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum Removal {
+    /// Go ahead, taking these instances with it. Empty when nothing pointed
+    /// at the target, or when the user chose to strand what did.
+    Proceed { with: Vec<(RefKind, String)> },
+    /// Leave everything alone.
+    Cancel,
+}
+
+/// Asks what to do about the instances that point at `(kind, id)` before a
+/// removal strands them.
+///
+/// Nothing pointing at it means no prompt. A session with nobody to ask
+/// removes only what was asked for, after saying what that breaks.
+pub(crate) fn confirm_removal(ctx: &crate::AppContext, kind: RefKind, id: &str) -> Result<Removal> {
+    let stranded = dependents(kind, id, &ctx.config);
+    if stranded.is_empty() {
+        return Ok(Removal::Proceed { with: stranded });
+    }
+
+    ctx.ui.warn(&format!("Removing {kind} '{id}' will break:"));
+    for (dependent_kind, dependent_id) in &stranded {
+        let type_suffix = type_name(*dependent_kind, dependent_id, &ctx.config)
+            .map(|t| format!(" ({t})"))
+            .unwrap_or_default();
+        ctx.ui.info(&format!(
+            "  - {dependent_kind} '{dependent_id}'{type_suffix}"
+        ));
+    }
+
+    if !ctx.ui.is_interactive() {
+        ctx.ui.warn(&format!(
+            "Removing only {kind} '{id}'. What depended on it needs fixing."
+        ));
+        return Ok(Removal::Proceed { with: Vec::new() });
+    }
+
+    let together = match stranded.as_slice() {
+        [(dependent_kind, dependent_id)] => {
+            format!("Remove {kind} '{id}' and {dependent_kind} '{dependent_id}' together")
+        }
+        _ => format!(
+            "Remove {kind} '{id}' and the {} instances that depend on it",
+            stranded.len()
+        ),
+    };
+    let items = vec![
+        together,
+        format!("Cancel, keep {kind} '{id}'"),
+        format!("Remove only {kind} '{id}', fix the rest later"),
+    ];
+
+    // Cancelling is the default: this is the destructive prompt, and the
+    // other two answers both delete something.
+    match ctx.ui.select("What would you like to do?", &items, 1)? {
+        0 => Ok(Removal::Proceed { with: stranded }),
+        2 => Ok(Removal::Proceed { with: Vec::new() }),
+        _ => Ok(Removal::Cancel),
+    }
+}
+
+/// Removes each instance through its own removal command, so anything
+/// depending on *them* gets the same question in turn.
+pub(crate) fn remove_all(ctx: &mut crate::AppContext, ids: &[(RefKind, String)]) -> Result<()> {
+    for (kind, id) in ids {
+        remove(ctx, *kind, id)?;
+    }
+    Ok(())
 }
 
 /// Validates `(kind, id)` and offers a fix for whatever is broken,
@@ -130,7 +207,7 @@ pub(crate) async fn remediate(
             }
             Choice::Remove => {
                 previous = Some(error);
-                remove(ctx, &fix)?;
+                remove(ctx, fix.kind, &fix.id)?;
             }
             Choice::Disable => {
                 previous = Some(error);
@@ -315,9 +392,8 @@ fn disable(ctx: &mut crate::AppContext, fix: &Fix) -> Result<()> {
     Ok(())
 }
 
-fn remove(ctx: &mut crate::AppContext, fix: &Fix) -> Result<()> {
-    let id = fix.id.as_str();
-    match fix.kind {
+fn remove(ctx: &mut crate::AppContext, kind: RefKind, id: &str) -> Result<()> {
+    match kind {
         RefKind::Launcher => LauncherCommands::remove(ctx, id),
         RefKind::Capability => CapabilityCommands::remove(ctx, id),
         RefKind::Model => ModelCommands::remove(ctx, id),
@@ -405,6 +481,81 @@ mod tests {
         ctx
     }
 
+    /// Capability `chat` uses the one configured model, and nothing enables
+    /// the capability, so removing it strands nothing further.
+    fn ctx_model_with_one_dependent() -> crate::AppContext {
+        let mut ctx = ctx_with_a_dangling_model_ref();
+        ctx.config.launchers.clear();
+        ctx.config.capabilities.get_mut("chat").unwrap().config =
+            serde_json::json!({ "model_id": "granite-3.1-8b-instruct" });
+        ctx
+    }
+
+    #[test]
+    fn removing_a_model_with_its_dependent_removes_both() {
+        let _home = crate::config::TestConfigHome::new();
+        let mut ctx = ctx_model_with_one_dependent();
+        answer(&ctx, &[0]);
+
+        ModelCommands::remove(&mut ctx, "granite-3.1-8b-instruct").unwrap();
+
+        assert!(ctx.config.get_model("granite-3.1-8b-instruct").is_none());
+        assert!(ctx.config.get_capability("chat").is_none());
+    }
+
+    #[test]
+    fn cancelling_a_removal_keeps_both() {
+        let _home = crate::config::TestConfigHome::new();
+        let mut ctx = ctx_model_with_one_dependent();
+        answer(&ctx, &[1]);
+
+        ModelCommands::remove(&mut ctx, "granite-3.1-8b-instruct").unwrap();
+
+        assert!(ctx.config.get_model("granite-3.1-8b-instruct").is_some());
+        assert!(ctx.config.get_capability("chat").is_some());
+    }
+
+    #[test]
+    fn removing_only_what_was_asked_leaves_the_dependent_broken() {
+        let _home = crate::config::TestConfigHome::new();
+        let mut ctx = ctx_model_with_one_dependent();
+        answer(&ctx, &[2]);
+
+        ModelCommands::remove(&mut ctx, "granite-3.1-8b-instruct").unwrap();
+
+        assert!(ctx.config.get_model("granite-3.1-8b-instruct").is_none());
+        // Left in place, and now dangling, which `capability list` reports.
+        assert!(ctx.config.get_capability("chat").is_some());
+        assert!(!find_dangling(RefKind::Capability, &ctx.config).is_empty());
+    }
+
+    #[test]
+    fn a_session_with_nobody_to_ask_removes_only_what_was_asked() {
+        let _home = crate::config::TestConfigHome::new();
+        let mut ctx = ctx_model_with_one_dependent();
+        *capture(&ctx).interactive.borrow_mut() = Some(false);
+
+        ModelCommands::remove(&mut ctx, "granite-3.1-8b-instruct").unwrap();
+
+        assert!(prompts(&ctx).is_empty());
+        assert!(ctx.config.get_model("granite-3.1-8b-instruct").is_none());
+        assert!(ctx.config.get_capability("chat").is_some());
+        // The user is told what was broken even though nothing was asked.
+        let warns = capture(&ctx).warns.borrow().clone();
+        assert!(warns.iter().any(|w| w.contains("will break")), "{warns:?}");
+    }
+
+    #[test]
+    fn removing_something_nothing_depends_on_does_not_prompt() {
+        let _home = crate::config::TestConfigHome::new();
+        let mut ctx = ctx_model_with_one_dependent();
+
+        CapabilityCommands::remove(&mut ctx, "chat").unwrap();
+
+        assert!(prompts(&ctx).is_empty());
+        assert!(ctx.config.get_capability("chat").is_none());
+    }
+
     #[tokio::test]
     async fn a_healthy_instance_is_clean_without_prompting() {
         let mut ctx = ctx_with_a_dangling_model_ref();
@@ -461,7 +612,9 @@ mod tests {
     async fn remove_deletes_the_instance_holding_the_reference() {
         let _home = crate::config::TestConfigHome::new();
         let mut ctx = ctx_with_a_dangling_model_ref();
-        answer(&ctx, &[1]);
+        // Remove, then keep the launcher that enables `chat` when the
+        // removal asks about it.
+        answer(&ctx, &[1, 2]);
 
         let outcome = remediate(&mut ctx, RefKind::Capability, "chat", OnDecline::Skip, true)
             .await

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -762,6 +762,36 @@ mod tests {
     }
 
     #[test]
+    fn an_insert_that_cannot_be_saved_still_lands_in_memory() {
+        let _home = TestConfigHome::new();
+        // Point the home at a file, so writing any config file under it
+        // fails.
+        let home = std::env::var("GRANITE_CLI_HOME").unwrap();
+        let blocked = Path::new(&home).join("blocked");
+        fs::write(&blocked, "not a directory").unwrap();
+        // SAFETY: serialized by CONFIG_HOME_LOCK, held by `_home`.
+        unsafe { std::env::set_var("GRANITE_CLI_HOME", &blocked) };
+
+        let mut config = Config::default();
+        let result = config.insert_provider(
+            "p1",
+            ProviderConfig {
+                provider_id: "p1".to_string(),
+                provider_type: "ollama".to_string(),
+                config: serde_json::json!({}),
+            },
+        );
+
+        // The caller is told, and the entry is in memory regardless. Callers
+        // treat that error as a warning, which is how a setup step can report
+        // success over configuration that was never written, and why the
+        // helpers that configure something new check what is actually there
+        // afterwards.
+        assert!(result.is_err());
+        assert!(config.get_provider("p1").is_some());
+    }
+
+    #[test]
     fn insert_and_remove_launcher() {
         let _home = TestConfigHome::new();
 

--- a/src/config/validation.rs
+++ b/src/config/validation.rs
@@ -109,6 +109,47 @@ pub(crate) fn find_dangling(kind: RefKind, config: &Config) -> Vec<DanglingRef> 
         .collect()
 }
 
+/// The configured instances that point at `(kind, id)`, which is what
+/// removing it would strand. Sorted, so a caller listing them is stable.
+///
+/// This is [`Validatable::refs`] read backwards: an instance depends on the
+/// target when the target appears among the references it declares.
+///
+/// # Examples
+///
+/// ```ignore
+/// // Before `model remove granite-3.1-8b-instruct` deletes anything.
+/// let stranded = dependents(RefKind::Model, "granite-3.1-8b-instruct", &config);
+/// // -> [(RefKind::Capability, "chat")]
+/// ```
+pub(crate) fn dependents(kind: RefKind, id: &str, config: &Config) -> Vec<(RefKind, String)> {
+    let mut found: Vec<(RefKind, String)> = [
+        RefKind::Launcher,
+        RefKind::Capability,
+        RefKind::Model,
+        RefKind::Provider,
+    ]
+    .into_iter()
+    .flat_map(|referrer_kind| {
+        config_entries(config, referrer_kind)
+            .into_iter()
+            .map(move |entry| (referrer_kind, entry))
+    })
+    .filter(|(_, entry)| {
+        // An instance that cannot name its references, such as a capability
+        // missing a required dependency, points at nothing.
+        entry.refs().is_ok_and(|refs| {
+            refs.iter()
+                .any(|(target_kind, target_id)| *target_kind == kind && *target_id == id)
+        })
+    })
+    .map(|(referrer_kind, entry)| (referrer_kind, entry.config_id().to_string()))
+    .collect();
+
+    found.sort_by(|a, b| a.0.to_string().cmp(&b.0.to_string()).then(a.1.cmp(&b.1)));
+    found
+}
+
 /// The `*_type` of a configured instance: the registry key that its setup
 /// command needs to reconfigure it. `None` when `id` names nothing.
 pub(crate) fn type_name<'a>(kind: RefKind, id: &str, config: &'a Config) -> Option<&'a str> {
@@ -751,6 +792,44 @@ mod tests {
             assert_eq!(found, expected, "{kind}");
             assert!(find_dangling(kind, &config).iter().all(|d| d.kind == kind));
         }
+    }
+
+    #[test]
+    fn dependents_are_the_instances_pointing_at_the_target() {
+        let config = healthy();
+
+        assert_eq!(
+            dependents(RefKind::Provider, "p1", &config),
+            vec![(RefKind::Model, "m1".to_string())]
+        );
+        assert_eq!(
+            dependents(RefKind::Model, "m1", &config),
+            vec![(RefKind::Capability, "chat".to_string())]
+        );
+        assert_eq!(
+            dependents(RefKind::Capability, "chat", &config),
+            vec![(RefKind::Launcher, "claude".to_string())]
+        );
+        // Nothing points at a launcher, and nothing points at what is not
+        // configured.
+        assert!(dependents(RefKind::Launcher, "claude", &config).is_empty());
+        assert!(dependents(RefKind::Model, "gone", &config).is_empty());
+    }
+
+    #[test]
+    fn dependents_lists_every_referrer_of_one_target() {
+        let mut config = healthy();
+        config
+            .capabilities
+            .insert("second".into(), capability("second", "agent-model", "m1"));
+
+        assert_eq!(
+            dependents(RefKind::Model, "m1", &config),
+            vec![
+                (RefKind::Capability, "chat".to_string()),
+                (RefKind::Capability, "second".to_string()),
+            ]
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Description

[Spec 0024](https://github.com/ibm-granite-community/granite-cli/blob/main/docs/specs/0024-config-integrity-validation.md),
Sub-Tasks 4 and 5: a removal now checks what it would strand, and a setup step
can no longer leave a reference pointing at nothing. Stacked on #123.

The top 3 commits belong to this PR. The rest is PR #123.
I will rebase once #123 is merged.

## Changes

**Removal asks about its dependents.** The four removal commands scan for the
instances pointing at the target and offer to remove them together, cancel, or
remove only what was asked. Cancel is the default, since the other two both
delete something. A session with nobody to ask removes only what was asked and
warns. Dependents go through their own removal commands, so the question
repeats down the reference graph. Finding them is `Validatable::refs` read
backwards, next to the walk in `config::validation`.

**Setup checks what it actually configured.** `Config::insert_*` updates the
in-memory map before saving and its callers treat a save failure as a warning,
so a nested setup step could report success over configuration that was never
written. `resolve_model_dependency` now keeps only the ids setup left behind
that validate. `select_provider`, which checked nothing, now rejects an id
configured as a different provider type, which is what a declined overwrite
onto a name collision used to return.

**Selection prompts name the instance currently configured** and say when it
no longer resolves, so pressing Enter through an overwrite cannot re-save a
dangling reference.

Also adds the spec's implementation summary, covering all five sub-tasks.

## Testing

11 new test functions, 740 to 751; the suite goes from 760 to 771 passing.
Line coverage is 98.7% on `config/validation.rs` and 97.9% on
`commands/remediation.rs`, 80.1% to 80.4% overall. fmt is clean, clippy adds
nothing new, and both feature commits pass the full suite on their own.

## Related Issue(s)

To file once this merges:

- [ ] **Removing a capability without breaking or deleting its launcher.** The
      prompt's three answers delete the launcher too, do nothing, or leave it
      pointing at something gone. A fourth would drop the id from
      `enabled_capabilities` as part of the removal; the behaviour exists in
      `remediation::unenable` and needs extracting.
- [ ] **A flag for non-interactive removal.** A script cannot ask for the
      dependents to go too, or for the removal to be refused with a non-zero
      exit when anything depends on the target.

## AI Usage

Drafted with Claude (Opus 5) and reviewed commit by commit; each commit
carries an `AI-usage: draft (Claude + Opus 5)` trailer.
